### PR TITLE
feat(announcements): add announcement system for homepage and admin

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,12 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /announcements/{docId} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.auth.token.admin == true;
+    }
+
     match /seasons/{year} {
       allow read: if true;
       allow write: if request.auth != null

--- a/src/components/admin-panel.ts
+++ b/src/components/admin-panel.ts
@@ -56,6 +56,8 @@ class AdminPanel extends HTMLElement {
   private _dateEditMode = false;
   /** Whether any entries have been saved for the currently selected week */
   private _weekHasScores = false;
+  /** null = not editing; else = announcement id being edited */
+  private _editingAnnouncementId: string | null = null;
 
   // ── Roster modal state ────────────────────────────────────────────────────
   private _rosterDialog: HTMLDialogElement | null = null;
@@ -70,6 +72,7 @@ class AdminPanel extends HTMLElement {
         <div class="admin-tabs">
           <button class="admin-tab-btn is-active" data-tab="team-mgmt">Team Management</button>
           <button class="admin-tab-btn" data-tab="score-entry">Score Entry</button>
+          <button class="admin-tab-btn" data-tab="announcements">Announcements</button>
         </div>
 
         <div class="admin-form-row">
@@ -125,6 +128,28 @@ class AdminPanel extends HTMLElement {
           </div>
 
         </div>
+
+        <!-- ── Announcements Panel ── -->
+        <div id="ap-panel-announcements" class="admin-tab-content admin-tab-panel--hidden">
+          <div class="admin-header"><h2>Announcements</h2></div>
+          <div class="ann-editor">
+            <div class="ann-editor__field">
+              <label for="ann-title">Title</label>
+              <input type="text" id="ann-title" class="ann-editor__input" placeholder="Announcement title" />
+            </div>
+            <div class="ann-editor__field">
+              <label for="ann-body">Message (Markdown)</label>
+              <textarea id="ann-body" class="ann-editor__textarea" rows="6"
+                placeholder="Write your announcement..."></textarea>
+            </div>
+            <div class="ann-editor__actions">
+              <button id="ann-post-btn" class="btn-primary">Post Announcement</button>
+              <button id="ann-cancel-btn" class="btn-secondary" style="display:none">Cancel Edit</button>
+            </div>
+            <p id="ann-status" class="admin-status" aria-live="polite"></p>
+          </div>
+          <div id="ann-list"></div>
+        </div>
       </div>`;
 
     // Tab switching
@@ -154,6 +179,13 @@ class AdminPanel extends HTMLElement {
     this.querySelector('#ap-save')!.addEventListener('click', () => void this._saveEntry());
     this.querySelector('#ap-publish')!.addEventListener('click', () => void this._publishWeek());
 
+    // Announcements listeners
+    this.querySelector('#ann-post-btn')!.addEventListener('click', () => {
+      if (this._editingAnnouncementId) void this._saveEditAnnouncement();
+      else void this._postAnnouncement();
+    });
+    this.querySelector('#ann-cancel-btn')!.addEventListener('click', () => this._clearAnnEditor());
+
     void this._fetchTeamsData();
     void this._fetchSeasonData();
     void this._loadSavedEntries();
@@ -168,10 +200,12 @@ class AdminPanel extends HTMLElement {
     for (const { id, name } of [
       { id: 'ap-panel-team-mgmt', name: 'team-mgmt' },
       { id: 'ap-panel-score-entry', name: 'score-entry' },
+      { id: 'ap-panel-announcements', name: 'announcements' },
     ]) {
       const el = this.querySelector(`#${id}`);
       if (el) el.classList.toggle('admin-tab-panel--hidden', name !== tab);
     }
+    if (tab === 'announcements') void this._loadAnnouncementsTab();
   }
 
   // ── Data loading ─────────────────────────────────────────────────────────
@@ -1294,6 +1328,161 @@ class AdminPanel extends HTMLElement {
       if (cancelBtn) cancelBtn.disabled = false;
       showToast('error', `Failed to save date: ${result.error}`);
     }
+  }
+
+  // ── Announcements ────────────────────────────────────────────────────────
+
+  private _annYear(): number {
+    return parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
+  }
+
+  private _setAnnStatus(message: string, type: '' | 'success' | 'error'): void {
+    const el = this.querySelector('#ann-status');
+    if (!el) return;
+    el.textContent = message;
+    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
+  }
+
+  private async _loadAnnouncementsTab(): Promise<void> {
+    const year = this._annYear();
+    const result = await scoreService.getAnnouncements(year);
+    if (!result.success) {
+      this._setAnnStatus(`Error loading announcements: ${result.error}`, 'error');
+      return;
+    }
+    this._renderAnnAdminList(result.data);
+  }
+
+  private _renderAnnAdminList(announcements: import('@/types/announcement').Announcement[]): void {
+    const list = this.querySelector('#ann-list');
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (announcements.length === 0) {
+      list.innerHTML = '<p style="color:var(--c-text-muted);font-size:var(--text-sm)">No announcements for this year.</p>';
+      return;
+    }
+
+    const fmt = (ts: import('firebase/firestore').Timestamp) =>
+      ts.toDate().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+    for (const ann of announcements) {
+      const card = document.createElement('div');
+      card.className = 'ann-admin-card';
+
+      const editedMeta = ann.lastEditedAt
+        ? `<span> · Edited ${fmt(ann.lastEditedAt)}</span>`
+        : '';
+
+      card.innerHTML = `
+        <div class="ann-admin-card__header">
+          <span class="ann-admin-card__title"></span>
+          <span class="ann-admin-card__meta">Posted ${fmt(ann.postedAt)}${editedMeta}</span>
+        </div>
+        <pre class="ann-admin-card__body"></pre>
+        <div class="ann-admin-card__actions">
+          <button class="btn-secondary ann-edit-btn" data-id="${ann.id}" data-year="${ann.year}">Edit</button>
+          <button class="btn-danger ann-delete-btn" data-id="${ann.id}" data-year="${ann.year}">Delete</button>
+        </div>`;
+
+      card.querySelector('.ann-admin-card__title')!.textContent = ann.title;
+      card.querySelector('.ann-admin-card__body')!.textContent = ann.body;
+
+      list.appendChild(card);
+    }
+
+    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-edit-btn')) {
+      btn.addEventListener('click', () => {
+        const ann = announcements.find((a) => a.id === btn.dataset['id']);
+        if (ann) this._startEditAnnouncement(ann.id, ann.title, ann.body);
+      });
+    }
+
+    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-delete-btn')) {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset['id'] ?? '';
+        const year = parseInt(btn.dataset['year'] ?? '0', 10);
+        const ann = announcements.find((a) => a.id === id);
+        void this._deleteAnnouncement(id, year, ann?.title ?? id);
+      });
+    }
+  }
+
+  private async _postAnnouncement(): Promise<void> {
+    const year = this._annYear();
+    const title = (this.querySelector<HTMLInputElement>('#ann-title')!.value).trim();
+    const body = (this.querySelector<HTMLTextAreaElement>('#ann-body')!.value).trim();
+
+    if (!title || !body) {
+      this._setAnnStatus('Title and message are required.', 'error');
+      return;
+    }
+
+    this._setAnnStatus('Posting…', '');
+    const result = await scoreService.createAnnouncement(year, title, body);
+    if (!result.success) {
+      this._setAnnStatus(`Error: ${result.error}`, 'error');
+      return;
+    }
+    this._clearAnnEditor();
+    void this._loadAnnouncementsTab();
+  }
+
+  private _startEditAnnouncement(id: string, title: string, body: string): void {
+    this.querySelector<HTMLInputElement>('#ann-title')!.value = title;
+    this.querySelector<HTMLTextAreaElement>('#ann-body')!.value = body;
+    this._editingAnnouncementId = id;
+    this.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Save Changes';
+    (this.querySelector<HTMLButtonElement>('#ann-cancel-btn')!).style.display = '';
+    this.querySelector('#ann-status')!.textContent = '';
+    this.querySelector('#ann-title')!.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  private async _saveEditAnnouncement(): Promise<void> {
+    const id = this._editingAnnouncementId!;
+    const year = this._annYear();
+    const title = (this.querySelector<HTMLInputElement>('#ann-title')!.value).trim();
+    const body = (this.querySelector<HTMLTextAreaElement>('#ann-body')!.value).trim();
+
+    if (!title || !body) {
+      this._setAnnStatus('Title and message are required.', 'error');
+      return;
+    }
+
+    this._setAnnStatus('Saving…', '');
+    const result = await scoreService.updateAnnouncement(id, year, title, body);
+    if (!result.success) {
+      this._setAnnStatus(`Error: ${result.error}`, 'error');
+      return;
+    }
+    this._clearAnnEditor();
+    void this._loadAnnouncementsTab();
+  }
+
+  private async _deleteAnnouncement(id: string, year: number, title: string): Promise<void> {
+    const confirmed = await this._showConfirmDialog({
+      title: 'Delete Announcement',
+      warning: `This will permanently delete "${title}". This cannot be undone.`,
+      nameToType: title,
+      deleteLabel: 'Delete Announcement',
+    });
+    if (!confirmed) return;
+    const result = await scoreService.deleteAnnouncement(id, year);
+    if (result.success) {
+      showToast('success', `Announcement "${title}" deleted.`);
+      void this._loadAnnouncementsTab();
+    } else {
+      showToast('error', `Failed to delete announcement: ${result.error}`);
+    }
+  }
+
+  private _clearAnnEditor(): void {
+    this.querySelector<HTMLInputElement>('#ann-title')!.value = '';
+    this.querySelector<HTMLTextAreaElement>('#ann-body')!.value = '';
+    this._editingAnnouncementId = null;
+    this.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Post Announcement';
+    (this.querySelector<HTMLButtonElement>('#ann-cancel-btn')!).style.display = 'none';
+    this.querySelector('#ann-status')!.textContent = '';
   }
 
   // ── Status helpers ───────────────────────────────────────────────────────

--- a/src/components/home-announcements.ts
+++ b/src/components/home-announcements.ts
@@ -1,0 +1,68 @@
+/**
+ * home-announcements — Custom Element
+ *
+ * Displays admin-posted announcements for the current season year.
+ * Silently renders nothing if there are no announcements or on error.
+ * No shadow DOM; uses global CSS classes.
+ */
+
+import { db } from '@/firebase-config';
+import { createRepositoryFactory } from '@/repositories/repository-factory';
+import { ScoreService } from '@/services/score-service';
+import { renderMarkdown } from '@/utils/markdown';
+import type { Announcement } from '@/types/announcement';
+
+const factory = createRepositoryFactory({ db });
+const scoreService = new ScoreService(factory.getScoreRepository());
+
+class HomeAnnouncements extends HTMLElement {
+  connectedCallback(): void {
+    const year = new Date().getFullYear();
+    void this._load(year);
+  }
+
+  private async _load(year: number): Promise<void> {
+    const result = await scoreService.getAnnouncements(year);
+    if (!result.success || result.data.length === 0) {
+      this.innerHTML = '';
+      return;
+    }
+    this._render(result.data);
+  }
+
+  private _render(announcements: Announcement[]): void {
+    const fmt = (ts: import('firebase/firestore').Timestamp) =>
+      ts.toDate().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+    const cards = announcements.map((ann) => {
+      const escapedTitle = ann.title
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
+      const editedSpan = ann.lastEditedAt
+        ? `<span class="ann-card__edited">Edited ${fmt(ann.lastEditedAt)}</span>`
+        : '';
+
+      return `
+        <article class="ann-card">
+          <header class="ann-card__header">
+            <h3 class="ann-card__title">${escapedTitle}</h3>
+            <div class="ann-card__meta">
+              <span>Posted ${fmt(ann.postedAt)}</span>
+              ${editedSpan}
+            </div>
+          </header>
+          <div class="ann-card__body">${renderMarkdown(ann.body)}</div>
+        </article>`;
+    }).join('');
+
+    this.innerHTML = `
+      <section class="ann-section">
+        <h2 class="ann-section__heading">Announcements</h2>
+        <div class="ann-card-list">${cards}</div>
+      </section>`;
+  }
+}
+
+customElements.define('home-announcements', HomeAnnouncements);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@
 
 import './styles/main.css';
 import './components/home-standings';
+import './components/home-announcements';
 import './components/season-scorecards';
 import './components/admin-panel';
 import './components/scoresheet-generator';

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -11,6 +11,7 @@
 import {
   collection,
   doc,
+  addDoc,
   getDoc,
   getDocs,
   setDoc,
@@ -21,11 +22,13 @@ import {
   where,
   orderBy,
   limit,
+  serverTimestamp,
   type Firestore,
 } from 'firebase/firestore';
 
 import type { Team, WeekResult, SeasonEntry } from '@/types/score';
 import type { Season, SeasonStandings } from '@/types/season';
+import type { Announcement } from '@/types/announcement';
 
 // ---------------------------------------------------------------------------
 // Result type + helpers
@@ -428,6 +431,61 @@ export class ScoreRepository {
       return success(undefined);
     } catch (err) {
       return failure(`Failed to save roster: ${(err as Error).message}`, 'FIRESTORE_WRITE_ERROR');
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Announcements
+  // -------------------------------------------------------------------------
+
+  async getAnnouncements(year: number): Promise<Result<Announcement[]>> {
+    try {
+      const q = query(
+        collection(this.db, 'announcements'),
+        where('year', '==', year),
+      );
+      const snap = await getDocs(q);
+      const announcements = snap.docs.map((d) => ({ id: d.id, ...d.data() } as Announcement));
+      announcements.sort((a, b) => b.postedAt.toMillis() - a.postedAt.toMillis());
+      return success(announcements);
+    } catch (err) {
+      return failure(`Failed to load announcements: ${(err as Error).message}`, 'FIRESTORE_ERROR');
+    }
+  }
+
+  async createAnnouncement(year: number, title: string, body: string): Promise<Result<Announcement>> {
+    try {
+      const ref = await addDoc(collection(this.db, 'announcements'), {
+        year,
+        title,
+        body,
+        postedAt: serverTimestamp(),
+        lastEditedAt: null,
+      });
+      const snap = await getDoc(ref);
+      return success({ id: snap.id, ...snap.data() } as Announcement);
+    } catch (err) {
+      return failure(`Failed to create announcement: ${(err as Error).message}`, 'FIRESTORE_ERROR');
+    }
+  }
+
+  async updateAnnouncement(id: string, title: string, body: string): Promise<Result<Announcement>> {
+    try {
+      const ref = doc(this.db, 'announcements', id);
+      await updateDoc(ref, { title, body, lastEditedAt: serverTimestamp() });
+      const snap = await getDoc(ref);
+      return success({ id: snap.id, ...snap.data() } as Announcement);
+    } catch (err) {
+      return failure(`Failed to update announcement: ${(err as Error).message}`, 'FIRESTORE_ERROR');
+    }
+  }
+
+  async deleteAnnouncement(id: string): Promise<Result<void>> {
+    try {
+      await deleteDoc(doc(this.db, 'announcements', id));
+      return success(undefined);
+    } catch (err) {
+      return failure(`Failed to delete announcement: ${(err as Error).message}`, 'FIRESTORE_ERROR');
     }
   }
 }

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -13,6 +13,7 @@ import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Season, SeasonStandings } from '@/types/season';
 import type { Team, WeekResult, SeasonEntry, ShooterScore } from '@/types/score';
 import type { SeasonData, ScorecardShooter } from '@/types/scorecard';
+import type { Announcement } from '@/types/announcement';
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -543,6 +544,38 @@ export class ScoreService {
       this.cache.delete('seasons:all');
     }
     return result.success ? { success: true, data: undefined } : result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Announcements
+  // -------------------------------------------------------------------------
+
+  async getAnnouncements(year: number): Promise<Result<Announcement[]>> {
+    const cacheKey = `announcements:${year}`;
+    const cached = getCached<Announcement[]>(this.cache, cacheKey);
+    if (cached !== undefined) return success(cached);
+
+    const result = await this.repository.getAnnouncements(year);
+    if (result.success) setCache(this.cache, cacheKey, result.data);
+    return result;
+  }
+
+  async createAnnouncement(year: number, title: string, body: string): Promise<Result<Announcement>> {
+    const result = await this.repository.createAnnouncement(year, title, body);
+    if (result.success) this.cache.delete(`announcements:${year}`);
+    return result;
+  }
+
+  async updateAnnouncement(id: string, year: number, title: string, body: string): Promise<Result<Announcement>> {
+    const result = await this.repository.updateAnnouncement(id, title, body);
+    if (result.success) this.cache.delete(`announcements:${year}`);
+    return result;
+  }
+
+  async deleteAnnouncement(id: string, year: number): Promise<Result<void>> {
+    const result = await this.repository.deleteAnnouncement(id);
+    if (result.success) this.cache.delete(`announcements:${year}`);
+    return result;
   }
 
   // -------------------------------------------------------------------------

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1260,6 +1260,23 @@ select:focus {
   box-shadow: 0 0 0 3px rgba(255, 128, 0, 0.15);
 }
 
+/* ── Announcements (homepage) ─────────────────────────────────────── */
+.ann-section { margin-bottom: var(--space-4); }
+.ann-section__heading { font-size: var(--text-lg); font-weight: 700; color: var(--c-heading); margin: 0 0 var(--space-3); }
+.ann-card-list { display: flex; flex-direction: column; gap: var(--space-3); }
+.ann-card { background: var(--c-bg); border: 1px solid var(--c-table-border); border-radius: var(--radius-md); padding: var(--space-4); }
+.ann-card__header { margin-bottom: var(--space-3); }
+.ann-card__title { font-size: var(--text-base); font-weight: 600; color: var(--c-heading); margin: 0 0 4px; }
+.ann-card__meta { display: flex; gap: var(--space-3); flex-wrap: wrap; font-size: var(--text-xs); color: var(--c-text-muted); }
+.ann-card__edited { font-style: italic; }
+.ann-card__body { font-size: var(--text-sm); color: var(--c-text); line-height: 1.6; }
+.ann-card__body p { margin: 0 0 0.5rem; }
+.ann-card__body p:last-child { margin-bottom: 0; }
+.ann-card__body ul, .ann-card__body ol { padding-left: 1.5rem; margin: 0.25rem 0 0.5rem; }
+.ann-card__body strong { font-weight: 600; }
+.ann-card__body a { color: var(--c-accent); }
+.ann-card__body code { font-size: 0.9em; background: var(--c-table-border); padding: 0.1em 0.3em; border-radius: 3px; }
+
 /* Controls containers — label + select row */
 .home-standings-controls,
 .season-scorecards-controls,
@@ -1443,6 +1460,21 @@ input[type="text"].ap-roster-name:focus {
 .roster-dialog .admin-table-wrapper {
   margin-bottom: 0;
 }
+
+/* ── Announcements admin ──────────────────────────────────────────── */
+.ann-editor { border: 1px solid var(--c-table-border); border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-4); }
+.ann-editor__field { display: flex; flex-direction: column; gap: 4px; margin-bottom: var(--space-3); }
+.ann-editor__field label { font-size: var(--text-sm); font-weight: 500; color: var(--c-heading); }
+.ann-editor__input,
+.ann-editor__textarea { width: 100%; padding: 6px 10px; border: 1px solid var(--c-table-border); border-radius: var(--radius-md); font-size: var(--text-sm); background: var(--c-bg); color: var(--c-text); box-sizing: border-box; }
+.ann-editor__textarea { resize: vertical; font-family: monospace; min-height: 120px; }
+.ann-editor__actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+.ann-admin-card { border: 1px solid var(--c-table-border); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); margin-bottom: var(--space-3); }
+.ann-admin-card__header { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.ann-admin-card__title { font-weight: 600; color: var(--c-heading); }
+.ann-admin-card__meta { font-size: var(--text-xs); color: var(--c-text-muted); }
+.ann-admin-card__body { font-size: var(--text-sm); white-space: pre-wrap; font-family: monospace; background: var(--c-table-border); padding: var(--space-3); border-radius: var(--radius-md); margin-bottom: var(--space-3); overflow-x: auto; }
+.ann-admin-card__actions { display: flex; gap: var(--space-3); }
 
 .admin-team-table {
   width: 100%;

--- a/src/types/announcement.ts
+++ b/src/types/announcement.ts
@@ -1,0 +1,10 @@
+import type { Timestamp } from 'firebase/firestore';
+
+export interface Announcement {
+  id: string;
+  year: number;
+  title: string;
+  body: string;
+  postedAt: Timestamp;
+  lastEditedAt: Timestamp | null;
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,9 @@
+import { marked, Renderer } from 'marked';
+
+const renderer = new Renderer();
+renderer.image = () => '';              // no images
+marked.use({ renderer, gfm: true, breaks: true });
+
+export function renderMarkdown(raw: string): string {
+  return marked.parse(raw) as string;
+}

--- a/src/views/home.ts
+++ b/src/views/home.ts
@@ -1,5 +1,3 @@
 export function homeView(): string {
-  return `
-    <home-standings></home-standings>
-    <season-calendar></season-calendar>`;
+  return `<home-announcements></home-announcements><home-standings></home-standings><season-calendar></season-calendar>`;
 }


### PR DESCRIPTION
## Summary

Adds a Firestore-backed announcement system with a homepage display component and a full admin CRUD interface.

- **`Announcement` type** — `id`, `year`, `title`, `body`, `postedAt`, `lastEditedAt`
- **`<home-announcements>` Custom Element** — renders current-year announcements as styled cards with Markdown body; silently renders nothing when there are no announcements or on error
- **`src/utils/markdown.ts`** — thin `marked` wrapper with image-stripping renderer
- **Repository** — `getAnnouncements`, `createAnnouncement`, `updateAnnouncement`, `deleteAnnouncement` against the `/announcements` Firestore collection
- **Service** — wraps repository with per-year cache; invalidates on any write
- **Admin panel** — new "Announcements" tab with post/edit/delete UI; delete uses the existing confirm dialog
- **Firestore rules** — `/announcements/{docId}`: public read, admin-only write
- **CSS** — `ann-card-*` homepage styles + `ann-editor`/`ann-admin-card-*` admin styles

## Test plan

- [ ] Homepage shows no announcements section when collection is empty
- [ ] Admin: post a new announcement — appears in list and on homepage after refresh
- [ ] Admin: edit an announcement — title/body update, "Edited" date appears
- [ ] Admin: delete an announcement — confirm dialog required; disappears from list and homepage
- [ ] `npm run deploy:rules` — Firestore rules deploy cleanly
- [ ] `npm run build` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)