### PR TITLE
feat(auth): admin access control — isAdmin claim gate + grant-admin CLI

### DIFF
--- a/.specs/technical/firebase-deployment.md
+++ b/.specs/technical/firebase-deployment.md
@@ -1,6 +1,6 @@
 # Firebase Deployment — citl.club
 
-**Firebase Project**: `citl`
+**Firebase Project**: `citl-baed2`
 **Hosting Region**: `us-east1` (Firestore) / Global CDN (Hosting)
 **Plan**: Spark (free tier)
 **Last Updated**: 2026-02-27
@@ -23,8 +23,8 @@ See [.specs/technical/cicd-pipeline.md](./cicd-pipeline.md).
 ### Project Binding
 
 ```
-Firebase project ID: citl
-Default alias:       default → citl
+Firebase project ID: citl-baed2
+Default alias:       default → citl-baed2
 Config file:         .firebaserc
 ```
 
@@ -44,9 +44,42 @@ Config file:         .firebaserc
 firebase login
 
 # Verify project binding
-firebase use citl
-firebase projects:list    # confirm 'citl' appears
+firebase use citl-baed2
+firebase projects:list    # confirm 'citl-baed2' appears
 ```
+
+---
+
+## Admin User Provisioning
+
+Admin portal access is gated on a Firebase custom claim (`admin: true`).
+Use `scripts/grant-admin.js` to grant or revoke the claim by email.
+
+### One-time developer setup
+
+```bash
+# Install gcloud CLI, then authenticate with the project owner account
+gcloud auth application-default login
+gcloud auth application-default set-quota-project citl-baed2
+```
+
+### Grant / revoke admin access
+
+```bash
+# Grant admin claim — user can now sign into #/admin
+node scripts/grant-admin.js grant user@example.com
+
+# Revoke admin claim — user sees "no access" message on next sign-in
+node scripts/grant-admin.js revoke user@example.com
+```
+
+The user must sign out and back in after a grant/revoke for the new token to take effect
+(Firebase ID tokens have a 1-hour TTL).
+
+**Required**: the developer running this script must have the **Firebase Authentication Admin**
+IAM role on the `citl-baed2` project.
+
+---
 
 ### Configuration Principles
 
@@ -81,7 +114,7 @@ Before running `npm run deploy` or `npm run deploy:preview`:
 
 - [ ] `npm run build` succeeds with no errors
 - [ ] `.env` is populated with valid `VITE_FIREBASE_*` values
-- [ ] `firebase use citl` is active (`firebase use` to verify)
+- [ ] `firebase use citl-baed2` is active (`firebase use` to verify)
 - [ ] All 5 SPA routes load correctly in `npm run preview`
 - [ ] No CSP violations in browser console during preview
 - [ ] Firebase Hosting quota not near 70% of 360 MB/day limit
@@ -279,7 +312,7 @@ terraform destroy    # in the Terraform directory
 
 ```bash
 firebase login --reauth
-firebase use citl
+firebase use citl-baed2
 npm run deploy
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,14 @@ npm run deploy:preview               # build + Firebase preview channel (7-day U
 | `src/modules/navigation.js` | Responsive nav, burger menu |
 | `src/firebase-config.js` | Firebase SDK init, exports `db` |
 | `src/services/score-service.js` | Firestore reads + 1-hr cache |
+| `src/modules/auth.js` | AuthModule: Google sign-in/out, isAdmin claim check |
 | `src/services/scoring-engine.js` | Pure scoring calculations (ADR-006) |
-| `src/components/standings-table.js` | Custom Element: cumulative season standings (reads Firestore) |
 | `src/repositories/score-repository.js` | Raw Firestore operations |
 | `src/repositories/repository-factory.js` | Factory: Firestore backend only |
 | `src/views/home.js` | Home page (static HTML — Phase 4 target) |
 | `src/views/scorecards.js` | Scorecards Web Component (Firestore-backed, all 7 seasons) |
 | `firebase.json` | Hosting config: SPA rewrite, CSP, cache headers |
+| `scripts/grant-admin.js` | CLI utility: grant/revoke admin custom claim (ADC) |
 | `.env.example` | Template for required `VITE_FIREBASE_*` env vars |
 
 ### Layer Dependency Direction
@@ -185,7 +186,7 @@ Goal: move admin-entered data from localStorage → Firestore; enforce security.
 
 - [x] Enable Firestore in console (production mode, `us-central1`) *(manual)*
 - [x] `firestore.rules` — public read, admin-write (`admin: true` custom claim)
-- [x] Set `admin: true` custom claim on admin user UID *(Firebase Admin SDK or console — manual)*
+- [x] Grant `admin: true` custom claim to admin users via `scripts/grant-admin.js` *(manual — see firebase-deployment.md)*
 - [x] `src/types/score.js` — add `TeamResult`, `ShooterScore`, `SeasonEntry` typedefs; update `WeekResult`
 - [x] `src/types/season.js` — update `Season` to Phase 6 schema; add `SeasonStandings` typedef
 - [x] `src/repositories/score-repository.js` — add `saveEntry`, `getEntry`, `getEntries`, `publishWeek`
@@ -213,6 +214,12 @@ Goal: move admin-entered data from localStorage → Firestore; enforce security.
 - [ ] Verify SSL provisioning
 - [ ] Validate production site at `citl.club`
 - [ ] `terraform destroy` — decommission AWS
+
+### Phase 8.5 — Admin Access Control ✅
+- [x] `src/modules/auth.js` — add `isAdmin()`: checks `admin` custom claim via `getIdTokenResult()`
+- [x] `src/views/admin.js` — add `#admin-unauthorized` section (signed-in, no claim)
+- [x] `src/main.js` — async `applyAuthState`: gates 3 sections on auth + admin claim
+- [x] `scripts/grant-admin.js` — permanent CLI utility: grant/revoke admin claim by email (ADC, no key file)
 
 ---
 

--- a/scripts/grant-admin.js
+++ b/scripts/grant-admin.js
@@ -1,0 +1,41 @@
+/**
+ * grant-admin.js — Firebase Admin SDK utility for managing admin custom claims
+ *
+ * Uses Application Default Credentials (ADC) — no key file required.
+ *
+ * One-time setup:
+ *   gcloud auth application-default login
+ *
+ * Usage:
+ *   node scripts/grant-admin.js grant user@example.com
+ *   node scripts/grant-admin.js revoke user@example.com
+ *
+ * Required IAM role on your Google account: Firebase Authentication Admin
+ */
+
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+const [,, action, email] = process.argv;
+
+if (!action || !email || !['grant', 'revoke'].includes(action)) {
+  console.error('Usage: node scripts/grant-admin.js <grant|revoke> <email>');
+  process.exit(1);
+}
+
+initializeApp({ projectId: 'citl-baed2' });
+
+const adminAuth = getAuth();
+
+try {
+  const user = await adminAuth.getUserByEmail(email);
+  const newClaims = action === 'grant' ? { admin: true } : { admin: false };
+
+  await adminAuth.setCustomUserClaims(user.uid, newClaims);
+
+  const verb = action === 'grant' ? 'Granted' : 'Revoked';
+  console.log(`${verb} admin claim for ${email} (uid: ${user.uid})`);
+} catch (error) {
+  console.error('Error:', error.message);
+  process.exit(1);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -110,10 +110,17 @@ class App {
   // ─── Admin auth ──────────────────────────────────────────────────────────────
 
   _initAdminAuth() {
-    const applyAuthState = (user) => {
+    const applyAuthState = async (user) => {
       this._navigation.updateAuthState(user);
+
+      let isAdmin = false;
+      if (user) {
+        isAdmin = await this._auth.isAdmin();
+      }
+
       document.getElementById('admin-login')?.toggleAttribute('hidden', !!user);
-      document.getElementById('admin-panel-container')?.toggleAttribute('hidden', !user);
+      document.getElementById('admin-unauthorized')?.toggleAttribute('hidden', !user || isAdmin);
+      document.getElementById('admin-panel-container')?.toggleAttribute('hidden', !user || !isAdmin);
 
       const userDisplay = document.getElementById('admin-user-display');
       if (userDisplay) {
@@ -130,6 +137,8 @@ class App {
     document.getElementById('admin-sign-in')
       ?.addEventListener('click', () => this._auth.signIn());
     document.getElementById('admin-sign-out')
+      ?.addEventListener('click', () => this._auth.signOut());
+    document.getElementById('admin-sign-out-unauth')
       ?.addEventListener('click', () => this._auth.signOut());
   }
 

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -9,6 +9,7 @@
  *   async signIn()              → { success, data: UserCredential } | { success: false, error }
  *   async signOut()             → { success } | { success: false, error }
  *   onAuthStateChanged(cb)      → Firebase unsubscribe function
+ *   async isAdmin()             → true if current user has admin custom claim
  */
 
 import { auth } from '@/firebase-config.js';
@@ -58,6 +59,16 @@ export class AuthModule {
       console.error('[AuthModule] signOut error:', error);
       return { success: false, error };
     }
+  }
+
+  /**
+   * Returns true if the current user has the admin custom claim.
+   * @returns {Promise<boolean>}
+   */
+  async isAdmin() {
+    if (!auth.currentUser) return false;
+    const tokenResult = await auth.currentUser.getIdTokenResult();
+    return tokenResult.claims.admin === true;
   }
 
   /**

--- a/src/views/admin.js
+++ b/src/views/admin.js
@@ -15,8 +15,14 @@ export function adminView() {
     <h1>Admin Portal</h1>
 
     <div id="admin-login">
-      <p>Sign in with your authorized Google account to access the admin panel.</p>
+      <p>Sign in with your Google account to access the admin panel.</p>
       <button id="admin-sign-in" class="btn-primary">Sign in with Google</button>
+    </div>
+
+    <div id="admin-unauthorized" hidden>
+      <p>You are signed in but do not have admin access to this portal.</p>
+      <p>Contact the league administrator to request access.</p>
+      <button id="admin-sign-out-unauth" class="btn-secondary">Sign out</button>
     </div>
 
     <div id="admin-panel-container" hidden>


### PR DESCRIPTION
## Summary

- **`src/modules/auth.js`** — add `isAdmin()`: checks `admin` custom claim via `getIdTokenResult()`
- **`src/views/admin.js`** — add `#admin-unauthorized` section for signed-in users without the admin claim
- **`src/main.js`** — async `applyAuthState` gates `admin-panel-container` on both auth and admin claim
- **`scripts/grant-admin.js`** — permanent CLI utility to grant/revoke admin claim by email (uses ADC, no key file)
- **`AGENTS.md`** — update Key Files table (add auth.js + grant-admin.js, remove stale standings-table.js), fix Phase 6 checklist item, add Phase 8.5 section
- **`.specs/technical/firebase-deployment.md`** — fix stale project ID (`citl` → `citl-baed2`), add Admin User Provisioning section

## Test plan

- [ ] Sign in with a non-admin Google account → `#admin-unauthorized` section visible, panel hidden
- [ ] Sign in with an admin Google account → `#admin-panel-container` visible, unauthorized section hidden
- [ ] Sign out from unauthorized section → returns to login gate
- [ ] `node scripts/grant-admin.js grant user@example.com` — verify claim set in Firebase console
- [ ] `node scripts/grant-admin.js revoke user@example.com` — verify claim cleared
- [ ] Confirm no real email addresses, UIDs, or credentials appear in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)