### PR TITLE
feat(scoring): captain-first roster ordering on scorecards and scoresheets

### DIFF
--- a/src/components/scoresheet-generator.ts
+++ b/src/components/scoresheet-generator.ts
@@ -1,0 +1,196 @@
+/**
+ * scoresheet-generator — Custom Element
+ *
+ * Renders print-ready scoresheets for all teams, showing each shooter's
+ * going-in average for the selected week. No shadow DOM; uses global CSS.
+ */
+
+import { db } from '@/firebase-config';
+import { createRepositoryFactory } from '@/repositories/repository-factory';
+import { ScoreService } from '@/services/score-service';
+import { computeGoingInAverage, isDummyName, normalizeShooterName, sortShootersWithCaptainFirst } from '@/services/scoring-engine';
+import type { Season } from '@/types/season';
+import type { Team, WeekResult } from '@/types/score';
+
+const factory = createRepositoryFactory({ db });
+const scoreService = new ScoreService(factory.getScoreRepository());
+
+class ScoresheetGenerator extends HTMLElement {
+  private _seasons: Season[] = [];
+  private _year = 0;
+  private _maxWeek = 1;
+  private _selectedWeek = 1;
+  private _teams: Team[] = [];
+  private _weekResults: WeekResult[] = [];
+
+  connectedCallback(): void {
+    this.innerHTML = `<p>Loading&hellip;</p>`;
+    void this._load();
+  }
+
+  private async _load(): Promise<void> {
+    const seasonsResult = await scoreService.getAllSeasons();
+    if (!seasonsResult.success || !seasonsResult.data?.length) {
+      this.innerHTML = `<p>No seasons available.</p>`;
+      return;
+    }
+
+    this._seasons = seasonsResult.data;
+    const season = this._seasons[0]!;
+    this._year = season.year;
+    this._maxWeek = Math.min(15, (season.currentWeek ?? 0) + 1);
+    this._selectedWeek = this._maxWeek;
+
+    await this._fetchYearData();
+
+    this.innerHTML = this._renderShell();
+    this._renderCards();
+    this._wireEvents();
+  }
+
+  private async _fetchYearData(): Promise<void> {
+    const [teamsResult, weeksResult] = await Promise.all([
+      scoreService.getTeams(this._year),
+      scoreService.getAllWeekResults(this._year),
+    ]);
+
+    this._teams = teamsResult.success ? (teamsResult.data ?? []) : [];
+    this._weekResults = weeksResult.success ? (weeksResult.data ?? []) : [];
+  }
+
+  private async _changeYear(year: number): Promise<void> {
+    this._year = year;
+    const season = this._seasons.find((s) => s.year === year);
+    this._maxWeek = Math.min(15, (season?.currentWeek ?? 0) + 1);
+    this._selectedWeek = this._maxWeek;
+
+    const container = this.querySelector<HTMLElement>('#sg-cards');
+    if (container) container.innerHTML = `<p>Loading&hellip;</p>`;
+
+    await this._fetchYearData();
+
+    const weekSelect = this.querySelector<HTMLSelectElement>('#sg-week');
+    if (weekSelect) weekSelect.innerHTML = this._weekOptions();
+
+    this._renderCards();
+  }
+
+  private _weekOptions(): string {
+    return Array.from({ length: this._maxWeek }, (_, i) => {
+      const w = i + 1;
+      const selected = w === this._selectedWeek ? ' selected' : '';
+      return `<option value="${w}"${selected}>Week ${w}</option>`;
+    }).join('');
+  }
+
+  private _renderShell(): string {
+    const yearOptions = this._seasons
+      .map((s) => {
+        const selected = s.year === this._year ? ' selected' : '';
+        return `<option value="${s.year}"${selected}>${s.year}</option>`;
+      })
+      .join('');
+
+    return `
+      <div class="scoresheet-controls">
+        <label for="sg-year">Season</label>
+        <select id="sg-year">${yearOptions}</select>
+        <label for="sg-week">Week</label>
+        <select id="sg-week">${this._weekOptions()}</select>
+        <button class="btn-primary scoresheet-print-btn">Print All Scoresheets</button>
+      </div>
+      <div id="sg-cards"></div>`;
+  }
+
+  private _renderCards(): void {
+    const container = this.querySelector<HTMLElement>('#sg-cards');
+    if (!container) return;
+    container.innerHTML = this._teams.map((team) => this._renderCard(team)).join('');
+  }
+
+  private _renderCard(team: Team): string {
+    const rows = sortShootersWithCaptainFirst(
+      team.shooters.filter((s) => !isDummyName(s.name)),
+      team.captain,
+    ).map((shooter) => {
+        const scores = new Array<number | null>(15).fill(null);
+        for (const wr of this._weekResults) {
+          const wi = wr.weekNumber - 1;
+          const teamResult = wr.teamResults?.find((tr) => tr.teamId === team.id);
+          if (!teamResult) continue;
+          const ss = teamResult.shooterScores?.find(
+            (s) => normalizeShooterName(s.name) === normalizeShooterName(shooter.name),
+          );
+          if (ss) scores[wi] = ss.total;
+        }
+
+        const avg = computeGoingInAverage(shooter.startingAvg, scores, this._selectedWeek - 1);
+        return `
+          <tr>
+            <td>${shooter.name}</td>
+            <td>${avg.toFixed(1)}</td>
+            <td class="fill"></td>
+            <td class="fill"></td>
+            <td class="fill"></td>
+          </tr>`;
+      })
+      .join('');
+
+    const blankRow = `
+          <tr>
+            <td class="fill">&nbsp;</td>
+            <td class="fill">&nbsp;</td>
+            <td class="fill">&nbsp;</td>
+            <td class="fill">&nbsp;</td>
+            <td class="fill">&nbsp;</td>
+          </tr>`;
+
+    return `
+      <div class="scoresheet-card">
+
+        <div class="scoresheet-print-header">
+          <h1 class="scoresheet-league-title">Central Illinois Trap League</h1>
+          <p class="scoresheet-week-label">Week ${this._selectedWeek} &middot; ${this._year} Season</p>
+        </div>
+
+        <h3 class="scoresheet-team-name">${team.name}</h3>
+        <table class="scoresheet-table">
+          <thead>
+            <tr>
+              <th>Shooter</th>
+              <th>Avg</th>
+              <th>Trap 1</th>
+              <th>Trap 2</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>${rows}${blankRow}${blankRow}</tbody>
+        </table>
+
+        <div class="scoresheet-print-footer">
+          <p>Central Illinois Trap League is an independently organized, non-discriminating shooting
+          sport. We encourage families and friends to participate. We remind everyone to keep it legal
+          by shooting with an adult if under age, or otherwise having a valid FOID card.</p>
+        </div>
+
+      </div>`;
+  }
+
+  private _wireEvents(): void {
+    this.querySelector<HTMLSelectElement>('#sg-year')
+      ?.addEventListener('change', (e) => {
+        void this._changeYear(parseInt((e.target as HTMLSelectElement).value, 10));
+      });
+
+    this.querySelector<HTMLSelectElement>('#sg-week')
+      ?.addEventListener('change', (e) => {
+        this._selectedWeek = parseInt((e.target as HTMLSelectElement).value, 10);
+        this._renderCards();
+      });
+
+    this.querySelector('.scoresheet-print-btn')
+      ?.addEventListener('click', () => window.print());
+  }
+}
+
+customElements.define('scoresheet-generator', ScoresheetGenerator);

--- a/src/components/season-scorecards.ts
+++ b/src/components/season-scorecards.ts
@@ -8,7 +8,7 @@
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService, buildPriorAvgMap } from '@/services/score-service';
-import { computeShooterAverage, computeShooterStartingAvg, isShooterRookie, mean, isDummyName, normalizeShooterName, getLastWord } from '@/services/scoring-engine';
+import { computeShooterAverage, computeShooterStartingAvg, isShooterRookie, mean, isDummyName, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst } from '@/services/scoring-engine';
 import type { Season } from '@/types/season';
 import type { Team, WeekResult } from '@/types/score';
 
@@ -255,15 +255,16 @@ class SeasonScorecards extends HTMLElement {
       return { ...s, weeksShot, finalAvg };
     });
 
-    // Sort: real shooters first, dummies last
-    shooters.sort((a, b) => {
+    // Sort: captain first (among real shooters), dummies last
+    const withCaptainFirst = sortShootersWithCaptainFirst(shooters, teamDoc?.captain ?? '');
+    withCaptainFirst.sort((a, b) => {
       if (a.isDummy === b.isDummy) return 0;
       return a.isDummy ? 1 : -1;
     });
 
     const headerCells = WEEK_HEADERS.map((w) => `<th>${w}</th>`).join('');
 
-    const shooterRows = shooters
+    const shooterRows = withCaptainFirst
       .map((s) => {
         const rookieMark = s.rookie ? 'R' : '';
         const scoreCells = s.scores.map((v) => `<td>${fmt(v)}</td>`).join('');

--- a/src/services/scoring-engine.test.ts
+++ b/src/services/scoring-engine.test.ts
@@ -26,6 +26,7 @@ import {
   computeSeasonAwards,
   computeSeasonTotals,
   computeDummyScore,
+  sortShootersWithCaptainFirst,
 } from './scoring-engine';
 
 // ---------------------------------------------------------------------------
@@ -726,5 +727,41 @@ describe('computeSeasonTotals', () => {
     computeSeasonTotals(seasonData);
     expect(seasonData.teams[0]!.totals.targets).toEqual(originalTargets0);
     expect(seasonData.teams[1]!.totals.targets).toEqual(originalTargets1);
+  });
+});
+
+describe('sortShootersWithCaptainFirst', () => {
+  it('moves captain to index 0', () => {
+    const shooters = [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Charlie' }];
+    const result = sortShootersWithCaptainFirst(shooters, 'Bob');
+    expect(result[0]?.name).toBe('Bob');
+    expect(result[1]?.name).toBe('Alice');
+    expect(result[2]?.name).toBe('Charlie');
+  });
+
+  it('is a no-op when captain is already first', () => {
+    const shooters = [{ name: 'Bob' }, { name: 'Alice' }];
+    const result = sortShootersWithCaptainFirst(shooters, 'Bob');
+    expect(result[0]?.name).toBe('Bob');
+    expect(result[1]?.name).toBe('Alice');
+  });
+
+  it('is case-insensitive (delegates to normalizeShooterName)', () => {
+    const shooters = [{ name: 'alice' }, { name: 'BOB' }];
+    const result = sortShootersWithCaptainFirst(shooters, 'bob');
+    expect(result[0]?.name).toBe('BOB');
+  });
+
+  it('preserves original order when captain is not found', () => {
+    const shooters = [{ name: 'Alice' }, { name: 'Bob' }];
+    const result = sortShootersWithCaptainFirst(shooters, 'Charlie');
+    expect(result[0]?.name).toBe('Alice');
+    expect(result[1]?.name).toBe('Bob');
+  });
+
+  it('does not mutate the input array', () => {
+    const shooters = [{ name: 'Alice' }, { name: 'Bob' }];
+    sortShootersWithCaptainFirst(shooters, 'Bob');
+    expect(shooters[0]?.name).toBe('Alice');
   });
 });

--- a/src/services/scoring-engine.ts
+++ b/src/services/scoring-engine.ts
@@ -41,6 +41,25 @@ export function getLastWord(name: string): string {
   return parts[parts.length - 1] ?? name;
 }
 
+/**
+ * Returns a shallow copy of `shooters` with the captain moved to index 0.
+ * All other elements keep their original relative order.
+ * Comparison is case-insensitive via normalizeShooterName.
+ * No-op if captain is already first or not found.
+ */
+export function sortShootersWithCaptainFirst<T extends { name: string }>(
+  shooters: T[],
+  captainName: string,
+): T[] {
+  const cap = normalizeShooterName(captainName);
+  const idx = shooters.findIndex((s) => normalizeShooterName(s.name) === cap);
+  if (idx <= 0) return [...shooters];
+  const result = [...shooters];
+  const [captain] = result.splice(idx, 1);
+  result.unshift(captain!);
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Average computation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `sortShootersWithCaptainFirst<T extends { name: string }>` to `scoring-engine.ts` — a pure, generic utility that moves the team captain to index 0 while keeping all other shooters in their original relative order (case-insensitive via `normalizeShooterName`)
- `season-scorecards.ts` uses the utility before the existing dummy-sort, so the captain is first among real shooters and dummies remain at the bottom
- `scoresheet-generator.ts` applies it after filtering dummies, so the captain is the first printed row on every team's scoresheet

## Test plan

- [ ] `npm run build` — 0 TypeScript errors
- [ ] `npm test` — all 121 tests pass (5 new `sortShootersWithCaptainFirst` tests added)
- [ ] Scorecards page — open any team's scorecard; captain name is the first shooter row
- [ ] Downloads / Print preview — captain is the first data row on every team's scoresheet
- [ ] Standings page — no regression (no shooter rows affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)