### PR TITLE
feat(home): season calendar component

### DIFF
--- a/src/components/season-calendar.ts
+++ b/src/components/season-calendar.ts
@@ -1,0 +1,186 @@
+/**
+ * season-calendar — Custom Element
+ *
+ * Displays the current season's shoot schedule as a multi-month calendar grid.
+ * No shadow DOM; uses global CSS classes. No Firestore calls — year derived from Date.
+ *
+ * Business rules:
+ *  - Practice day:    2nd Tuesday of April
+ *  - Week 1:         3rd Tuesday of April
+ *  - Season length:  15 shoot weeks
+ *  - July 4th skip:  if July 4 falls Mon–Fri, the Tuesday of that Sun–Sat week
+ *                    is skipped; season extends by one week
+ *  - July 4th mark:  July 4 itself shown red when it is a weekday
+ *  - Months shown:   April → month containing the 15th shoot Tuesday
+ */
+
+interface ScheduleEvent {
+  date: Date;
+  type: 'practice' | 'shoot' | 'holiday';
+  week?: number; // 1-based, only for shoot days
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const DAY_HEADERS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+class SeasonCalendar extends HTMLElement {
+  connectedCallback(): void {
+    const year = new Date().getFullYear();
+    const schedule = this._computeSchedule(year);
+    this.innerHTML = this._renderCalendar(year, schedule);
+  }
+
+  // ─── Schedule computation ────────────────────────────────────────────────────
+
+  /** Returns the date of the Nth Tuesday (1-based) of the given month (0-based). */
+  private _nthTuesdayOfMonth(year: number, month: number, n: number): Date {
+    const firstDay = new Date(year, month, 1);
+    const firstDayOfWeek = firstDay.getDay(); // 0 = Sun, 2 = Tue
+    const daysUntilTuesday = (2 - firstDayOfWeek + 7) % 7;
+    const firstTuesdayDate = 1 + daysUntilTuesday;
+    return new Date(year, month, firstTuesdayDate + (n - 1) * 7);
+  }
+
+  /** Returns all schedule events for the season year. */
+  private _computeSchedule(year: number): ScheduleEvent[] {
+    const practice = this._nthTuesdayOfMonth(year, 3, 2); // April = month 3
+    const week1Start = this._nthTuesdayOfMonth(year, 3, 3);
+
+    const july4 = new Date(year, 6, 4);
+    const july4DayOfWeek = july4.getDay(); // 0 = Sun, 6 = Sat
+    const july4IsWeekday = july4DayOfWeek >= 1 && july4DayOfWeek <= 5;
+
+    // Tuesday of the Sun–Sat week that contains July 4
+    let skippedTuesday: Date | null = null;
+    if (july4IsWeekday) {
+      // Days since Sunday of that week = july4DayOfWeek
+      const sundayOffset = july4DayOfWeek; // days to subtract to reach Sunday
+      const sundayDate = 4 - sundayOffset; // July date of that Sunday
+      skippedTuesday = new Date(year, 6, sundayDate + 2); // +2 to reach Tuesday
+    }
+
+    const events: ScheduleEvent[] = [
+      { date: practice, type: 'practice' },
+    ];
+
+    if (july4IsWeekday) {
+      events.push({ date: july4, type: 'holiday' });
+    }
+
+    // Walk forward, collecting 15 shoot Tuesdays (skipping the July 4 week Tuesday)
+    const current = new Date(week1Start);
+    let shootWeek = 1;
+
+    while (shootWeek <= 15) {
+      const isSkipped =
+        skippedTuesday !== null &&
+        current.getFullYear() === skippedTuesday.getFullYear() &&
+        current.getMonth() === skippedTuesday.getMonth() &&
+        current.getDate() === skippedTuesday.getDate();
+
+      if (!isSkipped) {
+        events.push({ date: new Date(current), type: 'shoot', week: shootWeek });
+        shootWeek++;
+      }
+
+      current.setDate(current.getDate() + 7);
+    }
+
+    return events;
+  }
+
+  // ─── Rendering ───────────────────────────────────────────────────────────────
+
+  private _renderCalendar(year: number, schedule: ScheduleEvent[]): string {
+    // Month range: April (3) → month of last shoot event
+    const shootEvents = schedule.filter((e) => e.type === 'shoot');
+    const lastShoot = shootEvents[shootEvents.length - 1];
+    const lastMonth = lastShoot?.date.getMonth() ?? 6; // fallback July
+
+    let monthsHtml = '';
+    for (let m = 3; m <= lastMonth; m++) {
+      monthsHtml += this._renderMonth(year, m, schedule);
+    }
+
+    const legendHtml = this._renderLegend();
+
+    return `
+      <section class="season-calendar">
+        <h2>${year} Season Schedule</h2>
+        <div class="calendar-months">
+          ${monthsHtml}
+        </div>
+        ${legendHtml}
+      </section>`;
+  }
+
+  private _renderMonth(year: number, month: number, schedule: ScheduleEvent[]): string {
+    const firstDay = new Date(year, month, 1);
+    const startDayOfWeek = firstDay.getDay(); // 0 = Sun
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    const today = new Date();
+    const todayKey = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
+
+    // Build lookup: dateKey → CSS class
+    const scheduleMap = new Map<string, string>();
+    for (const event of schedule) {
+      const key = `${event.date.getFullYear()}-${event.date.getMonth()}-${event.date.getDate()}`;
+      // Holiday takes priority over any shoot that might share the same date
+      if (!scheduleMap.has(key) || event.type === 'holiday') {
+        scheduleMap.set(key, `calendar-cell--${event.type}`);
+      }
+    }
+
+    const headersHtml = DAY_HEADERS.map((d) => `<div class="calendar-day-header">${d}</div>`).join('');
+
+    const emptyCells = Array.from({ length: startDayOfWeek }, () =>
+      '<div class="calendar-cell calendar-cell--empty"></div>',
+    ).join('');
+
+    let dayCells = '';
+    for (let d = 1; d <= daysInMonth; d++) {
+      const key = `${year}-${month}-${d}`;
+      const schedClass = scheduleMap.get(key) ?? '';
+      const todayClass = key === todayKey ? 'calendar-cell--today' : '';
+      const classes = ['calendar-cell', schedClass, todayClass].filter(Boolean).join(' ');
+      dayCells += `<div class="${classes}">${d}</div>`;
+    }
+
+    return `
+      <div class="calendar-month">
+        <div class="calendar-month-title">${MONTH_NAMES[month] ?? ''} ${year}</div>
+        <div class="calendar-grid">
+          ${headersHtml}
+          ${emptyCells}
+          ${dayCells}
+        </div>
+      </div>`;
+  }
+
+  private _renderLegend(): string {
+    const items: Array<{ label: string; style: string }> = [
+      { label: 'Shoot Day', style: 'background: var(--c-table-header-bg)' },
+      { label: 'Practice Day', style: 'background: var(--c-accent)' },
+      { label: 'Holiday', style: 'background: #dc2626' },
+    ];
+
+    const itemsHtml = items
+      .map(
+        ({ label, style }) => `
+      <div class="calendar-legend-item">
+        <div class="calendar-legend-swatch" style="${style}"></div>
+        <span>${label}</span>
+      </div>`,
+      )
+      .join('');
+
+    return `<div class="calendar-legend">${itemsHtml}</div>`;
+  }
+}
+
+customElements.define('season-calendar', SeasonCalendar);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import './components/home-standings';
 import './components/season-scorecards';
 import './components/admin-panel';
 import './components/scoresheet-generator';
+import './components/season-calendar';
 
 import { NavigationModule } from './modules/navigation';
 import { RouterModule } from './modules/router';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1612,3 +1612,44 @@ input[type="text"].ap-roster-name:focus {
     padding-top: 6pt;
   }
 }
+
+/* ─── Season Calendar ──────────────────────────────────────────────────────── */
+
+/* Layout */
+.season-calendar       { margin-bottom: var(--space-8); }
+.calendar-months       { display: flex; flex-wrap: wrap; gap: var(--space-6); }
+.calendar-month        { flex: 1 1 280px; background: var(--c-surface);
+                         border: 1px solid var(--c-border); border-radius: var(--radius-md);
+                         padding: var(--space-4); }
+.calendar-month-title  { font-size: var(--text-lg); font-weight: 600;
+                         color: var(--c-heading); margin-bottom: var(--space-3); }
+
+/* Grid */
+.calendar-grid         { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; }
+.calendar-day-header   { text-align: center; font-size: var(--text-xs);
+                         color: var(--c-text-muted); font-weight: 600;
+                         padding-bottom: var(--space-1); }
+
+/* Cells */
+.calendar-cell         { aspect-ratio: 1; display: flex; align-items: center;
+                         justify-content: center; border-radius: var(--radius-sm);
+                         font-size: var(--text-sm); color: var(--c-text); }
+.calendar-cell--empty  { /* invisible placeholder */ }
+.calendar-cell--shoot  { background: var(--c-table-header-bg); /* navy */
+                         color: #fff; font-weight: 600; }
+.calendar-cell--practice { background: var(--c-accent); /* orange */
+                           color: #fff; font-weight: 600; }
+.calendar-cell--holiday  { background: #dc2626; color: #fff; font-weight: 600; }
+.calendar-cell--today  { outline: 2px solid var(--c-accent); outline-offset: -2px; }
+
+/* Dark mode — shoot day needs lighter treatment on dark bg */
+@media (prefers-color-scheme: dark) {
+  .calendar-cell--shoot { background: #1e5f8e; }
+}
+
+/* Legend */
+.calendar-legend       { display: flex; gap: var(--space-4); flex-wrap: wrap;
+                         margin-top: var(--space-4); font-size: var(--text-sm);
+                         color: var(--c-text-muted); align-items: center; }
+.calendar-legend-item  { display: flex; align-items: center; gap: var(--space-1); }
+.calendar-legend-swatch { width: 14px; height: 14px; border-radius: var(--radius-sm); }

--- a/src/views/home.ts
+++ b/src/views/home.ts
@@ -1,3 +1,5 @@
 export function homeView(): string {
-  return '<home-standings></home-standings>';
+  return `
+    <home-standings></home-standings>
+    <season-calendar></season-calendar>`;
 }


### PR DESCRIPTION
## Summary

- Adds a `<season-calendar>` Custom Element that renders the shoot schedule as a multi-month calendar grid on the home page
- League rules encoded: practice on 2nd Tuesday of April, Week 1 on 3rd Tuesday, 15 shoot weeks, July 4th weekday skip (season extends by one week)
- Colour-coded cells: navy = shoot day, orange = practice, red = holiday/July 4; today outlined in accent colour
- Legend rendered below grid; months shown April → month of final shoot week
- No Firestore calls — year derived from `new Date()`

## Test plan

- [ ] Home page displays the season calendar for the current year
- [ ] Practice day falls on the 2nd Tuesday of April; Week 1 on the 3rd Tuesday
- [ ] July 4 weekday years show a red cell on July 4 and no navy cell that week
- [ ] July 4 weekend years show uninterrupted consecutive navy Tuesdays
- [ ] Today's date is outlined in orange regardless of cell type
- [ ] `npm run build` passes with 0 TypeScript errors
- [ ] `npm test` passes (121 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)