### PR TITLE
chore: add LICENSE file with all rights reserved notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Copyright (c) 2026 Tyler DeKnecht. All Rights Reserved.
+
+This source code is made available for transparency and reference purposes only.
+No permission is granted to copy, modify, merge, publish, distribute, sublicense,
+or sell copies of this software or any portion of it.


### PR DESCRIPTION
## Summary
- Adds an explicit `LICENSE` file to the repo root before making the repository public
- Reserves all rights — no permission granted to copy, modify, distribute, or sublicense
- Makes the proprietary intent unambiguous to anyone browsing the repo

## Test plan
- [x] Confirm `LICENSE` appears in the repo root
- [x] Confirm copyright year (2026) and name (Tyler DeKnecht) are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)