### PR TITLE
fix(downloads): center yardage table and fix print race condition

### DIFF
--- a/src/components/scoresheet-generator.ts
+++ b/src/components/scoresheet-generator.ts
@@ -249,6 +249,7 @@ class ScoresheetGenerator extends HTMLElement {
 
     this.querySelector('.scoresheet-print-btn')
       ?.addEventListener('click', () => {
+        document.body.classList.remove('print-yardage');
         document.body.classList.add('print-scoresheets');
         window.print();
         window.addEventListener('afterprint', () => {

--- a/src/components/yardage-table.ts
+++ b/src/components/yardage-table.ts
@@ -5,6 +5,7 @@ class YardageTable extends HTMLElement {
     this.innerHTML = this._render();
     this.querySelector('.yardage-print-btn')
       ?.addEventListener('click', () => {
+        document.body.classList.remove('print-scoresheets');
         document.body.classList.add('print-yardage');
         window.print();
         window.addEventListener('afterprint', () => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1800,13 +1800,14 @@ input[type="text"].ap-roster-name:focus {
   text-transform: uppercase;
   padding: var(--space-2) var(--space-3);
   font-size: 0.75rem;
-  text-align: left;
+  text-align: center;
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 }
 .yardage-table td {
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--c-table-border);
+  text-align: center;
 }
 
 .downloads-section-heading {


### PR DESCRIPTION
## Summary

- Center-align `th` and `td` cells in `.yardage-table` (headers were explicitly `text-align: left`; cells had no declaration)
- Fix blank scoresheets on first print after yardage table: if `afterprint` fires late, both `print-yardage` and `print-scoresheets` could coexist on `<body>`, causing the CSS isolation rules to hide both sections simultaneously → blank print preview. Each button now removes the other class before adding its own.

## Test plan

- [ ] Downloads page: yardage table headers and data cells are centered
- [ ] Print Yardage Table → close → Print All Scoresheets: scoresheets render correctly on first attempt
- [ ] Print All Scoresheets → close → Print Yardage Table: yardage table renders correctly on first attempt
- [ ] Print preview (Ctrl+P) on Downloads page: center alignment present in print layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)