### PR TITLE
feat(home): pre-season standings + rounded table corners

### DIFF
--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -8,6 +8,7 @@
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
+import type { Team } from '@/types/score';
 import type { Season } from '@/types/season';
 import type { WeekResult } from '@/types/score';
 
@@ -19,6 +20,7 @@ class HomeStandings extends HTMLElement {
   private _selectedYear: number | null = null;
   private _season: Season | null = null;
   private _allWeekResults: WeekResult[] = [];
+  private _teams: Team[] = [];
 
   connectedCallback(): void {
     this.innerHTML = `
@@ -75,9 +77,10 @@ class HomeStandings extends HTMLElement {
   private async _loadYear(year: number): Promise<void> {
     this.querySelector('#hs-table')!.innerHTML = '<p>Loading&hellip;</p>';
 
-    const [weeksResult, seasonResult] = await Promise.all([
+    const [weeksResult, seasonResult, teamsResult] = await Promise.all([
       scoreService.getAllWeekResults(year),
       scoreService.getSeason(year),
+      scoreService.getTeams(year),
     ]);
 
     if (!seasonResult.success || !seasonResult.data) {
@@ -87,6 +90,7 @@ class HomeStandings extends HTMLElement {
 
     this._season = seasonResult.data;
     this._allWeekResults = weeksResult.success ? (weeksResult.data ?? []) : [];
+    this._teams = teamsResult.success ? (teamsResult.data ?? []) : [];
 
     const weekSelect = this.querySelector<HTMLSelectElement>('#hs-week')!;
     while (weekSelect.firstChild) weekSelect.removeChild(weekSelect.firstChild);
@@ -110,28 +114,42 @@ class HomeStandings extends HTMLElement {
 
   private _renderTable(weekKey: string): void {
     let rows: {
-      place: number;
+      place: number | string;
       teamName: string;
-      targets: number;
-      totalTargets: number;
-      rankPoints: number;
-      bonusPoints: number;
-      total: number;
+      targets: number | string;
+      totalTargets: number | string;
+      rankPoints: number | string;
+      bonusPoints: number | string;
+      total: number | string;
     }[];
     let subtitle: string;
 
     if (weekKey === 'season') {
       const standings = this._season?.standings ?? [];
-      rows = standings.map((s) => ({
-        place: s.rank,
-        teamName: s.teamName,
-        targets: s.totalTargets,
-        totalTargets: s.totalTargets,
-        rankPoints: s.totalRankPoints,
-        bonusPoints: s.totalBonusPoints,
-        total: s.totalRankPoints + s.totalBonusPoints,
-      }));
-      subtitle = 'Cumulative season totals';
+
+      if (standings.length > 0) {
+        rows = standings.map((s) => ({
+          place: s.rank,
+          teamName: s.teamName,
+          targets: s.totalTargets,
+          totalTargets: s.totalTargets,
+          rankPoints: s.totalRankPoints,
+          bonusPoints: s.totalBonusPoints,
+          total: s.totalRankPoints + s.totalBonusPoints,
+        }));
+        subtitle = 'Cumulative season totals';
+      } else {
+        rows = this._teams.map((t) => ({
+          place: '—',
+          teamName: t.name,
+          targets: '—',
+          totalTargets: '—',
+          rankPoints: '—',
+          bonusPoints: '—',
+          total: '—',
+        }));
+        subtitle = 'Season has not yet begun — teams registered';
+      }
     } else {
       const weekNum = parseInt(weekKey, 10);
       const weekResult = this._allWeekResults.find((w) => w.weekNumber === weekNum);
@@ -166,7 +184,7 @@ class HomeStandings extends HTMLElement {
         };
       });
 
-      rows.sort((a, b) => b.total - a.total);
+      rows.sort((a, b) => (b.total as number) - (a.total as number));
       rows = rows.map((r, i) => ({ ...r, place: i + 1 }));
       subtitle = `Week ${weekNum} results \u00b7 Total reflects season-to-date`;
     }
@@ -175,7 +193,15 @@ class HomeStandings extends HTMLElement {
   }
 
   private _buildTable(
-    rows: { place: number; teamName: string; targets: number; totalTargets: number; rankPoints: number; bonusPoints: number; total: number }[],
+    rows: {
+      place: number | string;
+      teamName: string;
+      targets: number | string;
+      totalTargets: number | string;
+      rankPoints: number | string;
+      bonusPoints: number | string;
+      total: number | string;
+    }[],
     subtitle: string,
   ): string {
     const trs = rows

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -585,6 +585,8 @@ a:hover { color: var(--c-link-hover); }
   display: block;
   overflow-x: auto;
   white-space: nowrap;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--c-table-border);
 }
 
 .standing-table th {
@@ -608,6 +610,8 @@ a:hover { color: var(--c-link-hover); }
 
 .standing-table td:nth-child(n+2):nth-child(-n+16),
 .standing-table th:nth-child(n+2):nth-child(-n+16) { width: 5%; }
+
+.standing-table tr:last-child td { border-bottom: none; }
 
 /* ============================================================
    Collapsible scorecards — heading-style accordion
@@ -659,10 +663,12 @@ a:hover { color: var(--c-link-hover); }
   border-collapse: collapse;
   table-layout: auto;
   width: 100%;
-  padding-top: var(--space-5);
+  margin-top: var(--space-5);
   display: block;
   overflow-x: auto;
   white-space: nowrap;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--c-table-border);
 }
 
 .scorecard-tables tr { height: 28px; }
@@ -710,6 +716,8 @@ a:hover { color: var(--c-link-hover); }
   background-color: var(--c-table-hover);
   color: var(--c-text);
 }
+
+.scorecard-tables tr:last-child td { border-bottom: none; }
 
 /* DUMMY shooter rows — italic + muted */
 .scorecard-tables tr.dummy-row td {
@@ -1381,6 +1389,10 @@ input[type="text"].ap-roster-name:focus {
   table-layout: fixed;   /* column widths set by th; never shift on content change */
   border-collapse: collapse;
   font-size: var(--text-sm);
+  display: block;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--c-table-border);
   margin-bottom: var(--space-4);
 }
 
@@ -1405,6 +1417,8 @@ input[type="text"].ap-roster-name:focus {
   border-bottom: 1px solid var(--c-table-border);
   vertical-align: middle;
 }
+
+.admin-team-table tr:last-child td { border-bottom: none; }
 
 /* Truncate text only in non-actions cells; actions cell must never clip button radii */
 .admin-team-table td:not(.admin-team-actions) {


### PR DESCRIPTION
## Summary

- **Pre-season standings:** When a season has no published weeks, the home-page standings table now shows all registered teams (fetched via `scoreService.getTeams()`, already cached) with `—` placeholders for all numeric columns and a subtitle of "Season has not yet begun — teams registered". Once Week 1 is published, the normal ranked standings display takes over unchanged. If no teams are registered yet, the table body remains empty (no regression).
- **Rounded table corners:** All three site tables (`.standing-table`, `.scorecard-tables`, `.admin-team-table`) now have `border-radius: var(--radius-md)` and a `1px` border, consistent with buttons, cards, and other components. Each table's last row has `border-bottom: none` to avoid a double-border at the rounded edge. `scorecard-tables` `padding-top` changed to `margin-top` so the visible border starts at the header row rather than wrapping blank space (margin is still included in the accordion `scrollHeight` since `.scorecard` is a BFC).

## Files Changed

- `src/components/home-standings.ts` — imports `Team`, adds `_teams` field, parallel-fetches `getTeams()` in `_loadYear()`, pre-season branch in `_renderTable('season')`
- `src/styles/main.css` — rounded corners + border on all three table classes; last-row border removal

## Test plan

- [ ] `npm run build` — 0 errors
- [ ] `npm test` — 153 tests pass
- [ ] Pre-season: standings table shows registered teams with `—` values and correct subtitle
- [ ] Post-Week-1: normal ranked standings appear unchanged
- [ ] No-teams season: table body empty (no regression)
- [ ] All three tables display rounded corners consistently with other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)