### PR TITLE
feat: site-wide notification banner

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,12 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /config/{doc} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.auth.token.admin == true;
+    }
+
     match /announcements/{docId} {
       allow read: if true;
       allow write: if request.auth != null

--- a/src/components/admin-panel.ts
+++ b/src/components/admin-panel.ts
@@ -58,6 +58,7 @@ class AdminPanel extends HTMLElement {
   private _weekHasScores = false;
   /** null = not editing; else = announcement id being edited */
   private _editingAnnouncementId: string | null = null;
+  private _bannerLoaded = false;
 
   // ── Roster modal state ────────────────────────────────────────────────────
   private _rosterDialog: HTMLDialogElement | null = null;
@@ -138,7 +139,24 @@ class AdminPanel extends HTMLElement {
 
         <!-- ── Announcements Panel ── -->
         <div id="ap-panel-announcements" class="admin-tab-content admin-tab-panel--hidden">
-          <div class="admin-header"><h2>Announcements</h2></div>
+          <h3>Site Banner</h3>
+          <p class="admin-publish-note">
+            Displays a message to all visitors below the navigation bar. Clear the field and save to remove it.
+          </p>
+          <div class="banner-editor ann-editor">
+            <div class="ann-editor__field">
+              <label for="banner-msg">Banner message</label>
+              <textarea id="banner-msg" class="ann-editor__textarea" rows="3"
+                placeholder="e.g. Tonight&#39;s shoot is cancelled due to severe weather."></textarea>
+            </div>
+            <div class="ann-editor__actions">
+              <button id="banner-save-btn" class="btn-primary">Save Banner</button>
+              <button id="banner-clear-btn" class="btn-secondary">Clear Banner</button>
+            </div>
+            <p id="banner-status" class="admin-status" aria-live="polite"></p>
+          </div>
+          <hr class="admin-divider">
+          <h3>Announcements</h3>
           <div class="ann-editor">
             <div class="ann-editor__field">
               <label for="ann-title">Title</label>
@@ -186,6 +204,10 @@ class AdminPanel extends HTMLElement {
     this.querySelector('#ap-save')!.addEventListener('click', () => void this._saveEntry());
     this.querySelector('#ap-publish')!.addEventListener('click', () => void this._publishWeek());
 
+    // Banner listeners
+    this.querySelector('#banner-save-btn')!.addEventListener('click', () => void this._saveBanner());
+    this.querySelector('#banner-clear-btn')!.addEventListener('click', () => void this._clearBanner());
+
     // Announcements listeners
     this.querySelector('#ann-post-btn')!.addEventListener('click', () => {
       if (this._editingAnnouncementId) void this._saveEditAnnouncement();
@@ -212,7 +234,10 @@ class AdminPanel extends HTMLElement {
       const el = this.querySelector(`#${id}`);
       if (el) el.classList.toggle('admin-tab-panel--hidden', name !== tab);
     }
-    if (tab === 'announcements') void this._loadAnnouncementsTab();
+    if (tab === 'announcements') {
+      void this._loadBannerTab();
+      void this._loadAnnouncementsTab();
+    }
   }
 
   // ── Data loading ─────────────────────────────────────────────────────────
@@ -1341,6 +1366,38 @@ class AdminPanel extends HTMLElement {
 
   private _annYear(): number {
     return parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
+  }
+
+  private _setBannerStatus(msg: string, type: '' | 'success' | 'error'): void {
+    const el = this.querySelector('#banner-status');
+    if (!el) return;
+    el.textContent = msg;
+    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
+  }
+
+  private async _loadBannerTab(): Promise<void> {
+    if (this._bannerLoaded) return;
+    const result = await scoreService.getBanner();
+    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
+    const ta = this.querySelector<HTMLTextAreaElement>('#banner-msg');
+    if (ta) ta.value = result.data ?? '';
+    this._bannerLoaded = true;
+  }
+
+  private async _saveBanner(): Promise<void> {
+    const message = this.querySelector<HTMLTextAreaElement>('#banner-msg')!.value.trim();
+    this._setBannerStatus('Saving…', '');
+    const result = await scoreService.setBanner(message || null);
+    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
+    this._bannerLoaded = false;
+    showToast('success', message ? 'Banner updated.' : 'Banner cleared.');
+    this._setBannerStatus('', '');
+  }
+
+  private async _clearBanner(): Promise<void> {
+    const ta = this.querySelector<HTMLTextAreaElement>('#banner-msg');
+    if (ta) ta.value = '';
+    await this._saveBanner();
   }
 
   private _setAnnStatus(message: string, type: '' | 'success' | 'error'): void {

--- a/src/components/site-banner.ts
+++ b/src/components/site-banner.ts
@@ -1,0 +1,44 @@
+/**
+ * site-banner — Custom Element
+ *
+ * Displays a site-wide notification banner below the nav when a message is set.
+ * Hidden entirely (no layout impact) when no message is configured.
+ * Message is always rendered via textContent to prevent XSS.
+ */
+
+import { db } from '@/firebase-config';
+import { createRepositoryFactory } from '@/repositories/repository-factory';
+import { ScoreService } from '@/services/score-service';
+
+const factory = createRepositoryFactory({ db });
+const scoreService = new ScoreService(factory.getScoreRepository());
+
+class SiteBanner extends HTMLElement {
+  connectedCallback(): void {
+    void this._load();
+  }
+
+  private async _load(): Promise<void> {
+    const result = await scoreService.getBanner();
+    const message = result.success ? result.data : null;
+    if (!message) { this.hidden = true; return; }
+    this.hidden = false;
+    this.innerHTML = `
+      <div class="site-banner__inner">
+        <span class="site-banner__icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+            fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0
+              1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+        </span>
+        <p class="site-banner__text"></p>
+      </div>`;
+    this.querySelector('.site-banner__text')!.textContent = message;
+  }
+}
+
+customElements.define('site-banner', SiteBanner);

--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,8 @@
 
   </nav>
 
+  <site-banner></site-banner>
+
   <!-- Router renders view content here -->
   <main class="main" id="main-content"></main>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@
 import './styles/main.css';
 import './components/home-standings';
 import './components/home-announcements';
+import './components/site-banner';
 import './components/season-scorecards';
 import './components/admin-panel';
 import './components/scoresheet-generator';

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -502,4 +502,25 @@ export class ScoreRepository {
       return failure(`Failed to delete announcement: ${(err as Error).message}`, 'FIRESTORE_ERROR');
     }
   }
+
+  async getBanner(): Promise<Result<string | null>> {
+    try {
+      const ref = doc(this.db, 'config', 'banner');
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return success(null);
+      const data = snap.data() as { message?: string | null };
+      return success(data.message ?? null);
+    } catch (err) {
+      return failure(`Failed to load banner: ${(err as Error).message}`, 'FIRESTORE_ERROR');
+    }
+  }
+
+  async setBanner(message: string | null): Promise<Result<void>> {
+    try {
+      await setDoc(doc(this.db, 'config', 'banner'), { message: message ?? null });
+      return success(undefined);
+    } catch (err) {
+      return failure(`Failed to save banner: ${(err as Error).message}`, 'FIRESTORE_ERROR');
+    }
+  }
 }

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -596,6 +596,18 @@ export class ScoreService {
   }
 
   // -------------------------------------------------------------------------
+  // Banner
+  // -------------------------------------------------------------------------
+
+  async getBanner(): Promise<Result<string | null>> {
+    return this.repository.getBanner();
+  }
+
+  async setBanner(message: string | null): Promise<Result<void>> {
+    return this.repository.setBanner(message?.trim() || null);
+  }
+
+  // -------------------------------------------------------------------------
   // Cache control
   // -------------------------------------------------------------------------
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -507,6 +507,45 @@ a:hover { color: var(--c-link-hover); }
 }
 
 /* ============================================================
+   Site Banner
+   ============================================================ */
+
+site-banner {
+  display: block;
+  position: sticky;
+  top: var(--nav-height);
+  z-index: 8;
+}
+
+site-banner[hidden] {
+  display: none !important;
+}
+
+.site-banner__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-6);
+  background: var(--c-status-warning-bg);
+  border-left: 4px solid var(--c-accent);
+  border-bottom: 1px solid var(--c-border);
+}
+
+.site-banner__icon {
+  display: flex;
+  flex-shrink: 0;
+  color: var(--c-accent);
+}
+
+.site-banner__text {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--c-status-warning);
+  line-height: 1.5;
+}
+
+/* ============================================================
    Main content area
    ============================================================ */
 
@@ -1025,6 +1064,8 @@ a:hover { color: var(--c-link-hover); }
 .ap-date-badge             { font-size: var(--text-xs); background: var(--c-accent);
                              color: #fff; padding: 2px 6px; border-radius: var(--radius-sm); }
 .ap-date-badge--cancelled  { background: #dc2626; }
+
+.admin-divider { border: none; border-top: 1px solid var(--c-border); margin: var(--space-6) 0; }
 
 /* ============================================================
    Map container (About view)


### PR DESCRIPTION
## Summary

- Admins can broadcast urgent messages (weather cancellations, closures, etc.) to all visitors via a sticky amber banner below the nav
- Banner is a singleton Firestore document (`config/banner`) — one message at a time, no date binding
- Users cannot dismiss it; it disappears only when an admin clears it

## Changes

- **`score-repository.ts`** — `getBanner` / `setBanner` using `getDoc` / `setDoc` on `config/banner`
- **`score-service.ts`** — thin wrappers with no caching (always fresh) and empty-string → `null` coercion
- **`site-banner.ts`** — new custom element; sticky below nav, message set via `textContent` (XSS-safe), `hidden` attribute when no message
- **`admin-panel.ts`** — Site Banner section at top of Announcements tab with Save/Clear buttons
- **`main.css`** — amber warning palette, sticky positioning, icon alignment fix
- **`index.html`** / **`main.ts`** — wire in the new element
- **`firestore.rules`** — public read / admin write for `config` collection

## Test plan

- [x] `npx firebase deploy --only firestore:rules` to push updated security rules
- [x] Sign in as admin → Announcements tab → enter a message → Save Banner → banner appears on all pages below nav
- [x] Scroll down — banner stays stuck below the nav
- [x] Admin → Clear Banner → banner disappears
- [x] Enter `<script>alert(1)</script>` as message — must render as literal text (no XSS)
- [x] Toggle dark mode with banner visible — amber palette renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)