### PR TITLE
chore: ignore .vite cache and update branching workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ public/assets/
 # Vite build output
 dist/
 
+# Vite dev cache
+.vite/
+
 # Optional npm cache directory
 .npm
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ npm run build     # production build
 
 ## Contribution Guidelines
 
-- Branch from `dev`; open PRs against `dev` (`main` = production)
-- No direct commits to `main` or `dev`
+- Branch from `main`; open PRs against `main`
+- No direct commits to `main`
 - Commit message format: `type(scope): description` (feat, fix, docs, refactor, chore, ci)
 - Business logic belongs in `src/services/scoring-engine.ts` — never reinlined elsewhere
 - Schedule logic belongs in `src/utils/schedule.ts` — same rule


### PR DESCRIPTION
## Summary

- Add `.vite/` to `.gitignore` — Vite's pre-bundling cache is machine-specific and auto-regenerated on every `npm run dev`; it should never be tracked
- Update `CONTRIBUTING.md` to reflect direct-to-main branching now that the temporary `dev` overhaul branch is retired

## Test Plan

- [ ] `git status` shows clean working tree after `npm run dev`
- [ ] Branching instructions in `CONTRIBUTING.md` are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)