### PR TITLE
feat(ux): skeleton loading shimmer for all async components

### DIFF
--- a/.specs/constitution.md
+++ b/.specs/constitution.md
@@ -1,7 +1,7 @@
 # Project Constitution: citl.club (Central Illinois Trap League)
 
-**Version:** 1.2.0
-**Last Updated:** 2026-03-10
+**Version:** 1.3.0
+**Last Updated:** 2026-03-13
 **Scope:** All development on the citl-static project
 **Review Frequency:** Quarterly (next review: 2026-05-27)
 
@@ -205,7 +205,49 @@ See [.specs/technical/firestore-schema.md](.specs/technical/firestore-schema.md)
 - [.prompts/core/security/security-principles.md](.prompts/core/security/security-principles.md)
 - [.prompts/platforms/firebase/firebase-security.md](.prompts/platforms/firebase/firebase-security.md)
 
-### III.3 Performance Standards
+### III.3 UX Loading States
+
+**Requirement**: Every async Web Component that fetches Firestore data MUST show a shimmer skeleton placeholder while loading — never plain text such as `<p>Loading…</p>`.
+
+**How to implement**:
+
+1. At the top of any async load method (before the first `await`), set `this.innerHTML` to skeleton HTML built from the utility classes in `src/styles/main.css`.
+2. Write the skeleton as a `private static` method on the component class so it can be called in both `connectedCallback` (initial render) and any year/week-change handler.
+3. Shape the skeleton to match the real content — use the same number of rows, columns, and approximate widths. Exact pixel perfection is not required; structural resemblance is.
+
+**Available CSS utilities** (`src/styles/main.css`):
+
+| Class | Purpose |
+|-------|---------|
+| `.skeleton` | Base shimmer block (apply to every placeholder element) |
+| `.skeleton--sm` | 0.75 rem tall — body text / meta lines |
+| `.skeleton--md` | 1.1 rem tall — normal text rows |
+| `.skeleton--lg` | 1.75 rem tall — headings / table rows |
+| `.skeleton--xl` | 2.5 rem tall — buttons / large controls |
+| `.skeleton-group` | `flex-direction: column` container with consistent gap |
+| `.skeleton-row` | `flex-direction: row` container for inline placeholder groups |
+
+**Example pattern** (inline in `connectedCallback`):
+
+```ts
+connectedCallback(): void {
+  this.innerHTML = MyComponent._skeleton();
+  void this._load();
+}
+
+private static _skeleton(): string {
+  return `
+    <div class="skeleton-group" style="padding-top:var(--space-2)">
+      <span class="skeleton skeleton--lg" style="width:50%"></span>
+      <span class="skeleton skeleton--md" style="width:90%"></span>
+      <span class="skeleton skeleton--md" style="width:75%"></span>
+    </div>`;
+}
+```
+
+**Dark mode**: The shimmer uses `--c-surface` and `--c-border` design tokens, which switch automatically — no additional dark-mode work is needed.
+
+### III.4 Performance Standards
 
 **Targets** (measurable at production launch):
 - Page Load Time: <3 seconds (p95)
@@ -230,7 +272,7 @@ See [.specs/technical/firestore-schema.md](.specs/technical/firestore-schema.md)
 - [.prompts/core/operations/monitoring-principles.md](.prompts/core/operations/monitoring-principles.md)
 - [.prompts/platforms/firebase/firebase-finops.md](.prompts/platforms/firebase/firebase-finops.md)
 
-### III.4 Code Quality Standards
+### III.5 Code Quality Standards
 
 **Language standards (TypeScript):**
 - Always `const` / `let`. Never `var`.
@@ -306,6 +348,7 @@ See [.specs/technical/firestore-schema.md](.specs/technical/firestore-schema.md)
 ❌  God modules > 500 lines                  Split by responsibility
 ❌  Circular imports between modules         Dependencies flow inward only
 ❌  Components importing from firebase/      Go through services → repositories
+❌  <p>Loading…</p> in async components      Use .skeleton shimmer classes (§III.3)
 ```
 
 **Process anti-patterns**:
@@ -494,6 +537,7 @@ If guidance is insufficient for a task:
 - ✅ `onSnapshot()` cleanup stored (if using real-time listeners)
 - ✅ No secrets in code (`.env` only)
 - ✅ Conventional commit format
+- ✅ Any new async Web Component loading state uses `.skeleton` classes — no `<p>Loading…</p>` (§III.3)
 
 **Mandatory before every PR**:
 - ✅ PR description includes Summary, Changes, Testing, Guidance References
@@ -508,3 +552,4 @@ If guidance is insufficient for a task:
 - 1.0.1 (2026-02-28): Minor metrics update
 - 1.1.0 (2026-03-01): TypeScript migration complete; CSS design system; dark mode; inline SVGs
 - 1.2.0 (2026-03-10): Removed phase references throughout; constitution is now state-based and timing-agnostic
+- 1.3.0 (2026-03-13): Added §III.3 UX Loading States — skeleton shimmer placeholders required for all async Web Components; added corresponding forbidden pattern and commit checklist item

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ npm run build     # production build
 - Full TypeScript: `allowJs: false`, `strict: true` — no `any`, no type suppressions
 - Every pure function exported from `scoring-engine.ts` or `schedule.ts` needs a unit test
 - Layer order: components → modules → services → repositories (never reverse)
+- Async Web Components must show shimmer skeleton placeholders while loading — never `<p>Loading…</p>` (see §III.3 of the constitution for the pattern and CSS utilities)
 
 ## Further Reading
 

--- a/src/components/home-announcements.ts
+++ b/src/components/home-announcements.ts
@@ -22,6 +22,13 @@ class HomeAnnouncements extends HTMLElement {
   }
 
   private async _load(year: number): Promise<void> {
+    this.innerHTML = `
+      <div class="skeleton-group" style="padding:var(--space-4) 0">
+        <span class="skeleton skeleton--lg" style="width:55%"></span>
+        <span class="skeleton skeleton--sm" style="width:90%"></span>
+        <span class="skeleton skeleton--sm" style="width:80%"></span>
+        <span class="skeleton skeleton--sm" style="width:65%"></span>
+      </div>`;
     const result = await scoreService.getAnnouncements(year);
     const latest = result.success ? result.data[0] : undefined;
     if (!latest) {

--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -31,7 +31,7 @@ class HomeStandings extends HTMLElement {
           <label for="hs-week">Week</label>
           <select id="hs-week"><option value="season">Season</option></select>
         </div>
-        <div id="hs-table"><p>Loading&hellip;</p></div>
+        <div id="hs-table">${HomeStandings._standingsSkeleton()}</div>
       </div>`;
 
     this.querySelector<HTMLSelectElement>('#hs-year')!.addEventListener('change', (e) => {
@@ -75,7 +75,7 @@ class HomeStandings extends HTMLElement {
   }
 
   private async _loadYear(year: number): Promise<void> {
-    this.querySelector('#hs-table')!.innerHTML = '<p>Loading&hellip;</p>';
+    this.querySelector('#hs-table')!.innerHTML = HomeStandings._standingsSkeleton();
 
     const [weeksResult, seasonResult, teamsResult] = await Promise.all([
       scoreService.getAllWeekResults(year),
@@ -221,6 +221,24 @@ class HomeStandings extends HTMLElement {
       <h3 class="accolades-section__heading">Accolades</h3>
       <ul class="accolades-list">${items}</ul>
     </div>`;
+  }
+
+  private static _standingsSkeleton(): string {
+    const dataRow = `
+      <div class="skeleton-row">
+        <span class="skeleton skeleton--lg" style="width:36px;flex-shrink:0"></span>
+        <span class="skeleton skeleton--lg" style="flex:2"></span>
+        <span class="skeleton skeleton--lg" style="flex:1"></span>
+        <span class="skeleton skeleton--lg" style="flex:1"></span>
+        <span class="skeleton skeleton--lg" style="flex:1"></span>
+        <span class="skeleton skeleton--lg" style="flex:1"></span>
+        <span class="skeleton skeleton--lg" style="flex:1"></span>
+      </div>`;
+    return `
+      <div class="skeleton-group" style="padding-top:var(--space-2)">
+        <span class="skeleton skeleton--sm" style="width:45%"></span>
+        ${dataRow.repeat(7)}
+      </div>`;
   }
 
   private _buildTable(

--- a/src/components/scoresheet-generator.ts
+++ b/src/components/scoresheet-generator.ts
@@ -27,7 +27,7 @@ class ScoresheetGenerator extends HTMLElement {
   private _dateMap = new Map<number, Date | null>();
 
   connectedCallback(): void {
-    this.innerHTML = `<p>Loading&hellip;</p>`;
+    this.innerHTML = ScoresheetGenerator._fullSkeleton();
     void this._load();
   }
 
@@ -70,7 +70,7 @@ class ScoresheetGenerator extends HTMLElement {
     this._dateMap = this._buildDateMap(year, season?.weekDateOverrides ?? {});
 
     const container = this.querySelector<HTMLElement>('#sg-cards');
-    if (container) container.innerHTML = `<p>Loading&hellip;</p>`;
+    if (container) container.innerHTML = ScoresheetGenerator._cardsSkeleton();
 
     await this._fetchYearData();
 
@@ -259,6 +259,30 @@ class ScoresheetGenerator extends HTMLElement {
           document.body.classList.remove('print-scoresheets');
         }, { once: true });
       });
+  }
+
+  private static _cardsSkeleton(): string {
+    const card = `
+      <div class="skeleton-group" style="flex:1;min-width:200px">
+        <span class="skeleton skeleton--lg" style="width:70%"></span>
+        <span class="skeleton skeleton--md" style="width:90%"></span>
+        <span class="skeleton skeleton--md" style="width:80%"></span>
+        <span class="skeleton skeleton--md" style="width:85%"></span>
+        <span class="skeleton skeleton--md" style="width:75%"></span>
+        <span class="skeleton skeleton--md" style="width:90%"></span>
+      </div>`;
+    return `<div class="skeleton-row" style="align-items:flex-start;gap:var(--space-4);flex-wrap:wrap">${card.repeat(3)}</div>`;
+  }
+
+  private static _fullSkeleton(): string {
+    return `
+      <div class="skeleton-group" style="padding-top:var(--space-2)">
+        <div class="skeleton-row">
+          <span class="skeleton skeleton--lg" style="width:120px"></span>
+          <span class="skeleton skeleton--lg" style="width:120px"></span>
+        </div>
+        ${ScoresheetGenerator._cardsSkeleton()}
+      </div>`;
   }
 }
 

--- a/src/components/season-calendar.ts
+++ b/src/components/season-calendar.ts
@@ -33,7 +33,7 @@ const DAY_HEADERS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 class SeasonCalendar extends HTMLElement {
   async connectedCallback(): Promise<void> {
-    this.innerHTML = `<p>Loading&hellip;</p>`;
+    this.innerHTML = SeasonCalendar._calendarSkeleton();
 
     const year = new Date().getFullYear();
 
@@ -166,6 +166,21 @@ class SeasonCalendar extends HTMLElement {
       .join('');
 
     return `<div class="calendar-legend">${itemsHtml}</div>`;
+  }
+
+  private static _calendarSkeleton(): string {
+    const dayCell = `<span class="skeleton skeleton--md" style="flex:1"></span>`;
+    const weekRow = `<div class="skeleton-row">${dayCell.repeat(7)}</div>`;
+    const month = `
+      <span class="skeleton skeleton--lg" style="width:160px"></span>
+      <div class="skeleton-row">${dayCell.repeat(7)}</div>
+      ${weekRow.repeat(5)}`;
+    return `
+      <div class="skeleton-group" style="padding-top:var(--space-2)">
+        ${month}
+        <div style="height:var(--space-4)"></div>
+        ${month}
+      </div>`;
   }
 }
 

--- a/src/components/season-scorecards.ts
+++ b/src/components/season-scorecards.ts
@@ -51,7 +51,7 @@ class SeasonScorecards extends HTMLElement {
           <label for="sc-year">Season</label>
           <select id="sc-year"></select>
         </div>
-        <div id="sc-content"><p>Loading&hellip;</p></div>
+        <div id="sc-content">${SeasonScorecards._scorecardsSkeletonHTML()}</div>
       </div>`;
 
     this.querySelector<HTMLSelectElement>('#sc-year')!.addEventListener('change', (e) => {
@@ -102,8 +102,16 @@ class SeasonScorecards extends HTMLElement {
     }
   }
 
+  private static _scorecardsSkeletonHTML(): string {
+    const pill = `<span class="skeleton skeleton--xl" style="width:100%;border-radius:var(--radius-md)"></span>`;
+    return `
+      <div class="skeleton-group" style="padding-top:var(--space-2)">
+        ${pill.repeat(5)}
+      </div>`;
+  }
+
   private async _loadYear(year: number): Promise<void> {
-    this.querySelector('#sc-content')!.innerHTML = '<p>Loading&hellip;</p>';
+    this.querySelector('#sc-content')!.innerHTML = SeasonScorecards._scorecardsSkeletonHTML();
 
     const [teamsResult, weeksResult, prior1TeamsResult, prior2TeamsResult, prior1WeeksResult] = await Promise.all([
       scoreService.getTeams(year),

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1697,6 +1697,35 @@ input[type="text"].ap-roster-name:focus {
   opacity: 1;
 }
 
+/* ── Skeleton loading shimmer ─────────────────────────────────────────────── */
+@keyframes skeleton-shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position:  200% 0; }
+}
+
+.skeleton {
+  display: block;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--c-surface) 25%,
+    var(--c-border)  50%,
+    var(--c-surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+}
+
+/* Height modifiers */
+.skeleton--sm  { height: 0.75rem; }
+.skeleton--md  { height: 1.1rem;  }
+.skeleton--lg  { height: 1.75rem; }
+.skeleton--xl  { height: 2.5rem;  }
+
+/* Layout helpers */
+.skeleton-group { display: flex; flex-direction: column; gap: var(--space-2); }
+.skeleton-row   { display: flex; gap: var(--space-2); align-items: center; }
+
 /* "Add Team" button below the table */
 .admin-add-team-btn {
   margin-top: var(--space-2);


### PR DESCRIPTION
## Summary

- Replaces every `<p>Loading…</p>` placeholder across five async Web Components with appropriately shaped shimmer skeleton screens
- Adds a `@keyframes skeleton-shimmer` animation and `.skeleton` utility classes to `main.css`; shimmer uses `--c-surface`/`--c-border` design tokens so dark mode is handled automatically
- Updates constitution to v1.3.0 with §III.3 UX Loading States as a mandatory standard, adds the anti-pattern to §IV.2, and adds a pre-commit checklist item

## Components updated

| Component | Skeleton shape | Loading spots |
|-----------|---------------|---------------|
| `home-standings` | Subtitle line + 7-column table rows | Initial + year change |
| `season-scorecards` | 5 full-width pill buttons | Initial + year change |
| `season-calendar` | 2-month grid (day headers + 5 week rows each) | Initial load |
| `scoresheet-generator` | Controls bar + 3 scorecard columns | Initial + year change |
| `home-announcements` | Single card (title + 3 body lines) | Initial load (previously silent) |

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Open home page, throttle network to Slow 3G in DevTools → each section shows a shimmer block (not plain text) before data loads
- [ ] Shimmer disappears and real content renders correctly once Firestore data arrives
- [ ] Toggle dark mode — shimmer adapts automatically (no flash, correct colors)
- [ ] Open `/scorecards` → year-change shows collapsible pill skeletons
- [ ] Open `/scoresheets` → year-change shows card skeletons in `#sg-cards`
- [ ] `home-announcements` shows card skeleton briefly before resolving (or renders empty if no announcements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)