### PR TITLE
security: tighten Firestore admin delete permissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,38 +1,44 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /config/{doc} {
-      allow read: if true;
-      allow write: if request.auth != null
-                   && request.auth.token.admin == true;
+
+    function isAdmin() {
+      return request.auth != null && request.auth.token.admin == true;
     }
 
+    // Banner config — set via setDoc (create or overwrite). Never deleted.
+    match /config/{doc} {
+      allow read: if true;
+      allow create, update: if isAdmin();
+    }
+
+    // Announcements — full lifecycle: create, edit, and delete are all portal actions.
     match /announcements/{docId} {
       allow read: if true;
-      allow write: if request.auth != null
-                   && request.auth.token.admin == true;
+      allow create, update, delete: if isAdmin();
     }
 
     match /seasons/{year} {
+      // Season documents — created/updated, never deleted (permanent record).
       allow read: if true;
-      allow write: if request.auth != null
-                   && request.auth.token.admin == true;
+      allow create, update: if isAdmin();
 
       match /teams/{teamId} {
+        // Teams — created, edited, and deleted via portal.
         allow read: if true;
-        allow write: if request.auth != null
-                     && request.auth.token.admin == true;
+        allow create, update, delete: if isAdmin();
       }
 
       match /weeks/{weekNumber} {
+        // Published week results — created/updated by publish action. Never deleted.
         allow read: if true;
-        allow write: if request.auth != null
-                     && request.auth.token.admin == true;
+        allow create, update: if isAdmin();
       }
 
       match /entries/{entryId} {
-        allow read, write: if request.auth != null
-                           && request.auth.token.admin == true;
+        // Draft entries — created/updated by score entry; deleted only during team deletion cascade.
+        allow read: if isAdmin();
+        allow create, update, delete: if isAdmin();
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replaces broad `allow write` rules with granular `allow create, update` or `allow create, update, delete` per collection
- Admin role can now only delete documents where the portal explicitly exposes a delete action: **announcements** and **teams** (with entry cascade)
- Seasons, published week results (`weeks`), and config documents are no longer deletable by any client-side Firebase operation — even by an authenticated admin
- Extracts a reusable `isAdmin()` helper function to reduce duplication across rules

## Permission changes

| Collection | Before | After |
|---|---|---|
| `config/{doc}` | create + update + ~~delete~~ | create + update |
| `announcements/{docId}` | create + update + delete | create + update + delete |
| `seasons/{year}` | create + update + ~~delete~~ | create + update |
| `seasons/{year}/teams/{teamId}` | create + update + delete | create + update + delete |
| `seasons/{year}/weeks/{weekNumber}` | create + update + ~~delete~~ | create + update |
| `seasons/{year}/entries/{entryId}` | create + update + delete | create + update + delete |

## Test plan

- [ ] Verify allowed deletes still work: delete an announcement and delete a team via the admin portal
- [ ] Verify blocked deletes fail with `permission-denied`: attempt `deleteDoc` on a season, week result, or config document from the browser console while signed in as admin
- [ ] Regression: publish a week, save a score entry, set/clear banner, create a team — all should succeed

> Rules already deployed to `citl-baed2` via `firebase deploy --only firestore:rules` and confirmed compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)