### PR TITLE
fix: sanitize marked output with DOMPurify to prevent stored XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "dompurify": "^3.3.2",
         "firebase": "^12.9.0",
         "marked": "^17.0.4"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "firebase-admin": "^13.0.0",
         "firebase-tools": "^15.0.0",
         "terser": "^5.44.1",
@@ -3248,6 +3250,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3324,6 +3336,13 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -5332,6 +5351,18 @@
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "firebase-admin": "^13.0.0",
     "firebase-tools": "^15.0.0",
     "terser": "^5.44.1",
@@ -31,6 +32,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "dompurify": "^3.3.2",
     "firebase": "^12.9.0",
     "marked": "^17.0.4"
   }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { marked, Renderer } from 'marked';
 
 const renderer = new Renderer();
@@ -5,5 +6,5 @@ renderer.image = () => '';              // no images
 marked.use({ renderer, gfm: true, breaks: true });
 
 export function renderMarkdown(raw: string): string {
-  return marked.parse(raw) as string;
+  return DOMPurify.sanitize(marked.parse(raw) as string);
 }


### PR DESCRIPTION
## Summary

- Announcement body content rendered via `marked` was injected into the DOM via `innerHTML` without sanitization
- The site's CSP does not block inline event handlers, making payloads like `<img src=x onerror="...">` fully exploitable by a malicious or compromised admin account
- Wraps `renderMarkdown()` return value with `DOMPurify.sanitize()`, covering all current and future callers
- Adds `dompurify` to `dependencies` and `@types/dompurify` to `devDependencies`

## Test plan

- [x] `npm run typecheck` — passes with no new type errors
- [x] `npm run test` — 170/170 tests pass
- [ ] Manual smoke test: create announcement with `<img src=x onerror="alert('XSS')">` and verify no alert fires on home page
- [ ] Manual smoke test: verify normal markdown (bold, links, line breaks) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)