### PR TITLE
feat(home): show only most recent announcement; fix pre-existing TS errors

### DIFF
--- a/src/components/home-announcements.ts
+++ b/src/components/home-announcements.ts
@@ -23,44 +23,42 @@ class HomeAnnouncements extends HTMLElement {
 
   private async _load(year: number): Promise<void> {
     const result = await scoreService.getAnnouncements(year);
-    if (!result.success || result.data.length === 0) {
+    const latest = result.success ? result.data[0] : undefined;
+    if (!latest) {
       this.innerHTML = '';
       return;
     }
-    this._render(result.data);
+    this._render(latest);
   }
 
-  private _render(announcements: Announcement[]): void {
+  private _render(ann: Announcement): void {
     const fmt = (ts: import('firebase/firestore').Timestamp) =>
       ts.toDate().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
 
-    const cards = announcements.map((ann) => {
-      const escapedTitle = ann.title
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
+    const escapedTitle = ann.title
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 
-      const editedSpan = ann.lastEditedAt
-        ? `<span class="ann-card__edited">Edited ${fmt(ann.lastEditedAt)}</span>`
-        : '';
-
-      return `
-        <article class="ann-card">
-          <header class="ann-card__header">
-            <h3 class="ann-card__title">${escapedTitle}</h3>
-            <div class="ann-card__meta">
-              <span>Posted ${fmt(ann.postedAt)}</span>
-              ${editedSpan}
-            </div>
-          </header>
-          <div class="ann-card__body">${renderMarkdown(ann.body)}</div>
-        </article>`;
-    }).join('');
+    const editedSpan = ann.lastEditedAt
+      ? `<span class="ann-card__edited">Edited ${fmt(ann.lastEditedAt)}</span>`
+      : '';
 
     this.innerHTML = `
       <section class="ann-section">
         <h2 class="ann-section__heading">Announcements</h2>
-        <div class="ann-card-list">${cards}</div>
+        <div class="ann-card-list">
+          <article class="ann-card">
+            <header class="ann-card__header">
+              <h3 class="ann-card__title">${escapedTitle}</h3>
+              <div class="ann-card__meta">
+                <span>Posted ${fmt(ann.postedAt)}</span>
+                ${editedSpan}
+              </div>
+            </header>
+            <div class="ann-card__body">${renderMarkdown(ann.body)}</div>
+          </article>
+        </div>
       </section>`;
   }
 }

--- a/src/components/season-calendar.ts
+++ b/src/components/season-calendar.ts
@@ -65,6 +65,7 @@ class SeasonCalendar extends HTMLElement {
       const key = String(event.week);
       if (!(key in overrides)) return event;
       const override = overrides[key];
+      if (override === undefined) return event;
       if (override === null) {
         return { ...event, type: 'cancelled' as const };
       }

--- a/src/services/score-service.test.ts
+++ b/src/services/score-service.test.ts
@@ -563,7 +563,7 @@ function makePublishRepo(opts: {
     getSeason: async () => success(opts.season ?? null),
     publishWeek: async (_y, wr, su) => {
       opts.onPublish?.(wr, su as object);
-      return success(undefined);
+      return success({ weekResult: wr, seasonUpdates: su });
     },
   };
   return stub as unknown as ScoreRepository;
@@ -770,7 +770,7 @@ describe('publishWeek — cache invalidation', () => {
       getEntries: async () => success([entry]),
       getTeams: async () => success([makeTeamFromEntry(entry)]),
       getSeason: async () => { getSeasonCallCount++; return success(season); },
-      publishWeek: async () => success(undefined),
+      publishWeek: async (_y, wr, su) => success({ weekResult: wr, seasonUpdates: su }),
     };
     const svc = new ScoreService(repo as unknown as ScoreRepository);
 

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -12,7 +12,7 @@
 
 export interface ScheduleEvent {
   date: Date;
-  type: 'practice' | 'shoot' | 'holiday';
+  type: 'practice' | 'shoot' | 'holiday' | 'cancelled';
   week?: number; // 1-based, shoot days only
 }
 


### PR DESCRIPTION
## Summary

- **Homepage** now displays only the single most recent announcement (`result.data[0]`) instead of all year-scoped announcements for the current year; admin panel is unaffected
- **`ScheduleEvent` type** (`schedule.ts`): added `'cancelled'` to the union — was missing despite `season-calendar.ts` always relying on it for admin-overridden weeks
- **`season-calendar.ts`**: added `undefined` guard before the `null` check in `_applyOverrides` to satisfy `noUncheckedIndexedAccess`
- **`score-service.test.ts`**: fixed two `publishWeek` stubs that returned `success(undefined)` to return `success({ weekResult, seasonUpdates })`, matching the repository interface

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run build` — passes
- [x] `npm test` — 153/153 passing
- [ ] Homepage with 0 announcements → renders nothing
- [ ] Homepage with 1 announcement → that announcement appears
- [ ] Homepage with 2+ announcements → only the newest appears; admin panel still shows all

🤖 Generated with [Claude Code](https://claude.com/claude-code)