### PR TITLE
feat: introduce three-role RBAC (owner/admin/user)

### DIFF
--- a/.claude/agents/speckit.md
+++ b/.claude/agents/speckit.md
@@ -76,6 +76,7 @@ These are non-negotiable for every feature:
 - **File size**: Target <500 lines per file; hard limit 750 lines
 - **Dependency direction**: `components → modules → services → repositories` (never reverse)
 - **Cost discipline**: Firebase Blaze plan (§VI.1); usage targets Spark-equivalent quotas. New Cloud Functions need a documented justification — they should solve a problem the client SDK + rules cannot.
+- **Cloud Functions deploy ops**: When a feature adds a new Cloud Function (especially a 2nd-gen callable), the spec **must** flag the post-deploy operational steps from the `firebase-deploy-runbook` global skill: lowercased Cloud Run service name, one-time `roles/run.invoker` binding for `allUsers` after first deploy, and (for a brand-new project) the GCF source bucket IAM fix. These add ~10 minutes to the first deploy and must be in the implementation plan, not discovered at deploy time.
 - **TypeScript strict**: No implicit `any`; explicit return types; `noUncheckedIndexedAccess: true`
 - **Imports**: Use `@/` absolute path alias, never relative paths across layers
 - **Security**: Admin writes enforced by Firestore rules, not client-side checks alone

--- a/.claude/agents/speckit.md
+++ b/.claude/agents/speckit.md
@@ -75,7 +75,7 @@ These are non-negotiable for every feature:
 - **Loading states**: New async Web Components must use `.skeleton` shimmer classes (§III.3)
 - **File size**: Target <500 lines per file; hard limit 750 lines
 - **Dependency direction**: `components → modules → services → repositories` (never reverse)
-- **Free tier**: Firebase Spark plan only — no Cloud Functions, no paid features
+- **Cost discipline**: Firebase Blaze plan (§VI.1); usage targets Spark-equivalent quotas. New Cloud Functions need a documented justification — they should solve a problem the client SDK + rules cannot.
 - **TypeScript strict**: No implicit `any`; explicit return types; `noUncheckedIndexedAccess: true`
 - **Imports**: Use `@/` absolute path alias, never relative paths across layers
 - **Security**: Admin writes enforced by Firestore rules, not client-side checks alone

--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,27 @@ VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 # Environment
 NODE_ENV=development
 
+# App Check (production / staging only)
+# reCAPTCHA Enterprise site key registered for citl.club domains.
+# Leave unset for emulator-only local dev — the App Check init is skipped
+# when VITE_USE_EMULATOR=true.
+VITE_APPCHECK_SITE_KEY=
+
+# Local emulator suite
+# `npm run dev` sets this automatically; do not set it for production builds.
+# When true, Auth, Firestore, and Functions SDKs connect to:
+#   auth      127.0.0.1:9099
+#   firestore 127.0.0.1:8080
+#   functions 127.0.0.1:5001
+# App Check init is also skipped in emulator mode.
+# VITE_USE_EMULATOR=true
+
 # Instructions:
 # 1. Copy this file: cp .env.example .env
 # 2. Go to https://console.firebase.google.com
 # 3. Select the "citl-baed2" project
 # 4. Go to Project Settings (gear icon) > General > Your apps
 # 5. Copy the config values and replace the placeholders above
+# 6. (production deploys) Register a reCAPTCHA Enterprise site key in
+#    the Firebase console > App Check, paste the key into
+#    VITE_APPCHECK_SITE_KEY above.

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ NODE_ENV=development
 # reCAPTCHA Enterprise site key registered for citl.club domains.
 # Leave unset for emulator-only local dev — the App Check init is skipped
 # when VITE_USE_EMULATOR=true.
-VITE_APPCHECK_SITE_KEY=
+VITE_RECAPTCHA_ENTERPRISE_SITE_KEY=
 
 # Local emulator suite
 # `npm run dev` sets this automatically; do not set it for production builds.
@@ -36,4 +36,4 @@ VITE_APPCHECK_SITE_KEY=
 # 5. Copy the config values and replace the placeholders above
 # 6. (production deploys) Register a reCAPTCHA Enterprise site key in
 #    the Firebase console > App Check, paste the key into
-#    VITE_APPCHECK_SITE_KEY above.
+#    VITE_RECAPTCHA_ENTERPRISE_SITE_KEY above.

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ dist/
 .claude/settings.local.json
 .claude/user-*
 .claude/.history
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # But commit shared project commands and agents
 !.claude/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ firebase-debug.log
 service-account.json
 *-service-account.json
 *-firebase-adminsdk-*.json
+.secrets/
+
+# Firebase emulator data
+.emulator-data/
 
 # Logs
 logs

--- a/.prompts/meta/architectural-decision-log.md
+++ b/.prompts/meta/architectural-decision-log.md
@@ -444,6 +444,107 @@ modern OS preference APIs being widely available.
 
 ---
 
+### ADR-009: Adopt Blaze + Multi-User RBAC (Security Phase 1 → Phase 2)
+
+**Date**: 2026-05-03
+**Status**: Accepted
+**Domains Affected**: Security · Cost · Platform · UI · Testing
+
+**Context**
+
+The single `admin: true` boolean custom claim that gated the legacy
+admin portal made it hard to grant access to multiple league
+volunteers without giving every one of them the keys to the kingdom.
+Sub-admins (score keepers, content managers) needed a path to perform
+content writes without being able to grant or revoke access. The
+constitution's stated cost posture (Spark only, no Cloud Functions)
+also drifted from reality: Blaze had been enabled on the project to
+unlock the runtime needed for safe role-write semantics.
+
+**Decision**
+
+Replace the boolean claim with a three-role system
+(`role: 'owner' | 'admin' | 'user'`). The custom claim is the
+rules-engine source of truth (Firestore rules read
+`request.auth.token.role`); a `users/{uid}` Firestore mirror is the
+admin-UI source of truth; an append-only `audit/` collection tracks
+every role change. The `setUserRole` Cloud Function is the sole writer
+of the role claim — it validates input with zod, enforces a
+last-owner guard, rate-limits at 20 calls/hour/owner, and orders the
+auth claim write *before* the queued Firestore writes inside one TX
+so a partial failure fails closed for revocations (see feature spec
+§VI Design Decisions for the full failure-mode analysis). An
+`onUserCreate` auth trigger seeds users/{uid} on first sign-in. A CLI
+(`scripts/set-role.js`) provides bootstrap (first owner) and
+recovery (lockout) paths; day-to-day promote/demote happens through
+an in-app role dropdown rendered for owner only on the Admin Portal
+Users panel.
+
+This advances the **Security domain from Phase 1 to Phase 2** (App
+Check + custom-claim RBAC) per the architectural-evolution-strategy.
+
+**Rationale**
+
+- **Privilege separation**: admins do content; only owner changes
+  trust boundaries. The legacy `admin: true` couldn't represent this.
+- **Security-first ordering**: claim-first inside the TX guarantees
+  fail-closed on revocations even if the second-system write fails —
+  see feature spec §VI for the trade-table.
+- **Server-authoritative writes**: all role mutations go through the
+  callable (or the Admin-SDK CLI for bootstrap). Clients can never
+  write the `role` field — Firestore rules deny it explicitly.
+- **Audit trail**: every role change writes an audit entry with
+  actor, target, from-role, to-role, timestamp. The audit collection
+  is owner-readable only; no client can write it.
+- **Test coverage**: 44 rules-unit-testing cases (the full
+  {owner, admin, user, anon} matrix on every protected collection)
+  + 15 Cloud Function unit cases against the local emulator.
+
+**Alternatives Considered**
+
+- **Stay on Spark, extend the CLI to handle three roles**: rejected
+  because it forces all role writes through a CLI that operators run
+  on their dev machines, with no rate-limiting, no in-app UX, and no
+  end-state path to a self-service admin UI.
+- **TX-first ordering** (set claim *after* the TX commits): rejected
+  because a failed claim write after a successful TX leaves the
+  user with stale privileges (mirror says new role, claim still
+  old) — fail-open on revocation. Would require a scheduled
+  reconciliation job to be production-safe.
+- **Defer the in-app dropdown to v2, ship CLI-only v1**: rejected
+  after user feedback — production-ready end state should not depend
+  on operators running a script for routine role changes.
+
+**Consequences**
+
+- **Enables**:
+  - Granular access for league volunteers (admins) without
+    full owner privileges
+  - Full audit trail of every role change
+  - Cloud Functions runtime for any future server-side privileged
+    operations (only with documented justification per §VI.1)
+  - Emulator-first local dev workflow — `npm run dev` boots the
+    auth+firestore+functions emulators and connects Vite via
+    `VITE_USE_EMULATOR=true`, eliminating accidental writes to
+    production from localhost
+- **Constrains**:
+  - `firestore.rules`, `setUserRole.ts`, `onUserCreate.ts`, and
+    `scripts/set-role.js` are all part of the security-critical
+    surface — changes require running the rules + function test
+    suites and ideally an `@reviewer` pass
+  - Cloud Functions are now a deployable surface; CI must include
+    `firebase deploy --only functions` (see updated
+    `npm run deploy`)
+  - Constitution §VI.1 requires Blaze budget alerts and per-function
+    justification documentation
+  - `admin-panel.ts` is now a known constitution-§II.3 violation
+    (1781 lines); follow-up task tracked to refactor into per-tab
+    modules and integrate `<admin-users-panel>` as a 4th tab
+
+**Review Date**: 2026-08-03
+
+---
+
 ## How AI Agents Should Use This Log
 
 1. **Before implementing a new feature**: Check if a relevant decision exists that constrains

--- a/.specs/constitution.md
+++ b/.specs/constitution.md
@@ -1,9 +1,9 @@
 # Project Constitution: citl.club (Central Illinois Trap League)
 
-**Version:** 1.4.0
-**Last Updated:** 2026-04-12
+**Version:** 1.5.0
+**Last Updated:** 2026-05-03
 **Scope:** All development on the citl-static project
-**Review Frequency:** Quarterly (next review: 2026-05-27)
+**Review Frequency:** Quarterly (next review: 2026-08-03)
 
 ---
 
@@ -62,18 +62,18 @@ Project-specific strategic frameworks remain in `.prompts/meta/`.
 
 ### II.1 Current Architectural State
 
-**Last Updated**: 2026-03-10
-**Last Architecture Review**: 2026-03-10
+**Last Updated**: 2026-05-03
+**Last Architecture Review**: 2026-05-03
 
 | Domain | Current State | Status |
 |--------|---------------|--------|
-| **UI Components** | 3 Web Components (`home-standings`, `season-scorecards`, `admin-panel`) | Live |
-| **Security** | Firebase Auth (Google) + Firestore rules; custom claim `admin: true` | Complete |
-| **Data** | Firestore drives home page and scorecards; JSON scorecard files are permanent static assets per §II.5 | Live |
-| **Testing** | Vitest unit tests for scoring engine, score service, schedule utils | Active |
-| **Deployment** | GitHub Actions CI/CD (push to `main` → Firebase Hosting + Firestore rules) | Active |
+| **UI Components** | 4 Web Components (`home-standings`, `season-scorecards`, `admin-panel`, `admin-users-panel`) | Live |
+| **Security** | Phase 2: Firebase Auth (Google) + Firestore rules + App Check + custom-claim RBAC (`role: 'owner' \| 'admin' \| 'user'`); Cloud Functions are sole writer of role claim + mirror | Complete |
+| **Data** | Firestore drives home page, scorecards, RBAC user mirror, audit log; JSON scorecard files are permanent static assets per §II.5 | Live |
+| **Testing** | Vitest unit tests for scoring engine, score service, schedule utils; rules-unit-testing matrix (44 cases); function unit tests (15 cases) | Active |
+| **Deployment** | GitHub Actions CI/CD (push to `main` → Firebase Hosting + Firestore rules + Functions) | Active |
 | **Monitoring** | Manual Firebase console checks | Active |
-| **Cost** | Firebase Spark free tier | Near 0% usage |
+| **Cost** | Firebase Blaze (pay-as-you-go); usage discipline targets Spark-equivalent quotas | Near 0% usage |
 | **Platform** | 2 platforms (Firebase + GitHub) | Maintain at 2 |
 
 **Key Metrics** (as of 2026-03-10):
@@ -84,7 +84,7 @@ Project-specific strategic frameworks remain in `.prompts/meta/`.
 - **Types**: 4 (`score`, `shooter`, `season`, `scorecard`)
 - **Data files**: 7 JSON scorecard seasons (2019–2025)
 - **Team Size**: 1 developer
-- **Firebase Usage**: Hosting configured (DNS not yet cutover); Firestore live; Spark free tier usage <5%
+- **Firebase Usage**: Hosting configured (DNS not yet cutover); Firestore live; Cloud Functions deployed (RBAC role-writer + auth trigger); Blaze plan, near-zero spend
 
 **TypeScript**: All source files are `.ts`; `allowJs: false`; `strict: true`; `noUncheckedIndexedAccess: true`.
 
@@ -245,9 +245,9 @@ private static _skeleton(): string {
 - First Contentful Paint (FCP): <1.5 seconds (p95)
 - JS bundle: <250 kB gzipped (currently ~34 kB gzipped ✅)
 
-**Firebase Quota Constraints** (Spark free tier):
-| Resource | Daily Limit | Alert Threshold (70%) |
-|----------|------------|----------------------|
+**Firebase Quota Constraints** (Blaze, with Spark-equivalent discipline — see §VI.1):
+| Resource | Daily target ceiling | Alert Threshold (70%) |
+|----------|---------------------|----------------------|
 | Firestore reads | 50,000 | 35,000 |
 | Firestore writes | 20,000 | 14,000 |
 | Hosting transfer | 360 MB | 252 MB |
@@ -304,11 +304,13 @@ private static _skeleton(): string {
 - **Type checking**: `tsconfig.json` with `strict: true`, `allowJs: false`, `noUncheckedIndexedAccess: true` — full strict type checking; `src/vite-env.d.ts` types `ImportMetaEnv` for all VITE_* vars
 
 **Backend / Platform**:
-- **Platform**: Firebase (`citl` project, Spark plan)
+- **Platform**: Firebase (`citl-baed2` project, Blaze plan with Spark-equivalent usage discipline per §VI.1)
   - Firestore (NoSQL, `us-central1` region, production mode)
   - Hosting (SPA rewrite, security headers, cache rules)
-  - Auth (Google, admin-only)
-- **SDK**: `firebase` npm package (installed; imported as ES modules)
+  - Auth (Google, role-based custom claims)
+  - Cloud Functions (TypeScript, Node 22, us-central1 — RBAC role-writer + auth trigger)
+  - App Check (reCAPTCHA Enterprise, enforced in prod, relaxed under FUNCTIONS_EMULATOR)
+- **SDK**: `firebase` npm package (installed; imported as ES modules); `firebase-admin` + `firebase-functions` in `functions/` package
 
 **Development**:
 - **Version Control**: Git + GitHub
@@ -400,22 +402,36 @@ If guidance is insufficient for a task:
 
 ## VI. Cost Constraints
 
-### VI.1 Firebase Free Tier Limits (Spark Plan)
+### VI.1 Firebase Blaze Plan with Spark-Equivalent Discipline
 
-| Resource | Daily Limit | Alert at 70% |
-|----------|------------|--------------|
+CITL is on Blaze (pay-as-you-go) but operates with usage discipline that
+targets the former Spark free-tier quotas. The plan was upgraded as part
+of the multi-user RBAC feature (002-multi-user-rbac, 2026-05-03) to
+unlock Cloud Functions, which the RBAC role-writer pattern requires.
+
+| Resource | Daily target ceiling | Alert at 70% |
+|----------|---------------------|--------------|
 | Firestore reads | 50,000 | 35,000 |
 | Firestore writes | 20,000 | 14,000 |
 | Firestore deletes | 20,000 | 14,000 |
 | Hosting storage | 10 GB total | — |
 | Hosting transfer | 360 MB/day | 252 MB |
 | Authentication | Unlimited | — |
-| Cloud Functions | Not available (Spark plan) | — |
+| Cloud Functions invocations | 2,000,000/month | 1,400,000/month |
+| Cloud Functions GB-seconds | 400,000/month | 280,000/month |
 
 **Hard constraints**:
-- MUST stay within free tier indefinitely (CITL is a hobby league — no budget for paid tier)
-- MUST implement caching before hitting 70% of any limit
-- Cloud Functions require upgrading to Blaze — requires explicit decision + approval
+- MUST stay within target ceilings above; spend should round to ~$0/mo at
+  CITL's traffic volume. CITL is a hobby league with no operational
+  budget — Blaze is enabled to unlock the Functions runtime, NOT to fund
+  free-spending architecture.
+- MUST implement caching before hitting 70% of any read/write limit.
+- New Cloud Functions require justification documented in this section
+  or a feature spec — they should solve a specific problem (e.g.
+  privileged writes, atomic cross-system operations) that the client
+  SDK + Firestore rules cannot satisfy alone.
+- Set a Blaze budget alert at $5/mo as a safety net; investigate any
+  spend above $1/mo immediately.
 
 
 ### VI.2 Cost Optimization

--- a/.specs/features/002-multi-user-rbac/bootstrap.md
+++ b/.specs/features/002-multi-user-rbac/bootstrap.md
@@ -1,0 +1,193 @@
+# Owner Bootstrap Runbook
+
+**One-time procedure** to grant the first `owner` role on a Firebase Auth
+user in CITL. After this runs, role management can happen via the
+`scripts/set-role.js` CLI (owner-only) or, in v2, via the Admin Portal
+dropdown.
+
+You should only run the bootstrap once, as part of initial RBAC rollout
+or if every owner is locked out and you need to recover.
+
+CITL uses **gcloud Application Default Credentials (ADC)** — no
+service-account key download required. This is the same mechanism
+[scripts/grant-admin.js](../../../scripts/grant-admin.js) uses today,
+extended to handle the three-role model.
+
+---
+
+## Prerequisites
+
+1. The target user has **signed in to CITL at least once** via Google.
+   The `onUserCreate` trigger must have fired for their UID — otherwise
+   there's no Auth record to attach a claim to and no `users/{uid}` doc
+   to update.
+2. `gcloud` CLI installed and authenticated to your Google account:
+   ```bash
+   gcloud auth login
+   gcloud auth application-default login
+   gcloud config set project citl-baed2
+   ```
+3. Your Google account has the **Firebase Authentication Admin** role on
+   the `citl-baed2` GCP project (IAM → grant if missing).
+4. Node 24+ and npm available (matches repo `engines`).
+5. Repo cloned and `npm install` complete.
+
+---
+
+## First-time owner promotion
+
+Once and only once, after RBAC ships:
+
+```bash
+# Find the target UID
+node scripts/set-role.js list
+
+# Output looks like:
+# uid                                 email                  role
+# AbCdEfGhIj1234567890                you@example.com        user
+# ...
+
+# Promote yourself to owner
+node scripts/set-role.js set you@example.com owner
+
+# Output:
+# ─── set-role ──────────────────────────────────────
+# project   : citl-baed2
+# target    : you@example.com (uid: AbCd...)
+# from role : user
+# to role   : owner
+# ───────────────────────────────────────────────────
+# ✓ set custom claim role=owner
+# ✓ updated users/AbCd.../role to owner + roleChangedAt=...
+# ✓ wrote audit/{auto} (actorUid: cli)
+# ───────────────────────────────────────────────────
+# Sign out and back in for the new claim to take effect.
+```
+
+The script prints a clear summary; if `DRY_RUN=1` is set it prints what
+it *would* do without writing.
+
+After the script exits, **sign out of CITL and sign back in**. The Admin
+nav link should appear and the Users tab in the admin panel should now
+list every seeded user.
+
+---
+
+## Day-to-day role management
+
+Once at least one owner exists, role changes happen via the same CLI:
+
+```bash
+# Promote a teammate to admin
+node scripts/set-role.js set teammate@example.com admin
+
+# Demote (alias for `set <email> user`)
+node scripts/set-role.js revoke teammate@example.com
+
+# Inspect everyone
+node scripts/set-role.js list
+
+# Try a destructive change without committing it
+DRY_RUN=1 node scripts/set-role.js set teammate@example.com owner
+```
+
+Every CLI write is also logged to the `audit/` collection with
+`actorUid: 'cli'`, so the audit trail mirrors what the in-app callable
+would produce.
+
+The CLI enforces the same **last-owner guard** as the
+`setUserRole` callable: it refuses to demote the only `owner`. If you're
+the only owner and the script blocks you from changing yourself, that's
+the safety net working — promote a second owner first.
+
+---
+
+## Verifying
+
+1. **Claim set** — sign out and in, then in browser devtools:
+   ```js
+   firebase.auth().currentUser.getIdTokenResult(true).then(r => console.log(r.claims))
+   // { role: 'owner', ... }
+   ```
+
+2. **Mirror doc updated** — Firebase Console → Firestore →
+   `users/<uid>` → confirm `role: "owner"` and `roleChangedAt` set.
+
+3. **Audit entry written** — Firebase Console → Firestore → `audit` →
+   newest doc shows `{ actorUid: 'cli', targetUid, fromRole, toRole,
+   at }`.
+
+4. **Admin nav link** — sign in to citl.club; the Admin link should
+   appear in the dropdown for owner+admin roles only.
+
+---
+
+## Running against the emulator
+
+For local development the same script works with the emulator — no GCP
+auth needed.
+
+```bash
+# Terminal 1: start emulators
+firebase emulators:start --only auth,firestore,functions
+
+# Terminal 2: sign in once via http://localhost:3000 to seed users/{uid}
+
+# Terminal 3: copy your emulator UID from http://localhost:4000/auth, then:
+FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 \
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+GCLOUD_PROJECT=citl-baed2 \
+node scripts/set-role.js set you@example.com owner
+
+# Sign out + in in the browser; admin nav appears.
+```
+
+Emulator data persists across restarts if started with
+`--export-on-exit=.emulator-data --import=.emulator-data`. Add to
+`.gitignore` (already covered by `.secrets/` if you put it there).
+
+---
+
+## Recovery — every owner locked out
+
+If the only owner has lost access (forgotten Google password, account
+deleted, etc.) and no other owner exists, you can re-bootstrap via the
+same script — gcloud ADC credentials are tied to **your Google account's
+IAM permissions**, not to the in-app user.
+
+1. Confirm your Google account still has Firebase Authentication Admin
+   on the GCP project.
+2. Run `gcloud auth application-default login` if your ADC has expired.
+3. `node scripts/set-role.js set <recovery-email> owner`.
+4. Audit entry shows `actorUid: 'cli'` — review against any expected
+   activity.
+
+---
+
+## When **not** to use this script
+
+- Day-to-day role changes by an owner who already has access — once v2
+  ships the in-app dropdown, prefer that path. v1 ships read-only, so
+  the CLI is the only path until then.
+- Granting roles to accounts that haven't signed in yet — they have no
+  Firebase Auth record, so the script will fail at `getUserByEmail`. Ask
+  them to sign in once first.
+- Bypassing the rate limit deliberately — the CLI uses Admin SDK and
+  bypasses the callable's 20/hr cap intentionally, but every CLI write
+  shows up in `audit/` for review. Don't use it to mass-promote.
+
+---
+
+## Related
+
+- [scripts/set-role.js](../../../scripts/set-role.js) — the script itself
+- [functions/src/setUserRole.ts](../../../functions/src/setUserRole.ts)
+  — the in-app callable (mirrors this script's safety logic)
+- [.specs/features/002-multi-user-rbac/spec.md](./spec.md) — feature
+  spec
+- [.specs/features/002-multi-user-rbac/tasks.md](./tasks.md) — task
+  breakdown
+- Reference implementation:
+  [`~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/bootstrap.md`](~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/bootstrap.md)
+  (uses SA key download instead of gcloud ADC — citl uses the cleaner
+  ADC path)

--- a/.specs/features/002-multi-user-rbac/bootstrap.md
+++ b/.specs/features/002-multi-user-rbac/bootstrap.md
@@ -1,17 +1,24 @@
-# Owner Bootstrap Runbook
+# Owner Bootstrap & Recovery Runbook
 
-**One-time procedure** to grant the first `owner` role on a Firebase Auth
-user in CITL. After this runs, role management can happen via the
-`scripts/set-role.js` CLI (owner-only) or, in v2, via the Admin Portal
-dropdown.
+**This runbook covers the two scenarios where role management happens
+*outside* the Admin Portal Users tab:**
 
-You should only run the bootstrap once, as part of initial RBAC rollout
-or if every owner is locked out and you need to recover.
+1. **Bootstrap**: minting the *first* `owner` so the in-app role
+   dropdown becomes usable. Required exactly once during initial
+   rollout — until at least one owner exists, the `setUserRole`
+   callable rejects every caller, so an Admin-SDK-credentialed
+   operator must seed the first owner manually.
+2. **Recovery**: re-minting an `owner` if every existing owner is
+   locked out (forgotten Google password, deleted account, etc.). The
+   in-app last-owner guard prevents accidental self-lockout, but
+   account-level lockout is outside the app's control.
+
+For everything else — promote, demote, list — use the Admin Portal
+**Users tab** in the Admin Panel. The CLI is intentionally not the
+day-to-day path.
 
 CITL uses **gcloud Application Default Credentials (ADC)** — no
-service-account key download required. This is the same mechanism
-[scripts/grant-admin.js](../../../scripts/grant-admin.js) uses today,
-extended to handle the three-role model.
+service-account key download required.
 
 ---
 
@@ -73,32 +80,22 @@ list every seeded user.
 
 ---
 
-## Day-to-day role management
+## Day-to-day role management — use the Admin Portal
 
-Once at least one owner exists, role changes happen via the same CLI:
+Once at least one owner exists, **all subsequent role management goes
+through the Admin Portal Users tab** (Admin Panel → Users → role
+dropdown next to each row). The dropdown invokes the `setUserRole`
+Cloud Function, which enforces the rate limit, last-owner guard, and
+audit trail server-side and is the canonical path.
 
-```bash
-# Promote a teammate to admin
-node scripts/set-role.js set teammate@example.com admin
+**Do not use the CLI for routine promotions or demotions.** It bypasses
+the rate limit (the CLI uses Admin SDK directly, while the dropdown
+goes through the callable) and creates audit entries with
+`actorUid: 'cli'` rather than the actual operator's UID, which makes
+the audit log harder to interpret.
 
-# Demote (alias for `set <email> user`)
-node scripts/set-role.js revoke teammate@example.com
-
-# Inspect everyone
-node scripts/set-role.js list
-
-# Try a destructive change without committing it
-DRY_RUN=1 node scripts/set-role.js set teammate@example.com owner
-```
-
-Every CLI write is also logged to the `audit/` collection with
-`actorUid: 'cli'`, so the audit trail mirrors what the in-app callable
-would produce.
-
-The CLI enforces the same **last-owner guard** as the
-`setUserRole` callable: it refuses to demote the only `owner`. If you're
-the only owner and the script blocks you from changing yourself, that's
-the safety net working — promote a second owner first.
+The CLI's day-to-day subcommands (`set`, `revoke`, `list`) remain in
+place for the rare operator scenarios documented in this runbook.
 
 ---
 
@@ -166,15 +163,19 @@ IAM permissions**, not to the in-app user.
 
 ## When **not** to use this script
 
-- Day-to-day role changes by an owner who already has access — once v2
-  ships the in-app dropdown, prefer that path. v1 ships read-only, so
-  the CLI is the only path until then.
-- Granting roles to accounts that haven't signed in yet — they have no
-  Firebase Auth record, so the script will fail at `getUserByEmail`. Ask
-  them to sign in once first.
-- Bypassing the rate limit deliberately — the CLI uses Admin SDK and
-  bypasses the callable's 20/hr cap intentionally, but every CLI write
-  shows up in `audit/` for review. Don't use it to mass-promote.
+- **Day-to-day role changes by an owner who already has access** — use
+  the Admin Portal Users tab dropdown instead. It runs the same safety
+  machinery server-side, attributes the audit entry to the operator's
+  actual UID rather than `'cli'`, and respects the rate limit.
+- **Granting roles to accounts that haven't signed in yet** — they have
+  no Firebase Auth record, so the script will fail at
+  `getUserByEmail`. Ask them to sign in once first; the
+  `onUserCreate` trigger will seed their `users/{uid}` doc, and then
+  the dropdown can promote them.
+- **Bypassing the rate limit deliberately** — the CLI uses Admin SDK
+  directly and bypasses the callable's 20/hr cap, but every CLI write
+  shows up in `audit/` with `actorUid: 'cli'`. Treat the CLI as a
+  break-glass tool, not a workflow accelerator.
 
 ---
 

--- a/.specs/features/002-multi-user-rbac/spec.md
+++ b/.specs/features/002-multi-user-rbac/spec.md
@@ -21,9 +21,20 @@ audit log. New users get auto-seeded on first sign-in via an
 
 This mirrors the implementation shipped in `~/Developer/salmoncow`,
 adapted to CITL's TypeScript/Vite stack and existing patterns. v1 ships
-a **read-only** Users tab in the existing `<admin-panel>` Custom
-Element; in-app role-change UI is deferred to v2 (the callable exists
-and is tested, just not invoked from the UI).
+a **Users tab** in the existing `<admin-panel>` Custom Element with:
+- a paginated user list visible to owner+admin (read-only fields);
+- an inline **role-change dropdown rendered only for owner**, which
+  invokes the `setUserRole` callable.
+
+The CLI (`scripts/set-role.js`) ships alongside but its end-state
+purpose is **bootstrap + emergency recovery only**, not day-to-day
+role management:
+- **Bootstrap**: the very first owner promotion (no owner exists yet,
+  so the callable cannot authorize anyone) must go through Admin SDK,
+  which is what the script provides.
+- **Recovery**: if all owners are locked out, only an operator with
+  GCP IAM permissions can re-mint an owner via Admin SDK.
+- Day-to-day role management (promote, demote, list) is the dropdown.
 
 **Pre-launch context**: 0 production users today (legacy AWS site still
 serves citl.club). The cutover from `admin: true` → `role` claim is
@@ -34,25 +45,34 @@ free — no backwards-compat shim needed.
 ## User Stories
 
 **Owner** (single seed user, league administrator)
-- As the owner, after the bootstrap CLI sets `role: 'owner'` on my UID,
-  my next ID-token refresh shows the Admin nav link and grants me write
-  access to all admin surfaces.
+- As the owner, after the one-time bootstrap script sets
+  `role: 'owner'` on my UID, my next ID-token refresh shows the Admin
+  nav link and grants me write access to all admin surfaces.
+- As the owner, I open the Admin Portal Users tab and see the full
+  user list with an inline role dropdown next to each row.
+- As the owner, I change another user's role via the dropdown; after
+  the callable returns, the target's next token refresh reflects the
+  new role and the row updates in my view.
 - As the owner, I can read the `audit/` collection to see every role
-  change.
-- As the owner, I can run `npm run set-role list` to see every user
-  + role; `set-role set <email> admin` to promote; `set-role set
-  <email> user` to demote.
-- As the owner, I cannot demote myself if I'm the last owner.
+  change (visible in Firebase Console; not surfaced in the v1 UI).
+- As the owner, I cannot demote myself if I'm the last owner — the
+  callable rejects with `failed-precondition` and the UI surfaces a
+  toast explaining why.
+- As the owner, the CLI (`scripts/set-role.js`) is available for
+  emergency-recovery scenarios (e.g. all owners locked out) but I
+  don't use it day-to-day.
 
 **Admin** (sub-admin, content/score manager)
 - As an admin, I can do everything I can today (team management, score
   entry, announcements, banner) — existing behavior preserved.
-- As an admin, I can see the Users tab read-only (displayName, email,
-  role, lastSignInAt, createdAt).
-- As an admin, I cannot change anyone's role. The `setUserRole` callable
-  rejects non-owner callers with `permission-denied`.
-- As an admin, my role can only be changed by the owner via CLI (v1) or
-  Admin Portal dropdown (v2, deferred).
+- As an admin, I can see the Users tab (displayName, email, role,
+  lastSignInAt, createdAt) but the role dropdown is **not rendered**
+  for me — the column shows the role as plain text.
+- As an admin, I cannot change anyone's role. If I attempt to call
+  `setUserRole` directly (e.g. via devtools), the callable rejects
+  with `permission-denied`.
+- As an admin, my role can only be changed by an owner through the
+  dropdown.
 
 **User** (default)
 - As a new user signing in with Google for the first time, the
@@ -83,9 +103,12 @@ free — no backwards-compat shim needed.
   `role` is `owner` or `admin`.
 - [ ] AC-3: Users tab in admin-panel renders displayName, email,
   photoURL, createdAt, lastSignInAt, role for every user. Paginated at
-  20 per page with cursor.
-- [ ] AC-4: Users tab is read-only in v1 (no role-change controls
-  rendered for any role).
+  20 per page with cursor. Visible to owner + admin.
+- [ ] AC-4: Role-change dropdown is rendered **only for owner**;
+  admin sees role as plain text, no controls. On role-change submit,
+  the dropdown invokes the `setUserRole` callable; success refreshes
+  the row, callable errors (permission-denied, failed-precondition,
+  resource-exhausted, invalid-argument) surface as toast feedback.
 - [ ] AC-5: `setUserRole` callable: non-owner →
   `permission-denied`; invalid role → `invalid-argument`; only-owner
   self-demotion → `failed-precondition`; success → claim, mirror doc,

--- a/.specs/features/002-multi-user-rbac/spec.md
+++ b/.specs/features/002-multi-user-rbac/spec.md
@@ -202,6 +202,112 @@ sequencing" for the full file-by-file breakdown.
 
 ---
 
+## VI. Design Decisions
+
+This section captures non-obvious implementation choices and the
+reasoning behind them. Self-contained so it can be ported to sibling
+projects (e.g. salmoncow) that share the same architecture.
+
+### VI.1 `setUserRole` write ordering — claim-first
+
+**Problem.** A role change is a *cross-system* write that touches:
+
+1. **Firebase Auth** — the custom claim (`request.auth.token.role`) is
+   the rules-engine source of truth.
+2. **Firestore** — three records:
+   - `users/{uid}` mirror (admin-UI source of truth + `roleChangedAt`
+     watermark for forcing target token refresh)
+   - `audit/{auto}` append-only forensics record
+   - `rateLimits/setUserRole/actors/{actorUid}` abuse counter
+
+There is no native atomic transaction across Firebase Auth and
+Firestore. The Auth API call and the Firestore commit happen
+sequentially. If the second of the two fails, the system ends up in a
+partially-applied state. The **ordering** of the two operations
+determines what that partial state looks like — and crucially,
+whether it fails *open* or *closed* for the security boundary.
+
+**Failure-mode analysis.**
+
+| Ordering | If second op fails | Effect on a *demotion* | Effect on a *promotion* |
+|----------|-------------------|------------------------|--------------------------|
+| TX-first, then claim | Claim stale | User keeps old privileges (**fail-open** for revocation) | User can't use new role yet (fail-closed) |
+| **Claim-first, then TX** | Mirror + audit incomplete | User loses access immediately (**fail-closed** for revocation) | User has new role with stale audit row (recoverable) |
+
+**Decision: claim-first.** The auth custom claim is the rules-engine
+source of truth — Firestore rules read `request.auth.token.role`, not
+the mirror. Therefore:
+
+1. **Revocations take effect immediately even if the TX fails.** This
+   is fail-closed for the security-critical path (an admin or owner
+   losing access is a higher-stakes event than a new admin being
+   granted access).
+2. **Mirror + audit drift is recoverable.** The actor's identity and
+   timestamp are still captured by Cloud Audit Logs. The next
+   `setUserRole` call for the same target reads the now-stale mirror,
+   observes the divergence, and re-writes both atomically.
+3. **No additional infrastructure required for production-readiness.**
+   TX-first ordering would need a separate scheduled reconciliation
+   job (claim-vs-mirror drift scanner) to be production-safe; the
+   security gap on revocation is otherwise unmitigated. Claim-first is
+   production-safe as a code-only solution.
+
+**Implementation pattern.** The Auth API call lives *inside* the
+Firestore transaction function but *before* the queued Firestore
+writes:
+
+```ts
+await db.runTransaction(async (tx) => {
+  const userSnap = await tx.get(userRef);
+  if (!userSnap.exists) throw new HttpsError('not-found', ...);
+  const fromRole = userSnap.data().role;
+
+  await assertNotLastOwner(tx, db, fromRole, newRole);   // TX-internal read
+  await checkAndBumpInTransaction(tx, db, actorUid);     // queues counter write
+
+  // Auth API — committed BEFORE the queued Firestore writes.
+  await getAuth().setCustomUserClaims(targetUid, { role: newRole });
+
+  tx.update(userRef, { role: newRole, roleChangedAt: ... });
+  tx.create(auditRef, { actorUid, targetUid, fromRole, toRole, at: ... });
+});
+```
+
+If the claim throws, the queued writes never apply (TX returns before
+commit). If the claim succeeds and the TX commit later fails, the
+claim has already taken effect.
+
+**Trade-offs accepted:**
+
+- **TX retry under contention re-calls `setCustomUserClaims`** with the
+  same payload. Idempotent in practice; minor extra Auth API cost on
+  contention only.
+- **Rate-limit counter doesn't bump on TX-commit failure** even though
+  the claim was set. A small "rate-limit leak" — acceptable because
+  the counter is a soft control against mass-promotion abuse, and the
+  failure path is rare.
+- **Mirror + audit can lag** the actual auth state when a TX commit
+  fails post-claim. Detectable on the next `setUserRole` call; users
+  with a divergent doc will get an audit entry that records the true
+  fromRole on the next role change.
+
+**Alternative considered: TX-first with reconciliation cron.** Run all
+Firestore writes first; call `setCustomUserClaims` after commit. Add
+a scheduled Cloud Function that periodically scans `users/{uid}` for
+claim-vs-mirror divergence and repairs. Rejected because (a) it adds
+production infrastructure and cost, (b) the security gap window
+between TX commit and reconciliation run is unbounded, and (c)
+revocation is the higher-stakes failure mode and should fail closed
+without external dependencies.
+
+**Future hardening (optional).** A `reconcileClaims` scheduled
+function is a defense-in-depth nicety even with claim-first ordering
+— it would catch any drift across either failure direction. With
+claim-first this is forensics; with TX-first it would be a production
+prerequisite.
+
+---
+
 ## Implementation Plan
 
 The full sequenced plan is in [tasks.md](./tasks.md). Operational

--- a/.specs/features/002-multi-user-rbac/spec.md
+++ b/.specs/features/002-multi-user-rbac/spec.md
@@ -1,0 +1,242 @@
+# Feature: Multi-User RBAC (owner / admin / user)
+
+**Feature ID**: 002-multi-user-rbac
+**Created**: 2026-05-03
+**Status**: Approved — implementation in progress
+**Plan of record**: [/Users/ted/.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md](../../../../.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md)
+**Reference implementation**: [`~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/`](~/Developer/salmoncow/.specs/archive/001-multi-user-rbac)
+
+---
+
+## Overview
+
+Replace CITL's single `admin: true` Firebase Auth custom claim with a
+three-role RBAC system (`owner` / `admin` / `user`). Roles are enforced
+via custom claims (primary auth signal in Firestore rules) with a
+`users/{uid}` Firestore mirror as the source of truth for the admin UI.
+Role writes go through a callable Cloud Function (`setUserRole`) that
+enforces rate limits, last-owner protection, and writes an append-only
+audit log. New users get auto-seeded on first sign-in via an
+`onUserCreate` auth trigger.
+
+This mirrors the implementation shipped in `~/Developer/salmoncow`,
+adapted to CITL's TypeScript/Vite stack and existing patterns. v1 ships
+a **read-only** Users tab in the existing `<admin-panel>` Custom
+Element; in-app role-change UI is deferred to v2 (the callable exists
+and is tested, just not invoked from the UI).
+
+**Pre-launch context**: 0 production users today (legacy AWS site still
+serves citl.club). The cutover from `admin: true` → `role` claim is
+free — no backwards-compat shim needed.
+
+---
+
+## User Stories
+
+**Owner** (single seed user, league administrator)
+- As the owner, after the bootstrap CLI sets `role: 'owner'` on my UID,
+  my next ID-token refresh shows the Admin nav link and grants me write
+  access to all admin surfaces.
+- As the owner, I can read the `audit/` collection to see every role
+  change.
+- As the owner, I can run `npm run set-role list` to see every user
+  + role; `set-role set <email> admin` to promote; `set-role set
+  <email> user` to demote.
+- As the owner, I cannot demote myself if I'm the last owner.
+
+**Admin** (sub-admin, content/score manager)
+- As an admin, I can do everything I can today (team management, score
+  entry, announcements, banner) — existing behavior preserved.
+- As an admin, I can see the Users tab read-only (displayName, email,
+  role, lastSignInAt, createdAt).
+- As an admin, I cannot change anyone's role. The `setUserRole` callable
+  rejects non-owner callers with `permission-denied`.
+- As an admin, my role can only be changed by the owner via CLI (v1) or
+  Admin Portal dropdown (v2, deferred).
+
+**User** (default)
+- As a new user signing in with Google for the first time, the
+  `onUserCreate` trigger creates my `users/{uid}` doc with `role:
+  'user'` and sets the matching custom claim.
+- As a user, I can see public pages (home, scorecards, rules, about,
+  downloads). Deep-linking `/#/admin` redirects me to `/`.
+- As a user, attempting to write `users/{myUid}.role` directly via the
+  Firestore SDK is rejected by rules.
+
+**Negative scenarios**
+- Tampered ID token → signature check fails server-side; rules treat as
+  unauthenticated.
+- Compromised admin → can read users, edit content, but cannot elevate
+  to owner (callable rejects) and cannot bypass rules to write the
+  `role` field.
+- Rate-abusing owner → 21st `setUserRole` call within the hour returns
+  `resource-exhausted`.
+
+---
+
+## Acceptance Criteria
+
+**Functional**
+- [ ] AC-1: `onUserCreate` writes `users/{uid}` with `role: 'user'` and
+  sets the matching claim on first sign-in.
+- [ ] AC-2: `/#/admin` redirects to `/` unless current ID-token claim
+  `role` is `owner` or `admin`.
+- [ ] AC-3: Users tab in admin-panel renders displayName, email,
+  photoURL, createdAt, lastSignInAt, role for every user. Paginated at
+  20 per page with cursor.
+- [ ] AC-4: Users tab is read-only in v1 (no role-change controls
+  rendered for any role).
+- [ ] AC-5: `setUserRole` callable: non-owner →
+  `permission-denied`; invalid role → `invalid-argument`; only-owner
+  self-demotion → `failed-precondition`; success → claim, mirror doc,
+  and audit entry written atomically (claim outside TX, others
+  inside).
+- [ ] AC-6: `setUserRole` rate-limited to 20 calls/hour/owner via
+  Firestore counter; 21st returns `resource-exhausted`.
+- [ ] AC-7: Firestore rules reject any direct client write to
+  `users/{uid}.role` regardless of caller role.
+- [ ] AC-8: Existing admin write paths (team management, score entry,
+  announcements, banner) work unchanged for owner+admin under the new
+  rules.
+- [ ] AC-9: `users/{currentUid}` snapshot listener forces token refresh
+  on `roleChangedAt` bump → UI reflects new role without manual
+  re-login.
+- [ ] AC-10: `node scripts/set-role.js set <email> <role>` writes the
+  claim, upserts the mirror, appends an audit entry (actorUid:
+  `'cli'`), enforces last-owner guard, and supports `DRY_RUN=1`.
+
+**Security (critical path — 100% test coverage per §III.1)**
+- [ ] AC-11: Rules unit tests cover {owner, admin, user, anon} ×
+  {users CRUD on self+other, content CRUD, audit read, rateLimits
+  read} × {allow, deny}.
+- [ ] AC-12: Function unit tests cover every branch of `setUserRole`
+  and `onUserCreate`; claim and Firestore doc are always consistent
+  after success.
+- [ ] AC-13: Rules tested in the emulator before every deploy
+  (`firebase deploy --only firestore:rules --dry-run` then live).
+- [ ] AC-14: No service-account keys checked in. Bootstrap uses gcloud
+  ADC. `.secrets/` gitignored.
+
+**Performance & Cost**
+- [ ] AC-15: Users tab uses `limit(20)` + cursor pagination; never
+  full collection scans.
+- [ ] AC-16: Rules use `request.auth.token.role` (token-embedded,
+  zero-read) for all role checks — no `get()` lookups.
+- [ ] AC-17: Worst-case usage stays within constitution §VI.1 daily
+  thresholds (Firestore reads <35k, writes <14k).
+
+**Documentation**
+- [ ] AC-18: Bootstrap runbook at
+  `.specs/features/002-multi-user-rbac/bootstrap.md`.
+- [ ] AC-19: Constitution updated: §II.1 Cost row Spark→Blaze, §II.1
+  Security row Phase 1→Phase 2, §VI.1 Cloud Functions row, version
+  1.4.0 → 1.5.0; decision-log entry appended.
+- [ ] AC-20: PR description follows §V.1 (Summary, Changes, Testing,
+  Guidance References, Constitutional Compliance).
+
+---
+
+## Constitutional Constraints
+
+**Phase transitions triggered**
+- §II.1 **Security**: Phase 1 (Basic Auth + Rules) → Phase 2 (App
+  Check + custom-claim RBAC).
+- §II.1 **Cost**: Spark free tier → Blaze pay-as-you-go (Blaze
+  already enabled — drift correction).
+- §II.1 **Testing**: For RBAC critical-path code, advance to Phase 2
+  Unit Tests (rules + Functions). Broader Phase 2 adoption stays
+  pending its own trigger.
+
+**Quality standards that apply**
+- §III.1 Testing: critical path (auth/authorization) requires 100%
+  coverage. Rules matrix tests + Function unit tests live at unit
+  layer.
+- §III.2 Security: server-side authorization on every protected op;
+  never trust client role state; rules tested in emulator before
+  deploy.
+- §III.3 Performance: rules use `request.auth.token.role` (free); user
+  list paginated.
+- §IV.1 Tech stack: vanilla Custom Elements with TypeScript; Firebase
+  v12.x SDK (current).
+- §IV.2 Forbidden patterns: no client-side filtering, no unbounded
+  reads, no uncleaned `onSnapshot`.
+- §V.1 PR requirements: full body sections.
+
+**Forbidden patterns avoided**
+- ❌ Client-side role checks as security boundary (UI hiding only;
+  server authoritative via rules + callable).
+- ❌ Unbounded user list reads (paginated at 20 with cursor).
+- ❌ Granting clients write to the `role` field (rules deny; Admin SDK
+  is sole writer, called only by the Cloud Function or the CLI).
+
+---
+
+## Architecture Approach
+
+See approved plan §"Architecture overview" and §"Implementation
+sequencing" for the full file-by-file breakdown.
+
+**Layer assignments** (per §II.4):
+
+| Layer | Files |
+|-------|-------|
+| Components | [src/components/admin-panel.ts](../../../src/components/admin-panel.ts) (modify) — add Users tab |
+| Modules | [src/modules/auth.ts](../../../src/modules/auth.ts) (modify), `src/modules/role.ts` (new), [src/modules/navigation.ts](../../../src/modules/navigation.ts) (modify), [src/main.ts](../../../src/main.ts) (modify) |
+| Services | `src/services/admin-user-service.ts` (new) |
+| Repositories | `src/repositories/user-repository.ts` (new), [src/repositories/repository-factory.ts](../../../src/repositories/repository-factory.ts) (extend) |
+| Infrastructure | `src/infrastructure/functions.ts` (new), `src/infrastructure/appcheck.ts` (new) |
+| Server | `functions/src/{setUserRole,onUserCreate,index}.ts`, `functions/src/lib/{validate,rateLimit,lastOwnerGuard}.ts` |
+| Config | [firestore.rules](../../../firestore.rules) (rewrite), `firestore.indexes.json` (new), [firebase.json](../../../firebase.json) (add functions+emulators), `.gitignore` (add `.secrets/`) |
+| Scripts | `scripts/set-role.js` (replaces `grant-admin.js`) |
+| Tests | `tests/rules/*`, `tests/functions/*` |
+
+**Guidance references** (auto-activating skills):
+- `firebase-security` — custom claims, rules helpers, App Check
+- `firebase-best-practices` — callable shape, data modeling
+- `firebase-testing` — rules-unit-testing matrix, emulator
+- `firebase-cost-resilience` — rate limit counter pattern
+- `security-principles` — least privilege, server authoritative
+- `software-architecture` — layering, dependency direction
+- `testing-principles` — pyramid, critical-path coverage
+- `git-conventions` — branch/commit/PR conventions
+
+---
+
+## Implementation Plan
+
+The full sequenced plan is in [tasks.md](./tasks.md). Operational
+runbook for the very first owner promotion is in [bootstrap.md](./bootstrap.md).
+
+The technical plan, decision rationale, and verification protocol are
+in the approved plan-of-record (link at top of this file). This spec
+captures the contract; the plan-of-record captures how to execute it.
+
+---
+
+## Testing Checklist
+
+- [ ] `vitest run` (root) green — existing scoring/schedule tests + new
+  client unit tests.
+- [ ] `firebase emulators:exec --only firestore 'vitest run tests/rules'`
+  green — rules matrix.
+- [ ] `firebase emulators:exec --only auth,firestore,functions 'vitest
+  run tests/functions'` green — Cloud Function unit tests.
+- [ ] Emulator E2E walkthrough (plan §Group 8) — every happy + every
+  failure branch.
+- [ ] Preview-channel E2E walkthrough (plan §Group 10) — same flows
+  against real Firebase.
+- [ ] Quota check post-walkthrough — Firebase console Usage tab within
+  §VI.1 thresholds.
+- [ ] `@reviewer` audit clean.
+
+---
+
+## Out of Scope
+
+- Email/password or non-Google federation (future spec).
+- In-app role-change UI / dropdown (deferred — v2 of this feature).
+- Fine-grained per-feature permissions (e.g. announcements-only admin).
+- Account deletion / GDPR export.
+- Soft-delete of users.
+- Real content schema beyond what's already in CITL — RBAC layer adds
+  no new content collections.

--- a/.specs/features/002-multi-user-rbac/tasks.md
+++ b/.specs/features/002-multi-user-rbac/tasks.md
@@ -143,15 +143,21 @@ acceptance criteria in [spec.md](./spec.md) §"Acceptance Criteria".
 
 ---
 
-## Group 7 — Read-only Users tab
+## Group 7 — Users tab with owner-only role dropdown
 
-**Goal**: owner+admin see who has access; no role-change controls in v1.
-**Commit**: `feat(rbac): add read-only Users tab to admin panel`
+**Goal**: owner+admin see the user list; **owner** can change roles
+inline via a dropdown that calls the `setUserRole` callable. CLI is
+positioned as bootstrap + emergency-recovery only — the dropdown is
+the day-to-day path.
+**Commit**: `feat(rbac): add Users tab with owner-only role-change dropdown`
 **AC**: AC-3, AC-4, AC-15
 
-- [ ] **7.1 (M)** New `src/views/admin-users-tab.ts` — pure HTML factory: table with displayName / email / role / lastSignInAt / createdAt; "Load more" button for cursor pagination; loading/empty/error states matching existing `<admin-panel>` patterns.
-- [ ] **7.2 (M)** New `src/services/admin-user-service.ts` — `listUsers({ pageSize: 20, cursor })` calls `userRepository.listPaginated`; strips fields to the limited set; `setUserRole({ targetUid, role })` calls the `setUserRole` callable (deferred wiring; not invoked from any UI surface in v1).
-- [ ] **7.3 (M)** Modify [src/components/admin-panel.ts:73–80](../../../src/components/admin-panel.ts:73) — add a "Users" tab button alongside Team Management / Score Entry / Announcements. Render `admin-users-tab.ts` content inside.
+- [ ] **7.1 (M)** New `src/views/admin-users-tab.ts` — pure HTML factory: table with displayName / email / role / lastSignInAt / createdAt; "Load more" button for cursor pagination; loading/empty/error states matching existing `<admin-panel>` patterns. The `role` column renders a `<select>` dropdown ONLY when the current user's role === `'owner'`; otherwise plain text.
+- [ ] **7.2 (M)** New `src/services/admin-user-service.ts` — `listUsers({ pageSize: 20, cursor })` calls `userRepository.listPaginated`; strips to the limited field set. `setUserRole({ targetUid, role })` calls the `setUserRole` callable via the infrastructure helper from Group 5.4. Returns a typed `Result<{ fromRole, toRole }>` so the UI can branch on success vs. each error code.
+- [ ] **7.3 (M)** Modify [src/components/admin-panel.ts:73–80](../../../src/components/admin-panel.ts:73) — add a "Users" tab button alongside Team Management / Score Entry / Announcements. Render `admin-users-tab.ts` content inside; wire change events on the dropdown to `admin-user-service.setUserRole`.
+- [ ] **7.4 (M)** Confirmation flow + toast feedback: dropdown change opens a confirm dialog ("Change Alice's role from admin to user?"). On confirm, invoke the callable and show a toast for success or failure. Map callable error codes to user-facing messages: `permission-denied` → "Only the owner can change roles." (shouldn't happen since the dropdown only renders for owner — defense in depth); `failed-precondition` → "Cannot demote the last owner. Promote another user to owner first."; `resource-exhausted` → "Rate limit reached. Please wait before changing more roles."; `invalid-argument` → generic "Invalid role." (also shouldn't happen via the dropdown).
+- [ ] **7.5 (S)** On successful role change, refresh the local row so the new role + new `lastSignInAt` reflect immediately (re-query that single user, or optimistically update).
+- [ ] **7.6 (S)** Emulator smoke: as owner, change another user's role via dropdown → verify auth claim, mirror, audit entry; as admin, dropdown is absent and devtools call to `setUserRole` is rejected. *(Validation gate)*
 - [ ] **7.4 (S)** Wire fetch + pagination in `admin-panel.ts` (mirror existing patterns for the other tabs — no separate controller needed for v1).
 - [ ] **7.5 (S)** Emulator smoke: owner sees list; admin sees same list; user can't reach the page. *(Validation gate)*
 

--- a/.specs/features/002-multi-user-rbac/tasks.md
+++ b/.specs/features/002-multi-user-rbac/tasks.md
@@ -110,12 +110,12 @@ acceptance criteria in [spec.md](./spec.md) §"Acceptance Criteria".
 **AC**: AC-9, AC-15
 
 - [ ] **5.1 (M)** `src/infrastructure/functions.ts` — lazy `getFunctions` + `httpsCallable` helper, emulator-aware via `import.meta.env.VITE_USE_EMULATOR`.
-- [ ] **5.2 (M)** `src/infrastructure/appcheck.ts` — `initializeAppCheck` with reCAPTCHA Enterprise site key from `import.meta.env.VITE_APPCHECK_SITE_KEY`; debug token path for `import.meta.env.DEV`.
+- [ ] **5.2 (M)** `src/infrastructure/appcheck.ts` — `initializeAppCheck` with reCAPTCHA Enterprise site key from `import.meta.env.VITE_RECAPTCHA_ENTERPRISE_SITE_KEY`; debug token path for `import.meta.env.DEV`.
 - [ ] **5.3 (L)** `src/repositories/user-repository.ts` — `findById(uid): Promise<UserDoc | null>`, `listPaginated({ pageSize: 20, cursor }): Promise<{ users: UserDoc[]; nextCursor: DocumentSnapshot | null }>`, `observeSelf(uid, cb): Unsubscribe` (snapshot listener for `roleChangedAt`). Never writes the `role` field. Type `UserDoc` lives in `src/types/user.ts` (also new).
 - [ ] **5.4 (M)** Extend [src/repositories/repository-factory.ts:22](../../../src/repositories/repository-factory.ts:22) — add `getUserRepository()` next to `getScoreRepository()` with the same caching pattern.
 - [ ] **5.5 (M)** `src/modules/role.ts` — exports `Role` type, `getRole(force?: boolean): Promise<Role | null>`, `onRoleChange(cb): Unsubscribe`. Reads `getIdTokenResult().claims.role`; `force=true` triggers `getIdToken(true)`.
 - [ ] **5.6 (S)** Modify [src/firebase-config.ts](../../../src/firebase-config.ts) — initialize App Check after `initializeApp` when not in test env.
-- [ ] **5.7 (S)** `.env.example` — document `VITE_APPCHECK_SITE_KEY`, `VITE_USE_EMULATOR`.
+- [ ] **5.7 (S)** `.env.example` — document `VITE_RECAPTCHA_ENTERPRISE_SITE_KEY`, `VITE_USE_EMULATOR`.
 - [ ] **5.8 (S)** Manual smoke: sign in via emulator → verify `users/{uid}` doc appears, `role.ts` reports `'user'`. *(Validation gate)*
 
 ---

--- a/.specs/features/002-multi-user-rbac/tasks.md
+++ b/.specs/features/002-multi-user-rbac/tasks.md
@@ -1,0 +1,237 @@
+# Task Breakdown: Multi-User RBAC
+
+**Feature**: 002-multi-user-rbac
+**Spec**: [spec.md](./spec.md)
+**Plan of record**: [/Users/ted/.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md](../../../../.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md)
+**Status**: Ready for implementation
+
+Each numbered group below is one prospective commit. Commit only when
+every box is checked and the validation gate passes. AC refs map to
+acceptance criteria in [spec.md](./spec.md) §"Acceptance Criteria".
+
+**Complexity legend**: S = <30min · M = 30min–2h · L = >2h
+
+---
+
+## Group 0 — Spec-Kit artifacts (this directory)
+
+**Goal**: spec, tasks, bootstrap docs in `.specs/features/002-multi-user-rbac/`.
+**Commit**: `docs(rbac): add multi-user RBAC feature spec, tasks, bootstrap`
+**AC**: AC-18
+
+- [x] **0.1 (S)** Create `.specs/features/002-multi-user-rbac/` directory.
+- [x] **0.2 (M)** Write `spec.md` (this file's sibling).
+- [x] **0.3 (M)** Write `tasks.md` (this file).
+- [ ] **0.4 (M)** Write `bootstrap.md` adapted for gcloud ADC (no SA key download).
+
+**Validation**: all three files present; `/check` passes.
+
+---
+
+## Group 1 — Branch + scaffolding
+
+**Goal**: empty-but-valid scaffold for Functions + emulators.
+**Commit**: `chore(rbac): scaffold functions/, firestore indexes, emulator config`
+**AC**: AC-14 (gitignore)
+
+- [ ] **1.1 (S)** Branch `feat/multi-user-rbac` from `main`.
+- [ ] **1.2 (S)** Add `.secrets/` to `.gitignore`.
+- [ ] **1.3 (S)** Create `firestore.indexes.json` with `{"indexes":[],"fieldOverrides":[]}`.
+- [ ] **1.4 (M)** Create `functions/` package: `package.json` (firebase-functions ^5, firebase-admin ^13, zod ^3, vitest ^4, typescript ^5), `tsconfig.json`, `src/index.ts` (empty exports).
+- [ ] **1.5 (M)** Extend [firebase.json](../../../firebase.json) with `functions` block (source: `functions`, runtime: `nodejs20`) and `emulators` block (`auth:9099`, `firestore:8080`, `functions:5001`, `ui:4000`).
+- [ ] **1.6 (S)** Verify `.firebaserc` project alias `citl-baed2`.
+- [ ] **1.7 (S)** `firebase emulators:start --only auth,firestore,functions` boots clean. *(Validation gate)*
+
+---
+
+## Group 2 — Rules migration + tests
+
+**Goal**: role-aware rules + full unit-test matrix, replacing `admin: true`.
+**Commit**: `feat(rbac): migrate firestore rules to role-based gating with full test matrix`
+**AC**: AC-7, AC-8, AC-11, AC-13, AC-16
+
+- [ ] **2.1 (S)** Add dev deps at repo root: `@firebase/rules-unit-testing`.
+- [ ] **2.2 (S)** Add scripts: `test:rules`, `test:functions`, `emulators`.
+- [ ] **2.3 (M)** Rewrite [firestore.rules](../../../firestore.rules) per [spec.md](./spec.md) §"Architecture Approach" + plan-of-record §"Firestore rules — full migration":
+  - Helpers: `isSignedIn`, `roleOf`, `isOwner`, `isAdmin`, `isOwnerOrAdmin`, `isSelf`.
+  - `users/{uid}`: read self+owner+admin; create self without role; update self preserving role; no delete.
+  - `audit/{id}`: owner read; no client write.
+  - `rateLimits/{path=**}`: owner read; no client write.
+  - Existing `config`, `announcements`, `seasons/{year}/(teams|weeks|entries)` — all admin-only writes become `isOwnerOrAdmin()`. Public reads preserved.
+- [ ] **2.4 (L)** `tests/rules/users.test.ts` — full {owner, admin, user, anon} × {read self, read other, create with/without role, update non-role, update role (deny all), delete} matrix. ~28 cases.
+- [ ] **2.5 (M)** `tests/rules/seasons.test.ts` — public read; owner+admin write on seasons, teams, weeks, entries. ~8 cases.
+- [ ] **2.6 (S)** `tests/rules/content.test.ts` — public read on `config` + `announcements`; owner+admin write. ~6 cases.
+- [ ] **2.7 (S)** `tests/rules/audit.test.ts` — owner read only; no client writes. ~4 cases.
+- [ ] **2.8 (S)** `tests/rules/rateLimits.test.ts` — owner read only; no client writes. ~4 cases.
+- [ ] **2.9 (S)** `firebase emulators:exec --only firestore 'vitest run tests/rules'` green. *(Validation gate)*
+
+---
+
+## Group 3 — Cloud Functions + tests
+
+**Goal**: `setUserRole` callable + `onUserCreate` trigger with defense-in-depth.
+**Commit**: `feat(rbac): add setUserRole callable and onUserCreate trigger`
+**AC**: AC-1, AC-5, AC-6, AC-12
+
+- [ ] **3.1 (M)** `functions/src/lib/validate.ts` — zod: `setUserRoleInput = z.object({ targetUid: z.string().min(1), role: z.enum(['owner','admin','user']) })`.
+- [ ] **3.2 (M)** `functions/src/lib/rateLimit.ts` — sliding 1-hour window on `rateLimits/setUserRole/actors/{actorUid}`; throws `resource-exhausted` at 20.
+- [ ] **3.3 (M)** `functions/src/lib/lastOwnerGuard.ts` — TX-internal owner count; rejects demotion that would leave zero owners.
+- [ ] **3.4 (L)** `functions/src/setUserRole.ts` — callable, `onCall({ enforceAppCheck: !process.env.FUNCTIONS_EMULATOR })`. Sequence: owner check → zod → rate-limit → last-owner guard → `setCustomUserClaims` → TX (update mirror w/ `roleChangedAt`, create audit doc, bump rate-limit). Returns `{ ok: true, fromRole, toRole }`.
+- [ ] **3.5 (M)** `functions/src/onUserCreate.ts` — `auth.user().onCreate` (or v2 `beforeUserCreated` if Auth v2 supported). Idempotent: skip if `users/{uid}` exists. Sets `role: 'user'` claim + writes mirror with defaults + timestamps.
+- [ ] **3.6 (S)** `functions/src/index.ts` re-exports both.
+- [ ] **3.7 (L)** `tests/functions/setUserRole.test.ts` — 10 cases: no auth, non-owner, invalid role, last-owner demotion, 21st call, success (claim + doc consistent), audit entry written, App Check missing in prod env, App Check missing under emulator (allowed), idempotent on retry.
+- [ ] **3.8 (M)** `tests/functions/onUserCreate.test.ts` — 3 cases: doc seeded with defaults, claim set, idempotent.
+- [ ] **3.9 (S)** `firebase emulators:exec --only auth,firestore,functions 'vitest run tests/functions'` green. *(Validation gate)*
+
+---
+
+## Group 4 — Replace grant-admin with set-role CLI
+
+**Goal**: extend the existing CLI to handle three roles, with the same safety as the callable.
+**Commit**: `feat(rbac): replace grant-admin with multi-role set-role CLI + runbook`
+**AC**: AC-10, AC-14, AC-18
+
+- [ ] **4.1 (L)** Replace [scripts/grant-admin.js](../../../scripts/grant-admin.js) with `scripts/set-role.js`:
+  - Subcommands: `set <email> <role>`, `list`, `revoke <email>` (alias for `set <email> user`).
+  - Reuses gcloud ADC pattern (no SA key).
+  - Atomic: claim + mirror + audit (actorUid: `'cli'`) in one logical operation; last-owner guard.
+  - `DRY_RUN=1` mode prints diff without writing.
+  - Validation: rejects unknown roles, missing args, unknown email.
+- [ ] **4.2 (S)** Update [package.json](../../../package.json): rename `grant-admin` script entry to `set-role`. Keep `grant-admin` as a deprecated alias (`node scripts/set-role.js set "$1" admin`) for one release with a console.warn deprecation notice.
+- [ ] **4.3 (M)** Write [bootstrap.md](./bootstrap.md) — runbook covering: prerequisite (`gcloud auth application-default login`); first owner promotion; ongoing list/promote/demote; emulator dry runs; what to do if the only owner is locked out.
+- [ ] **4.4 (S)** `git status` shows no `.secrets/` or key files leaked. *(Validation gate)*
+
+---
+
+## Group 5 — Client infrastructure
+
+**Goal**: Functions, App Check, role module, and user repository wired on the client.
+**Commit**: `feat(rbac): wire Functions, App Check, role module, and user repository on client`
+**AC**: AC-9, AC-15
+
+- [ ] **5.1 (M)** `src/infrastructure/functions.ts` — lazy `getFunctions` + `httpsCallable` helper, emulator-aware via `import.meta.env.VITE_USE_EMULATOR`.
+- [ ] **5.2 (M)** `src/infrastructure/appcheck.ts` — `initializeAppCheck` with reCAPTCHA Enterprise site key from `import.meta.env.VITE_APPCHECK_SITE_KEY`; debug token path for `import.meta.env.DEV`.
+- [ ] **5.3 (L)** `src/repositories/user-repository.ts` — `findById(uid): Promise<UserDoc | null>`, `listPaginated({ pageSize: 20, cursor }): Promise<{ users: UserDoc[]; nextCursor: DocumentSnapshot | null }>`, `observeSelf(uid, cb): Unsubscribe` (snapshot listener for `roleChangedAt`). Never writes the `role` field. Type `UserDoc` lives in `src/types/user.ts` (also new).
+- [ ] **5.4 (M)** Extend [src/repositories/repository-factory.ts:22](../../../src/repositories/repository-factory.ts:22) — add `getUserRepository()` next to `getScoreRepository()` with the same caching pattern.
+- [ ] **5.5 (M)** `src/modules/role.ts` — exports `Role` type, `getRole(force?: boolean): Promise<Role | null>`, `onRoleChange(cb): Unsubscribe`. Reads `getIdTokenResult().claims.role`; `force=true` triggers `getIdToken(true)`.
+- [ ] **5.6 (S)** Modify [src/firebase-config.ts](../../../src/firebase-config.ts) — initialize App Check after `initializeApp` when not in test env.
+- [ ] **5.7 (S)** `.env.example` — document `VITE_APPCHECK_SITE_KEY`, `VITE_USE_EMULATOR`.
+- [ ] **5.8 (S)** Manual smoke: sign in via emulator → verify `users/{uid}` doc appears, `role.ts` reports `'user'`. *(Validation gate)*
+
+---
+
+## Group 6 — Auth + router integration
+
+**Goal**: `/admin` route guard; auth surfaces the role; nav updates on role change.
+**Commit**: `feat(rbac): role-aware auth module, /admin route guard, role-driven nav`
+**AC**: AC-2, AC-9
+
+- [ ] **6.1 (M)** Modify [src/modules/auth.ts:45–49](../../../src/modules/auth.ts:45):
+  - Replace `isAdmin()` with `getRole(): Promise<Role | null>`.
+  - Add `refreshTokenAndRole(): Promise<Role | null>` (calls `getIdToken(true)` then re-reads).
+  - Add `onRoleChange(cb)` — opens an `onSnapshot` on `users/{currentUid}` watching `roleChangedAt`; clean up on sign-out and via the returned unsubscribe.
+- [ ] **6.2 (M)** Modify [src/main.ts:55–62](../../../src/main.ts:55) `_setupRoutes`:
+  - Extend the existing `onBeforeNavigate` handler — if `path === '/admin'` and current role is not `owner`/`admin`, return `false` (router redirects to `/`). Maintain existing cleanup behavior for `/admin → other`.
+- [ ] **6.3 (M)** Modify [src/main.ts:117–146](../../../src/main.ts:117) `_initAdminAuth`:
+  - Replace `await this._auth!.isAdmin()` with `await this._auth!.getRole()`.
+  - Toggle `#admin-panel-container` for `role === 'owner' || role === 'admin'`.
+  - Toggle `#admin-unauthorized` for `signed in && role === 'user'`.
+- [ ] **6.4 (M)** Modify [src/modules/navigation.ts:81–83](../../../src/modules/navigation.ts:81) `updateAuthState`:
+  - Take `role` instead of relying on a no-op.
+  - Subscribe to `onRoleChange` so nav admin link toggles live.
+- [ ] **6.5 (S)** Manual smoke: deep-link `/#/admin` as `user` redirects to `/`; as admin/owner renders panel. *(Validation gate)*
+
+---
+
+## Group 7 — Read-only Users tab
+
+**Goal**: owner+admin see who has access; no role-change controls in v1.
+**Commit**: `feat(rbac): add read-only Users tab to admin panel`
+**AC**: AC-3, AC-4, AC-15
+
+- [ ] **7.1 (M)** New `src/views/admin-users-tab.ts` — pure HTML factory: table with displayName / email / role / lastSignInAt / createdAt; "Load more" button for cursor pagination; loading/empty/error states matching existing `<admin-panel>` patterns.
+- [ ] **7.2 (M)** New `src/services/admin-user-service.ts` — `listUsers({ pageSize: 20, cursor })` calls `userRepository.listPaginated`; strips fields to the limited set; `setUserRole({ targetUid, role })` calls the `setUserRole` callable (deferred wiring; not invoked from any UI surface in v1).
+- [ ] **7.3 (M)** Modify [src/components/admin-panel.ts:73–80](../../../src/components/admin-panel.ts:73) — add a "Users" tab button alongside Team Management / Score Entry / Announcements. Render `admin-users-tab.ts` content inside.
+- [ ] **7.4 (S)** Wire fetch + pagination in `admin-panel.ts` (mirror existing patterns for the other tabs — no separate controller needed for v1).
+- [ ] **7.5 (S)** Emulator smoke: owner sees list; admin sees same list; user can't reach the page. *(Validation gate)*
+
+---
+
+## Group 8 — Emulator E2E
+
+**Goal**: full story walkthrough green before any real-Firebase deploy.
+**No commit** — fixes fold into prior groups via `git commit --fixup`.
+**AC**: AC-1 through AC-9, AC-15
+
+Per [plan §Group 8](../../../../.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md). Run every numbered step; record any surprises in this file or in a fixup commit message.
+
+---
+
+## Group 9 — Constitution + decision log
+
+**Goal**: docs reflect new state.
+**Commit**: `docs(rbac): advance Security to Phase 2, correct plan tier to Blaze`
+**AC**: AC-19
+
+- [ ] **9.1 (S)** [.specs/constitution.md:76](../../constitution.md:76) Cost row → `Blaze pay-as-you-go (within Spark-equivalent budget)`.
+- [ ] **9.2 (S)** [.specs/constitution.md:71](../../constitution.md:71) Security row → `Phase 2: App Check + custom-claim RBAC (owner/admin/user); Cloud Functions sole role writer`.
+- [ ] **9.3 (S)** [.specs/constitution.md:413](../../constitution.md:413) Cloud Functions row → `Blaze; pay-per-invocation; rate-limited internally`.
+- [ ] **9.4 (S)** Update §VI.1 hard constraints — keep cost discipline language; remove "Spark-only" / "no Cloud Functions" language.
+- [ ] **9.5 (S)** Bump constitution version 1.4.0 → 1.5.0; "Last Updated" → 2026-05-03.
+- [ ] **9.6 (S)** Update [.claude/agents/speckit.md:78](../../../.claude/agents/speckit.md:78) — remove `Firebase Spark plan only — no Cloud Functions, no paid features` line; replace with `Cloud Functions allowed (Blaze); audit cost in §VI.1 before adding new functions`.
+- [ ] **9.7 (M)** Append to [.prompts/meta/architectural-decision-log.md](../../../.prompts/meta/architectural-decision-log.md): 2026-05-03 entry "Adopt Blaze + RBAC, enter Security Phase 2" with triggers met / decision / consequences.
+- [ ] **9.8 (S)** `git diff .specs/ .prompts/ .claude/` reviewed for accidental edits. *(Validation gate)*
+
+---
+
+## Group 10 — Preview deploy + real-Firebase E2E
+
+**No commit** — fixes via fixup.
+**AC**: AC-13, AC-17
+
+- [ ] **10.1 (S)** `firebase deploy --only firestore:rules --project citl-baed2 --dry-run` then live.
+- [ ] **10.2 (M)** `firebase deploy --only firestore:rules,firestore:indexes,functions --project citl-baed2`.
+- [ ] **10.3 (S)** `npm run deploy:preview`.
+- [ ] **10.4 (M)** Re-run Group 8 walkthrough on preview URL with real Google sign-in.
+- [ ] **10.5 (M)** Bootstrap real owner: `gcloud auth application-default login` then `node scripts/set-role.js set <your-email> owner`.
+- [ ] **10.6 (S)** Confirm Firebase console Usage tab within §VI.1 thresholds.
+
+---
+
+## Group 11 — Pull request
+
+**AC**: AC-20
+
+- [ ] **11.1 (S)** `git rebase -i --autosquash main` to fold fixups.
+- [ ] **11.2 (S)** `git push -u origin feat/multi-user-rbac`.
+- [ ] **11.3 (S)** Run `@reviewer` on the branch.
+- [ ] **11.4 (M)** `gh pr create`:
+  - Title: `feat: introduce three-role RBAC (owner/admin/user)`
+  - Body: Summary, Changes (one bullet per Group 1–9 commit), Testing checklist, Guidance References (skills used + spec sections), Constitutional Compliance (Security Phase 1→2, plan-tier correction, no forbidden patterns).
+
+---
+
+## AC → Task Map
+
+| AC | Tasks |
+|----|-------|
+| AC-1 | 3.5, 3.8, 8.* |
+| AC-2 | 6.2, 6.5, 8.* |
+| AC-3 | 7.1, 7.2, 7.3, 8.* |
+| AC-4 | 7.1, 7.3 |
+| AC-5 | 3.4, 3.7, 8.* |
+| AC-6 | 3.2, 3.4, 3.7, 8.* |
+| AC-7 | 2.3, 2.4, 8.* |
+| AC-8 | 2.3, 2.5, 2.6, 8.* |
+| AC-9 | 5.3, 6.1, 8.* |
+| AC-10 | 4.1, 4.2, 8.*, 10.5 |
+| AC-11 | 2.4, 2.5, 2.6, 2.7, 2.8, 2.9 |
+| AC-12 | 3.7, 3.8, 3.9 |
+| AC-13 | 2.9, 3.9, 10.1, 10.2 |
+| AC-14 | 1.2, 4.1, 4.4 |
+| AC-15 | 5.3, 7.1, 7.2 |
+| AC-16 | 2.3 |
+| AC-17 | 3.2, 10.6 |
+| AC-18 | 4.3, 0.4 |
+| AC-19 | 9.1–9.7 |
+| AC-20 | 11.4 |

--- a/.specs/technical/firebase-deployment.md
+++ b/.specs/technical/firebase-deployment.md
@@ -1,9 +1,17 @@
 # Firebase Deployment — citl.club
 
 **Firebase Project**: `citl-baed2`
-**Hosting Region**: `us-east1` (Firestore) / Global CDN (Hosting)
-**Plan**: Spark (free tier)
-**Last Updated**: 2026-02-27
+**Project Number**: `983886495824`
+**Hosting Region**: Global CDN (Hosting) / `us-east1` (Firestore + Functions)
+**Plan**: Blaze (pay-as-you-go; usage targets Spark-equivalent quotas)
+**Last Updated**: 2026-05-04
+
+> **First-time deploy to a new Firebase project?** Operational gotchas (IAM
+> propagation for the GCF source bucket, 2nd-gen callable invoker binding,
+> Artifact Registry cleanup policy, reCAPTCHA Enterprise key wildcard caveat)
+> are documented in the global `firebase-deploy-runbook` skill at
+> `~/.claude/skills/firebase-deploy-runbook/SKILL.md`. This file documents
+> only the citl-specific values + decisions.
 
 ---
 
@@ -108,6 +116,139 @@ Before running `npm run deploy` or `npm run deploy:preview`:
 - [ ] All 5 SPA routes load correctly in `npm run preview`
 - [ ] No CSP violations in browser console during preview
 - [ ] Firebase Hosting quota not near 70% of 360 MB/day limit
+
+---
+
+## Cloud Functions Deployment
+
+citl-baed2 has Cloud Functions deployed in `us-east1` (RBAC `setUserRole` callable
+plus the on-create user-mirror trigger). The first deploy occurred on 2026-05-04.
+
+### Subsequent deploys
+
+```bash
+firebase deploy --only functions --project citl-baed2
+```
+
+Routine deploys after the first one require no special handling. The IAM bindings
+applied during the first deploy persist.
+
+### Adding a new callable function
+
+Each new 2nd-gen callable needs one one-time IAM binding after its first deploy
+so the browser can reach it via Firebase's `httpsCallable` path. Use the
+**lowercased** function name (Cloud Run service names are always lowercase):
+
+```bash
+gcloud run services add-iam-policy-binding {function-name} \
+  --region=us-east1 \
+  --member=allUsers \
+  --role=roles/run.invoker \
+  --project=citl-baed2
+```
+
+This is **not** an authorization weakening — the in-function check on
+`req.auth.token.role` is the actual boundary. See the global
+`firebase-deploy-runbook` skill (Gotcha 2) for the full rationale.
+
+### First-time deploy to a different project
+
+If we ever stand up a new Firebase project (preview environment, fork, etc.), the
+first `firebase deploy --only functions` will fail with the well-known
+`gcf-sources-{PROJECT_NUMBER}-{REGION}` permission error. The fix is one
+`gcloud projects add-iam-policy-binding` command + a 30-60s wait, then retry.
+
+**See the global `firebase-deploy-runbook` skill** (`~/.claude/skills/firebase-deploy-runbook/SKILL.md`)
+for the full first-time-deploy checklist (IAM propagation, invoker binding,
+Artifact Registry cleanup policy).
+
+---
+
+## Browser API Key Restrictions
+
+citl-baed2's auto-created Browser API key has **HTTP referrer restrictions
+cleared** (`browserKeyRestrictions: {}`). This is intentional and matches the
+posture salmoncow has been running in production with no incidents.
+
+### Why cleared
+
+The auto-created restrictions only included production domains
+(`https://citl.club/*`, `https://citl-baed2.web.app/*`), which broke:
+
+- Firebase Hosting preview channels (`citl-baed2--*.web.app`) — sign-in
+  failed with `auth/requests-from-referer-...-are-blocked` (HTTP 403 from
+  `identitytoolkit.googleapis.com`)
+- Local-against-prod testing (`npm run dev:prod`) on non-`localhost:3000` ports
+
+Mid-host wildcards like `https://citl-baed2--*.web.app/*` **silently fail to
+match** — Google API key referrer restrictions only support leading-subdomain
+wildcards (`*.example.com`), not mid-host. There is no referrer-restriction
+syntax that covers all preview-channel URLs.
+
+### Why this is safe
+
+The Browser API key is fundamentally public — it's embedded in the JS bundle
+and visible to anyone reading the source. Referrer restrictions are a soft
+control (referrers are client-controlled and trivial to spoof), not a real
+defense. The actual security boundaries for citl are:
+
+- **API target restrictions** on the key (Firestore, Identity Toolkit, App
+  Check — keep these tight as the real boundary)
+- **Firestore security rules** + custom-claim RBAC (`role: owner | admin | user`)
+- **App Check** with reCAPTCHA Enterprise (configured but not yet enforced)
+- **Cloud Functions** in-body `req.auth.token.role` checks
+
+See `security-principles` skill section "Soft controls vs real boundaries"
+and the `firebase-deploy-runbook` skill (Gotcha 4) for the full framing.
+
+### How citl-baed2 was cleared
+
+```bash
+gcloud services api-keys update {KEY_ID} \
+  --allowed-referrers="" \
+  --project=citl-baed2
+```
+
+Find `{KEY_ID}` via `gcloud services api-keys list --project=citl-baed2`
+(look for "Browser key (auto created by Firebase)").
+
+> Note: `--clear-allowed-referrers` is **not** a valid flag despite gcloud's
+> suggestion text. Pass an empty string instead.
+
+---
+
+## App Check Configuration
+
+### Provider
+
+App Check on web for citl-baed2 uses **reCAPTCHA Enterprise (Score-based)**, not
+the legacy reCAPTCHA v3 product.
+
+### Site key env var
+
+The Vite-injected env var is **`VITE_RECAPTCHA_ENTERPRISE_SITE_KEY`** (not
+`VITE_APPCHECK_SITE_KEY` — provider-specific naming makes the key format obvious
+in code review).
+
+### Domain registration trade-off
+
+reCAPTCHA Enterprise key registration does **not** support wildcard domains, so
+Firebase preview-channel URLs (`citl-baed2--preview-{hash}.web.app`) cannot be
+covered by a single domain entry.
+
+citl currently uses **Option 1** from the runbook: one key with domain verification
+disabled, valid for prod, dev, and preview channels. The risk (anyone with the key
+can use it from any origin) is acceptable for citl because:
+
+- The actual authorization boundary is Firestore rules + Cloud Functions custom-claim
+  checks, not App Check
+- The site is public-by-design (standings/scorecards are open-read)
+- The user mirror collection is admin-only-write, enforced server-side
+
+If user PII is ever added to the data model, revisit and switch to Option 2 (split
+prod / dev keys with domain verification on the prod key).
+
+**See the `firebase-deploy-runbook` skill** for the full trade-off discussion.
 
 ### Post-Deployment Verification
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,32 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "runtime": "nodejs22",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log",
+        "*.local"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ],
+  "emulators": {
+    "auth": { "port": 9099 },
+    "firestore": { "port": 8080 },
+    "functions": { "port": 5001 },
+    "hosting": { "port": 5000 },
+    "ui": { "enabled": true, "port": 4000 },
+    "singleProjectMode": true
   },
   "hosting": {
     "public": "dist",

--- a/firebase.json
+++ b/firebase.json
@@ -85,7 +85,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'sha256-aicmPnaCrSxEOxi0YOp42K+dltS8SPfNqaRLOsuqxSU=' https://www.gstatic.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://*.googleusercontent.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://maps.google.com https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+            "value": "default-src 'self'; script-src 'self' 'sha256-aicmPnaCrSxEOxi0YOp42K+dltS8SPfNqaRLOsuqxSU=' https://www.gstatic.com https://apis.google.com https://www.google.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://*.googleusercontent.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://www.google.com https://*.cloudfunctions.net https://*.run.app; frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://maps.google.com https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
           }
         ]
       }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,43 +2,79 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    function isAdmin() {
-      return request.auth != null && request.auth.token.admin == true;
+    // ── Role helpers ────────────────────────────────────────────────────────
+    // Source of truth for role checks: request.auth.token.role
+    // (populated by setCustomUserClaims; client cannot forge).
+    function isSignedIn()      { return request.auth != null; }
+    function roleOf()          { return request.auth.token.role; }
+    function isOwner()         { return isSignedIn() && roleOf() == 'owner'; }
+    function isAdmin()         { return isSignedIn() && roleOf() == 'admin'; }
+    function isOwnerOrAdmin()  { return isOwner() || isAdmin(); }
+    function isSelf(uid)       { return isSignedIn() && request.auth.uid == uid; }
+
+    // ── users/{uid} — RBAC mirror ───────────────────────────────────────────
+    // Written server-side by the onUserCreate trigger and the setUserRole
+    // callable / scripts/set-role.js CLI. Clients may read their own doc
+    // and (for owner/admin) read the list. The role field is never client-
+    // writable.
+    match /users/{uid} {
+      allow read:   if isSelf(uid) || isOwnerOrAdmin();
+      // Self-create (defense in depth — onUserCreate normally seeds it)
+      // must not include the role field.
+      allow create: if isSelf(uid) && !('role' in request.resource.data);
+      // Self-update preserves role; the field can never change client-side.
+      // Two paths: either the update doesn't include the role field at all
+      // (typical preferences edit), or it includes it but matches the existing
+      // value. Either way, role is never client-mutable.
+      allow update: if isSelf(uid)
+                    && (!('role' in request.resource.data)
+                        || request.resource.data.role == resource.data.role);
+      allow delete: if false;
     }
 
-    // Banner config — set via setDoc (create or overwrite). Never deleted.
+    // ── audit/{id} — append-only role-change log ────────────────────────────
+    match /audit/{id} {
+      allow read:  if isOwner();
+      allow write: if false;
+    }
+
+    // ── rateLimits/** — Function-internal counters ──────────────────────────
+    match /rateLimits/{path=**} {
+      allow read:  if isOwner();
+      allow write: if false;
+    }
+
+    // ── config/{doc} — banner + site config ─────────────────────────────────
     match /config/{doc} {
-      allow read: if true;
-      allow create, update: if isAdmin();
+      allow read:           if true;
+      allow create, update: if isOwnerOrAdmin();
     }
 
-    // Announcements — full lifecycle: create, edit, and delete are all portal actions.
+    // ── announcements/{docId} ──────────────────────────────────────────────
     match /announcements/{docId} {
-      allow read: if true;
-      allow create, update, delete: if isAdmin();
+      allow read:                   if true;
+      allow create, update, delete: if isOwnerOrAdmin();
     }
 
+    // ── seasons/{year} and subcollections ──────────────────────────────────
     match /seasons/{year} {
-      // Season documents — created/updated, never deleted (permanent record).
-      allow read: if true;
-      allow create, update: if isAdmin();
+      allow read:           if true;
+      allow create, update: if isOwnerOrAdmin();
 
       match /teams/{teamId} {
-        // Teams — created, edited, and deleted via portal.
-        allow read: if true;
-        allow create, update, delete: if isAdmin();
+        allow read:                   if true;
+        allow create, update, delete: if isOwnerOrAdmin();
       }
 
       match /weeks/{weekNumber} {
-        // Published week results — created/updated by publish action. Never deleted.
-        allow read: if true;
-        allow create, update: if isAdmin();
+        allow read:           if true;
+        allow create, update: if isOwnerOrAdmin();
       }
 
       match /entries/{entryId} {
-        // Draft entries — created/updated by score entry; deleted only during team deletion cascade.
-        allow read: if isAdmin();
-        allow create, update, delete: if isAdmin();
+        // Drafts are owner/admin-only end-to-end.
+        allow read:                   if isOwnerOrAdmin();
+        allow create, update, delete: if isOwnerOrAdmin();
       }
     }
   }

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,5 +1,5 @@
-# Compiled JavaScript output
-lib/
+# Compiled JavaScript output (top-level only — keep src/lib/ tracked)
+/lib/
 
 # Local env / config
 .env

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,15 @@
+# Compiled JavaScript output
+lib/
+
+# Local env / config
+.env
+.runtimeconfig.json
+
+# Logs
+firebase-debug.log
+ui-debug.log
+firestore-debug.log
+*-debug.*.log
+
+# Dependencies (covered by root, but keep belt-and-suspenders)
+node_modules/

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,0 +1,8666 @@
+{
+  "name": "citl-functions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "citl-functions",
+      "version": "1.0.0",
+      "dependencies": {
+        "firebase-admin": "^13.0.0",
+        "firebase-functions": "^7.0.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "firebase-functions-test": "^3.4.0",
+        "typescript": "^5.6.0",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": "22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.4.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/firebase-functions": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.5",
+        "@types/express": "^4.17.21",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "protobufjs": "^7.2.2"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/firebase-functions-test": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-3.4.1.tgz",
+      "integrity": "sha512-qAq0oszrBGdf4bnCF6t4FoSgMsepeIXh0Pi/FhikSE6e+TvKKGpfrfUP/5pFjJZxFcLsweoau88KydCql4xSeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.14.104",
+        "lodash": "^4.17.5",
+        "ts-deepmerge": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+        "firebase-functions": ">=4.9.0",
+        "jest": ">=28.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-2.0.7.tgz",
+      "integrity": "sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "citl-functions",
+  "version": "1.0.0",
+  "description": "Cloud Functions for CITL — RBAC role writer and user-doc seeder",
+  "private": true,
+  "type": "module",
+  "main": "lib/index.js",
+  "engines": {
+    "node": "22"
+  },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "firebase-admin": "^13.0.0",
+    "firebase-functions": "^7.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "firebase-functions-test": "^3.4.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * CITL Cloud Functions entry point.
+ *
+ * Re-exports the callable + auth trigger used by the RBAC system.
+ * See [.specs/features/002-multi-user-rbac/spec.md](../../.specs/features/002-multi-user-rbac/spec.md).
+ */
+
+// Functions are added in Group 3:
+//   export { setUserRole } from './setUserRole.js';
+//   export { onUserCreate } from './onUserCreate.js';
+
+export {};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,8 +5,5 @@
  * See [.specs/features/002-multi-user-rbac/spec.md](../../.specs/features/002-multi-user-rbac/spec.md).
  */
 
-// Functions are added in Group 3:
-//   export { setUserRole } from './setUserRole.js';
-//   export { onUserCreate } from './onUserCreate.js';
-
-export {};
+export { setUserRole } from './setUserRole.js';
+export { onUserCreate } from './onUserCreate.js';

--- a/functions/src/lib/lastOwnerGuard.ts
+++ b/functions/src/lib/lastOwnerGuard.ts
@@ -1,0 +1,30 @@
+/**
+ * Refuse to demote the last `owner` in the system.
+ *
+ * Runs inside the setUserRole transaction so the owner count is read
+ * consistently with the role write.
+ */
+
+import type { Firestore, Transaction } from 'firebase-admin/firestore';
+import { HttpsError } from 'firebase-functions/v2/https';
+import type { Role } from './validate.js';
+
+export async function assertNotLastOwner(
+  tx: Transaction,
+  db: Firestore,
+  currentTargetRole: Role,
+  newRole: Role,
+): Promise<void> {
+  // Only relevant when demoting an owner.
+  if (currentTargetRole !== 'owner' || newRole === 'owner') {
+    return;
+  }
+
+  const owners = await tx.get(db.collection('users').where('role', '==', 'owner'));
+  if (owners.size <= 1) {
+    throw new HttpsError(
+      'failed-precondition',
+      'Cannot demote the last owner. Promote another user to owner first.',
+    );
+  }
+}

--- a/functions/src/lib/rateLimit.ts
+++ b/functions/src/lib/rateLimit.ts
@@ -1,0 +1,63 @@
+/**
+ * Sliding 1-hour window rate limit for setUserRole.
+ *
+ * Counter at rateLimits/setUserRole/actors/{actorUid} with shape:
+ *   { windowStart: number (ms epoch), count: number }
+ *
+ * Reads + bumps run inside the caller's Firestore transaction so the
+ * counter is consistent with the role write. If the counter is missing
+ * or its windowStart is older than WINDOW_MS, the window resets.
+ */
+
+import type { Firestore, Transaction } from 'firebase-admin/firestore';
+import { HttpsError } from 'firebase-functions/v2/https';
+
+export const WINDOW_MS = 60 * 60 * 1000;
+export const LIMIT = 20;
+
+interface RateCounter {
+  windowStart: number;
+  count: number;
+}
+
+export function rateLimitRef(db: Firestore, actorUid: string) {
+  return db.doc(`rateLimits/setUserRole/actors/${actorUid}`);
+}
+
+/**
+ * Inside the given transaction, check that actorUid has not exceeded the
+ * rate limit, then queue the write to bump the counter. Throws
+ * HttpsError('resource-exhausted') if at or above the limit in the
+ * current window.
+ */
+export async function checkAndBumpInTransaction(
+  tx: Transaction,
+  db: Firestore,
+  actorUid: string,
+  now: number = Date.now(),
+): Promise<void> {
+  const ref = rateLimitRef(db, actorUid);
+  const snap = await tx.get(ref);
+
+  if (!snap.exists) {
+    tx.set(ref, { windowStart: now, count: 1 });
+    return;
+  }
+
+  const data = snap.data() as RateCounter;
+  const windowExpired = now - data.windowStart >= WINDOW_MS;
+
+  if (windowExpired) {
+    tx.set(ref, { windowStart: now, count: 1 });
+    return;
+  }
+
+  if (data.count >= LIMIT) {
+    throw new HttpsError(
+      'resource-exhausted',
+      `Rate limit exceeded: ${LIMIT} role changes per hour per actor.`,
+    );
+  }
+
+  tx.update(ref, { count: data.count + 1 });
+}

--- a/functions/src/lib/validate.ts
+++ b/functions/src/lib/validate.ts
@@ -1,0 +1,18 @@
+/**
+ * Zod schemas for callable function inputs.
+ *
+ * Validation runs before any privileged operation; any failure is
+ * surfaced as `invalid-argument` to the caller.
+ */
+
+import { z } from 'zod';
+
+export const ROLES = ['owner', 'admin', 'user'] as const;
+export type Role = (typeof ROLES)[number];
+
+export const setUserRoleInput = z.object({
+  targetUid: z.string().min(1).max(128),
+  role: z.enum(ROLES),
+});
+
+export type SetUserRoleInput = z.infer<typeof setUserRoleInput>;

--- a/functions/src/onUserCreate.ts
+++ b/functions/src/onUserCreate.ts
@@ -1,0 +1,54 @@
+/**
+ * onUserCreate — Firebase Auth trigger that seeds a users/{uid} doc and
+ * sets `role: 'user'` custom claim on first sign-in.
+ *
+ * Idempotent: if users/{uid} already exists, the trigger no-ops. This
+ * matters because (a) the trigger may be re-delivered, and (b) the
+ * bootstrap CLI may seed an owner before the trigger fires for the
+ * very first user.
+ *
+ * Uses the v1 API (auth.user().onCreate) so the trigger runs
+ * asynchronously after sign-in completes — keeps sign-in latency low.
+ * v2 only offers blocking (`beforeUserCreated`) which we don't need.
+ */
+
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { auth } from 'firebase-functions/v1';
+import type { UserRecord } from 'firebase-admin/auth';
+
+if (getApps().length === 0) {
+  initializeApp();
+}
+
+/**
+ * Handler is exported so tests can call it directly without
+ * firebase-functions-test's wrap (which has known issues with v1 auth
+ * triggers swallowing post-await side effects).
+ */
+export async function handleUserCreated(user: UserRecord | { uid: string; email?: string | null; displayName?: string | null; photoURL?: string | null }): Promise<void> {
+  const db = getFirestore();
+  const adminAuth = getAuth();
+
+  const userRef = db.doc(`users/${user.uid}`);
+  const existing = await userRef.get();
+  if (existing.exists) {
+    return;
+  }
+
+  await adminAuth.setCustomUserClaims(user.uid, { role: 'user' });
+
+  await userRef.set({
+    uid: user.uid,
+    email: user.email ?? null,
+    displayName: user.displayName ?? null,
+    photoURL: user.photoURL ?? null,
+    role: 'user',
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    lastSignInAt: FieldValue.serverTimestamp(),
+  });
+}
+
+export const onUserCreate = auth.user().onCreate(handleUserCreated);

--- a/functions/src/setUserRole.ts
+++ b/functions/src/setUserRole.ts
@@ -10,10 +10,18 @@
  *   4. Inside a single Firestore transaction:
  *      - Target user doc exists.
  *      - Last-owner guard: cannot demote the only `owner`.
- *      - Rate limit: <=20 calls/hour/actor (sliding window).
- *      - Writes: update users/{targetUid} (role + roleChangedAt),
- *        create audit/{auto} entry, bump rateLimits counter.
- *   5. After TX commits: setCustomUserClaims with the new role.
+ *      - Rate limit: <=20 calls/hour/actor (sliding window). Counter
+ *        write is queued in this same TX so a failed commit doesn't
+ *        bump the count.
+ *      - **setCustomUserClaims (Auth API)** — called BEFORE the queued
+ *        Firestore writes. The claim is the security boundary that
+ *        Firestore rules read; ordering it ahead of the mirror+audit
+ *        commit gives fail-closed-on-revocation semantics if the TX
+ *        commit later fails. See spec.md §VI Design Decisions for the
+ *        full failure-mode table and rationale.
+ *      - Queued writes: update users/{targetUid} (role + roleChangedAt
+ *        + updatedAt), create audit/{auto}, bump rateLimits counter.
+ *   5. TX commits → all four Firestore writes apply atomically.
  *
  * Failure modes:
  *   - permission-denied: caller missing or not owner
@@ -21,6 +29,11 @@
  *   - not-found: target user doc doesn't exist
  *   - failed-precondition: would demote last owner
  *   - resource-exhausted: rate limit hit
+ *
+ * TX retry note: Firestore retries the TX function on contention.
+ * setCustomUserClaims is therefore called once per attempt with the
+ * same payload — idempotent, no security impact, marginal extra Auth
+ * API cost only on contention.
  */
 
 import { initializeApp, getApps } from 'firebase-admin/app';
@@ -58,6 +71,7 @@ export const setUserRole = onCall(
     const userRef = db.doc(`users/${targetUid}`);
 
     const result = await db.runTransaction(async (tx) => {
+      // Reads first (Firestore TX rule: all reads before any writes).
       const userSnap = await tx.get(userRef);
       if (!userSnap.exists) {
         throw new HttpsError('not-found', `User ${targetUid} not found.`);
@@ -66,6 +80,17 @@ export const setUserRole = onCall(
 
       await assertNotLastOwner(tx, db, currentRole, newRole);
       await checkAndBumpInTransaction(tx, db, actorUid);
+
+      // Claim-first: set the auth custom claim BEFORE queueing the
+      // Firestore writes. Two failure-mode reasons (see spec §VI):
+      //   - If this throws, the queued writes never apply (TX returns
+      //     before commit). Safe.
+      //   - If this succeeds and the TX commit later fails, the claim
+      //     is set but mirror+audit are not. The claim is the rules-
+      //     engine source of truth, so revocation has already taken
+      //     effect — fail-closed for the security-critical path.
+      //     Mirror+audit drift is recoverable by retry.
+      await getAuth().setCustomUserClaims(targetUid, { role: newRole });
 
       tx.update(userRef, {
         role: newRole,
@@ -83,13 +108,6 @@ export const setUserRole = onCall(
 
       return { fromRole: currentRole, toRole: newRole };
     });
-
-    // Claim is set after the TX commits. If this throws, the mirror has
-    // the new role but the claim is stale; the caller can retry to
-    // resync (the next TX will see currentRole == new role and short-
-    // circuit the duplicate audit entry path is acceptable since the
-    // last-owner guard still holds).
-    await getAuth().setCustomUserClaims(targetUid, { role: newRole });
 
     return { ok: true, ...result };
   },

--- a/functions/src/setUserRole.ts
+++ b/functions/src/setUserRole.ts
@@ -1,0 +1,96 @@
+/**
+ * setUserRole — owner-only callable that writes a user's role.
+ *
+ * Defense in depth (in order):
+ *   1. App Check enforced in production (relaxed under FUNCTIONS_EMULATOR
+ *      so the emulator E2E walkthrough works).
+ *   2. Caller must be authenticated AND have role:'owner' in their
+ *      Firebase ID-token claim.
+ *   3. zod-validated inputs ({ targetUid, role }).
+ *   4. Inside a single Firestore transaction:
+ *      - Target user doc exists.
+ *      - Last-owner guard: cannot demote the only `owner`.
+ *      - Rate limit: <=20 calls/hour/actor (sliding window).
+ *      - Writes: update users/{targetUid} (role + roleChangedAt),
+ *        create audit/{auto} entry, bump rateLimits counter.
+ *   5. After TX commits: setCustomUserClaims with the new role.
+ *
+ * Failure modes:
+ *   - permission-denied: caller missing or not owner
+ *   - invalid-argument: bad input
+ *   - not-found: target user doc doesn't exist
+ *   - failed-precondition: would demote last owner
+ *   - resource-exhausted: rate limit hit
+ */
+
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { setUserRoleInput, type Role } from './lib/validate.js';
+import { assertNotLastOwner } from './lib/lastOwnerGuard.js';
+import { checkAndBumpInTransaction } from './lib/rateLimit.js';
+
+if (getApps().length === 0) {
+  initializeApp();
+}
+
+const isEmulator = process.env['FUNCTIONS_EMULATOR'] === 'true';
+
+export const setUserRole = onCall(
+  {
+    enforceAppCheck: !isEmulator,
+    region: 'us-central1',
+  },
+  async (req): Promise<{ ok: true; fromRole: Role; toRole: Role }> => {
+    if (!req.auth || req.auth.token['role'] !== 'owner') {
+      throw new HttpsError('permission-denied', 'Owner role required.');
+    }
+    const actorUid = req.auth.uid;
+
+    const parsed = setUserRoleInput.safeParse(req.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', parsed.error.message);
+    }
+    const { targetUid, role: newRole } = parsed.data;
+
+    const db = getFirestore();
+    const userRef = db.doc(`users/${targetUid}`);
+
+    const result = await db.runTransaction(async (tx) => {
+      const userSnap = await tx.get(userRef);
+      if (!userSnap.exists) {
+        throw new HttpsError('not-found', `User ${targetUid} not found.`);
+      }
+      const currentRole = (userSnap.data()?.['role'] as Role | undefined) ?? 'user';
+
+      await assertNotLastOwner(tx, db, currentRole, newRole);
+      await checkAndBumpInTransaction(tx, db, actorUid);
+
+      tx.update(userRef, {
+        role: newRole,
+        roleChangedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+
+      tx.create(db.collection('audit').doc(), {
+        actorUid,
+        targetUid,
+        fromRole: currentRole,
+        toRole: newRole,
+        at: FieldValue.serverTimestamp(),
+      });
+
+      return { fromRole: currentRole, toRole: newRole };
+    });
+
+    // Claim is set after the TX commits. If this throws, the mirror has
+    // the new role but the claim is stale; the caller can retry to
+    // resync (the next TX will see currentRole == new role and short-
+    // circuit the duplicate audit entry path is acceptable since the
+    // last-owner guard still holds).
+    await getAuth().setCustomUserClaims(targetUid, { role: newRole });
+
+    return { ok: true, ...result };
+  },
+);

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["lib", "node_modules", "**/*.test.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.3.2",
-        "firebase": "^12.9.0",
+        "firebase": "^12.12.1",
         "marked": "^17.0.4"
       },
       "devDependencies": {
@@ -1227,15 +1227,15 @@
       "license": "MIT"
     },
     "node_modules/@firebase/ai": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.8.0.tgz",
-      "integrity": "sha512-grWYGFPsSo+pt+6CYeKR0kWnUfoLLS3xgWPvNrhAS5EPxl6xWq7+HjDZqX24yLneETyl45AVgDsTbVgxeWeRfg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.1.tgz",
+      "integrity": "sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1247,15 +1247,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.19",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.19.tgz",
-      "integrity": "sha512-3wU676fh60gaiVYQEEXsbGS4HbF2XsiBphyvvqDbtC1U4/dO4coshbYktcCHq+HFaGIK07iHOh4pME0hEq1fcg==",
+      "version": "0.10.21",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.21.tgz",
+      "integrity": "sha512-j2y2q65BlgLGB5Pwjhv/Jopw2X/TBTzvAtI5z/DSp56U4wBj7LfhBfzbdCtFPges+Wz0g55GdoawXibOH5jGng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1263,15 +1263,15 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.25.tgz",
-      "integrity": "sha512-fdzoaG0BEKbqksRDhmf4JoyZf16Wosrl0Y7tbZtJyVDOOwziE0vrFjmZuTdviL0yhak+Nco6rMsUUbkbD+qb6Q==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.27.tgz",
+      "integrity": "sha512-ZObpYpAxL6JfgH7GnvlDD0sbzGZ0o4nijV8skatV9ZX49hJtCYbFqaEcPYptT94rgX1KUoKEderC7/fa7hybtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.19",
+        "@firebase/analytics": "0.10.21",
         "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1285,14 +1285,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
-      "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
+      "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1301,14 +1301,14 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
-      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.2.tgz",
+      "integrity": "sha512-jcXQVMHAQ5AEKzVD5C7s5fmAYeFOuN6lAJeNTgZK2B9aLnofWaJt8u1A8Idm8gpsBBYSaY3cVyeH5SWMOVPBLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1319,16 +1319,16 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
-      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.2.tgz",
+      "integrity": "sha512-M91NhxqbSkI0ChkJWy69blC+rPr6HEgaeRllddSaU1pQ/7IiegeCQM9pPDIgvWnwnBSzKhUHpe6ro/jhJ+cvzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check": "0.11.2",
         "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1351,15 +1351,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
-      "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
+      "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.14.8",
-        "@firebase/component": "0.7.0",
+        "@firebase/app": "0.14.11",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1367,20 +1367,23 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.0.tgz",
-      "integrity": "sha512-zkvLpsrxynWHk07qGrUDfCSqKf4AvfZGEqJ7mVCtYGjNNDbGE71k0Yn84rg8QEZu4hQw1BC0qDEHzpNVBcSVmA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1388,7 +1391,7 @@
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^2.2.0"
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -1397,15 +1400,15 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.2.tgz",
-      "integrity": "sha512-8UhCzF6pav9bw/eXA8Zy1QAKssPRYEYXaWagie1ewLTwHkXv6bKp/j6/IwzSYQP67sy/BMFXIFaCCsoXzFLr7A==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.5.tgz",
+      "integrity": "sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.12.0",
+        "@firebase/auth": "1.13.0",
         "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1432,12 +1435,12 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
-      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1445,15 +1448,15 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.12.tgz",
-      "integrity": "sha512-baPddcoNLj/+vYo+HSJidJUdr5W4OkhT109c5qhR8T1dJoZcyJpkv/dFpYlw/VJ3dV66vI8GHQFrmAZw/xUS4g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.6.0.tgz",
+      "integrity": "sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1461,16 +1464,16 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
-      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -1479,16 +1482,16 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
-      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-types": "1.0.16",
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1496,24 +1499,24 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
-      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.13.0"
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.11.0.tgz",
-      "integrity": "sha512-Zb88s8rssBd0J2Tt+NUXMPt2sf+Dq7meatKiJf5t9oto1kZ8w9gK59Koe1uPVbaKfdgBp++N/z0I4G/HamyEhg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.0.tgz",
+      "integrity": "sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "@firebase/webchannel-wrapper": "1.0.5",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
@@ -1527,15 +1530,15 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.5.tgz",
-      "integrity": "sha512-yVX1CkVvqBI4qbA56uZo42xFA4TNU0ICQ+9AFDvYq9U9Xu6iAx9lFDAk/tN+NGereQQXXCSnpISwc/oxsQqPLA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz",
+      "integrity": "sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/firestore": "4.11.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/firestore": "4.14.0",
         "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1556,16 +1559,16 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
-      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.3.tgz",
+      "integrity": "sha512-csO7ckK3SSs+NUZW1nms9EK7ckHe/1QOjiP8uAkCYa7ND18s44vjE9g3KxEeIUpyEPqZaX1EhJuFyZjHigAcYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1576,15 +1579,15 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
-      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.3.tgz",
+      "integrity": "sha512-BxkEwWgx1of0tKaao/r2VR6WBLk/RAiyztatiONPrPE8gkitFkOnOCxf8i9cUyA5hX5RGt5H30uNn25Q6QNEmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/functions": "0.13.1",
+        "@firebase/component": "0.7.2",
+        "@firebase/functions": "0.13.3",
         "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1601,13 +1604,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
-      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.21.tgz",
+      "integrity": "sha512-xGFGTeICJZ5vhrmmDukeczIcFULFXybojML2+QSDFoKj5A7zbGN7KzFGSKNhDkIxpjzsYG9IleJyUebuAcmqWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1616,15 +1619,15 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
-      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.21.tgz",
+      "integrity": "sha512-zahIUkaVKbR8zmTeBHkdfaVl6JGWlhVoSjF7CVH33nFqD3SlPEpEEegn2GNT5iAfsVdtlCyJJ9GW4YKjq+RJKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
         "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1653,15 +1656,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
-      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.25.tgz",
+      "integrity": "sha512-7RhDwoDHlOK1/ou0/LeubxmjcngsTjDdrY/ssg2vwAVpUuVAhQzQvuCAOYxcX5wNC1zCgQ54AP1vdngBwbCmOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1670,14 +1673,14 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
-      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.25.tgz",
+      "integrity": "sha512-eoOQqGLtRlseTdiemTN44LlHZpltK5gnhq8XVUuLgtIOG+odtDzrz2UoTpcJWSzaJQVxNLb/x9f39tHdDM4N4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1691,15 +1694,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
-      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.11.tgz",
+      "integrity": "sha512-V3uAhrz7IYJuji+OgT3qYTGKxpek/TViXti9OSsUJ4AexZ3jQjYH5Yrn7JvBxk8MGiSLsC872hh+BxQiPZsm7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -1708,16 +1711,16 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
-      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.24.tgz",
+      "integrity": "sha512-YRlejH8wLt7ThWao+HXoKUHUrZKGYq+otxkPS+8nuE5PeN1cBXX7NAJl9ueuUkBwMIrnKdnDqL/voHXxDAAt3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/performance": "0.7.9",
+        "@firebase/performance": "0.7.11",
         "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1731,15 +1734,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.0.tgz",
-      "integrity": "sha512-sJz7C2VACeE257Z/3kY9Ap2WXbFsgsDLfaGfZmmToKAK39ipXxFan+vzB9CSbF6mP7bzjyzEnqPcMXhAnYE6fQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.2.tgz",
+      "integrity": "sha512-5EXqOThV4upjK9D38d/qOSVwOqRhemlaOFk9vCkMNNALeIlwr+4pLjtLNo4qoY8etQmU/1q4aIATE9N8PFqg0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1747,16 +1750,16 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.21.tgz",
-      "integrity": "sha512-9+lm0eUycxbu8GO25JfJe4s6R2xlDqlVt0CR6CvN9E6B4AFArEV4qfLoDVRgIEB7nHKwvH2nYRocPWfmjRQTnw==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.23.tgz",
+      "integrity": "sha512-4+KqRRHEUUmKT6tFmnpWATOsaFfmSuBs1jXH8JzVtMLEYqq/WS9IDM92OdefFDSrAA2xGd0WN004z8mKeIIscw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/remote-config": "0.8.0",
+        "@firebase/remote-config": "0.8.2",
         "@firebase/remote-config-types": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1783,13 +1786,13 @@
       }
     },
     "node_modules/@firebase/storage": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
-      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.2.tgz",
+      "integrity": "sha512-o/culaTeJ8GRpKXRJov21rux/n9dRaSOWLebyatFP2sqEdCxQPjVA1H9Z2fzYwQxMIU0JVmC7SPPmU11v7L6vQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1800,15 +1803,15 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
-      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.2.tgz",
+      "integrity": "sha512-R+aB38wxCH5zjIO/xu9KznI7fgiPuZAG98uVm1NcidHyyupGgIDLKigGmRGBZMnxibe/m2oxNKoZpfEbUX2aQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/storage": "0.14.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/storage": "0.14.2",
         "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1829,9 +1832,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
-      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8282,39 +8285,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.9.0.tgz",
-      "integrity": "sha512-CwwTYoqZg6KxygPOaaJqIc4aoLvo0RCRrXoln9GoxLE8QyAwTydBaSLGVlR4WPcuOgN3OEL0tJLT1H4IU/dv7w==",
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.1.tgz",
+      "integrity": "sha512-ee7xA+bTJLfjB9BP/8FQr3EkxmpAAGc1lNc5QkWgTDpUw24HYXFPm7FEWRdLtGnygxIdYpFmepSc5VjkI6NHhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.8.0",
-        "@firebase/analytics": "0.10.19",
-        "@firebase/analytics-compat": "0.2.25",
-        "@firebase/app": "0.14.8",
-        "@firebase/app-check": "0.11.0",
-        "@firebase/app-check-compat": "0.4.0",
-        "@firebase/app-compat": "0.5.8",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.12.0",
-        "@firebase/auth-compat": "0.6.2",
-        "@firebase/data-connect": "0.3.12",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-compat": "2.1.0",
-        "@firebase/firestore": "4.11.0",
-        "@firebase/firestore-compat": "0.4.5",
-        "@firebase/functions": "0.13.1",
-        "@firebase/functions-compat": "0.4.1",
-        "@firebase/installations": "0.6.19",
-        "@firebase/installations-compat": "0.2.19",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/messaging-compat": "0.2.23",
-        "@firebase/performance": "0.7.9",
-        "@firebase/performance-compat": "0.2.22",
-        "@firebase/remote-config": "0.8.0",
-        "@firebase/remote-config-compat": "0.2.21",
-        "@firebase/storage": "0.14.0",
-        "@firebase/storage-compat": "0.4.0",
-        "@firebase/util": "1.13.0"
+        "@firebase/ai": "2.11.1",
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-compat": "0.2.27",
+        "@firebase/app": "0.14.11",
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-compat": "0.4.2",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-compat": "0.4.3",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-compat": "0.2.21",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/messaging-compat": "0.2.25",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-compat": "0.2.24",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-compat": "0.2.23",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-compat": "0.4.2",
+        "@firebase/util": "1.15.0"
       }
     },
     "node_modules/firebase-admin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@firebase/rules-unit-testing": "^5.0.0",
         "@types/dompurify": "^3.0.5",
         "firebase-admin": "^13.0.0",
+        "firebase-functions-test": "^3.4.1",
         "firebase-tools": "^15.0.0",
         "terser": "^5.44.1",
         "typescript": "^5.9.3",
@@ -103,6 +104,578 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -165,6 +738,43 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.3.16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2182,6 +2792,467 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2190,6 +3261,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -2562,6 +3645,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@npmcli/agent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
@@ -2688,6 +3785,20 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3149,6 +4260,14 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3160,6 +4279,28 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -3226,6 +4367,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -3243,6 +4457,28 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -3269,6 +4505,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3287,6 +4589,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -3294,6 +4603,14 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3311,6 +4628,22 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/request": {
       "version": "2.48.13",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
@@ -3324,6 +4657,50 @@
         "@types/tough-cookie": "*",
         "form-data": "^2.5.5"
       }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -3346,6 +4723,345 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
@@ -3884,6 +5600,110 @@
         }
       }
     },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4004,6 +5824,20 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -4195,6 +6029,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -4408,6 +6288,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4420,6 +6311,28 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4507,6 +6420,14 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cjson": {
       "version": "0.3.3",
@@ -4672,6 +6593,26 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/color": {
       "version": "5.0.3",
@@ -5047,6 +6988,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -5244,6 +7193,22 @@
         }
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-equal-in-any-order": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.2.0.tgz",
@@ -5277,6 +7242,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -5335,6 +7311,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -5431,6 +7418,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5493,6 +7502,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -5618,6 +7638,17 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -5755,6 +7786,39 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/exegesis": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/exegesis/-/exegesis-4.3.0.tgz",
@@ -5843,6 +7907,36 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -5977,6 +8071,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -6043,6 +8145,17 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/fdir": {
@@ -6153,6 +8266,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/firebase": {
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.9.0.tgz",
@@ -6213,6 +8341,64 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/firebase-functions": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/cors": "^2.8.5",
+        "@types/express": "^4.17.21",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "protobufjs": "^7.2.2"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/firebase-functions-test": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-3.4.1.tgz",
+      "integrity": "sha512-qAq0oszrBGdf4bnCF6t4FoSgMsepeIXh0Pi/FhikSE6e+TvKKGpfrfUP/5pFjJZxFcLsweoau88KydCql4xSeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.14.104",
+        "lodash": "^4.17.5",
+        "ts-deepmerge": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+        "firebase-functions": ">=4.9.0",
+        "jest": ">=28.0.0"
       }
     },
     "node_modules/firebase-tools": {
@@ -6588,6 +8774,14 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6711,6 +8905,17 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6745,6 +8950,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6757,6 +8973,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-uri": {
@@ -7253,6 +9483,14 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -7332,6 +9570,17 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -7396,6 +9645,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7412,6 +9682,19 @@
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -7472,6 +9755,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7522,6 +9813,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -7721,6 +10023,99 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -7735,6 +10130,689 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jju": {
@@ -7766,6 +10844,14 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
@@ -7780,6 +10866,20 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -7789,6 +10889,14 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-helpfulerror": {
       "version": "1.0.3",
@@ -7821,6 +10929,20 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -7996,6 +11118,28 @@
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
       "dev": true
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lodash": {
       "version": "4.18.1",
@@ -8265,6 +11409,17 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.4",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
@@ -8306,6 +11461,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -8627,6 +11790,31 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/nearley": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
@@ -8803,6 +11991,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/nopt": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
@@ -8883,6 +12087,20 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -9061,6 +12279,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
@@ -9086,6 +12335,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -9143,6 +12403,26 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -9177,6 +12457,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
@@ -9192,6 +12483,17 @@
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -9374,6 +12676,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -9382,6 +12695,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/portfinder": {
@@ -9468,6 +12795,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proc-log": {
@@ -9637,6 +12994,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -9736,6 +13111,14 @@
         "nan": "^2.25.0",
         "node-gyp": "^12.2.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -9844,6 +13227,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/restore-cursor": {
@@ -10275,6 +13683,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -10419,6 +13838,20 @@
         "node": "*"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10499,6 +13932,21 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10553,6 +14001,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -10692,6 +14162,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tar": {
@@ -10863,6 +14350,71 @@
         "node": ">=10"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -11001,6 +14553,14 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11061,6 +14621,13 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-deepmerge": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-2.0.7.tgz",
+      "integrity": "sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -11119,6 +14686,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -11273,6 +14851,74 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/update-notifier-cjs": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz",
@@ -11352,6 +14998,22 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/valid-url": {
       "version": "1.0.9",
@@ -11530,6 +15192,17 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/wcwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "marked": "^17.0.4"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^5.0.0",
         "@types/dompurify": "^3.0.5",
         "firebase-admin": "^13.0.0",
         "firebase-tools": "^15.0.0",
@@ -1157,6 +1158,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
       "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.0.tgz",
+      "integrity": "sha512-C6+d3Msgjnqay2ml663ChvKYoD8VsQ+TIa0e+fGq0LFC0CKSPlacT1EVGL/ryo6Rc+wFs7Fpqz3fRlYdUEa2bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -9,17 +9,19 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "firebase emulators:exec --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data 'VITE_USE_EMULATOR=true vite'",
+    "dev:prod": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "deploy": "npm run build && firebase deploy --only hosting,firestore:rules",
+    "deploy": "npm run build && firebase deploy --only hosting,firestore:rules,firestore:indexes,functions",
     "deploy:hosting": "npm run build && firebase deploy --only hosting",
     "deploy:rules": "firebase deploy --only firestore:rules",
+    "deploy:functions": "firebase deploy --only functions",
     "deploy:preview": "npm run build && firebase hosting:channel:deploy preview",
     "deploy:rules:dryrun": "firebase deploy --only firestore:rules --dry-run",
-    "emulators": "firebase emulators:start --only auth,firestore,functions",
+    "emulators": "firebase emulators:start --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data",
     "set-role": "node scripts/set-role.js",
     "grant-admin": "node scripts/grant-admin.js",
     "test": "vitest run",
@@ -40,7 +42,7 @@
   },
   "dependencies": {
     "dompurify": "^3.3.2",
-    "firebase": "^12.9.0",
+    "firebase": "^12.12.1",
     "marked": "^17.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "deploy:rules:dryrun": "firebase deploy --only firestore:rules --dry-run",
     "emulators": "firebase emulators:start --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data",
     "set-role": "node scripts/set-role.js",
+    "set-role:emulator": "FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=citl-baed2 node scripts/set-role.js",
     "grant-admin": "node scripts/grant-admin.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:rules": "firebase emulators:exec --only firestore --project citl-rules-test 'vitest run --config tests/rules/vitest.config.ts'",
-    "test:functions": "firebase emulators:exec --only auth,firestore,functions --project citl-baed2 'vitest run --config tests/functions/vitest.config.ts'"
+    "test:functions": "firebase emulators:exec --only auth,firestore --project citl-fn-test 'vitest run --config tests/functions/vitest.config.ts'"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.0",
     "@types/dompurify": "^3.0.5",
     "firebase-admin": "^13.0.0",
+    "firebase-functions-test": "^3.4.1",
     "firebase-tools": "^15.0.0",
     "terser": "^5.44.1",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy:preview": "npm run build && firebase hosting:channel:deploy preview",
     "deploy:rules:dryrun": "firebase deploy --only firestore:rules --dry-run",
     "emulators": "firebase emulators:start --only auth,firestore,functions",
+    "set-role": "node scripts/set-role.js",
     "grant-admin": "node scripts/grant-admin.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,16 @@
     "deploy:hosting": "npm run build && firebase deploy --only hosting",
     "deploy:rules": "firebase deploy --only firestore:rules",
     "deploy:preview": "npm run build && firebase hosting:channel:deploy preview",
+    "deploy:rules:dryrun": "firebase deploy --only firestore:rules --dry-run",
+    "emulators": "firebase emulators:start --only auth,firestore,functions",
     "grant-admin": "node scripts/grant-admin.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:rules": "firebase emulators:exec --only firestore --project citl-rules-test 'vitest run --config tests/rules/vitest.config.ts'",
+    "test:functions": "firebase emulators:exec --only auth,firestore,functions --project citl-baed2 'vitest run --config tests/functions/vitest.config.ts'"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.0",
     "@types/dompurify": "^3.0.5",
     "firebase-admin": "^13.0.0",
     "firebase-tools": "^15.0.0",

--- a/scripts/grant-admin.js
+++ b/scripts/grant-admin.js
@@ -1,41 +1,38 @@
+#!/usr/bin/env node
 /**
- * grant-admin.js — Firebase Admin SDK utility for managing admin custom claims
+ * grant-admin.js — DEPRECATED shim. Use scripts/set-role.js instead.
  *
- * Uses Application Default Credentials (ADC) — no key file required.
- *
- * One-time setup:
- *   gcloud auth application-default login
- *
- * Usage:
- *   node scripts/grant-admin.js grant user@example.com
- *   node scripts/grant-admin.js revoke user@example.com
- *
- * Required IAM role on your Google account: Firebase Authentication Admin
+ * Behavior change: the old grant-admin.js wrote a boolean
+ * `admin: true` custom claim. The new RBAC model uses
+ * `role: 'owner' | 'admin' | 'user'` and additionally maintains a
+ * Firestore mirror + audit log. This shim delegates to set-role.js so
+ * old invocations continue to work while emitting a deprecation
+ * warning. It will be removed in a future release.
  */
 
-import { initializeApp } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
+import { spawn } from 'node:child_process';
 
-const [,, action, email] = process.argv;
+const [, , action, email] = process.argv;
+
+console.warn(
+  '\n[DEPRECATED] scripts/grant-admin.js — use scripts/set-role.js:\n' +
+    '  node scripts/set-role.js set <email> admin     # promote to admin\n' +
+    '  node scripts/set-role.js set <email> user      # demote to user\n' +
+    '  node scripts/set-role.js list                  # list all users\n' +
+    '\nNote: this script now writes role=<value> + Firestore mirror + audit\n' +
+    'log, instead of the old admin:true boolean claim. The legacy claim is\n' +
+    'no longer honored by Firestore rules.\n',
+);
 
 if (!action || !email || !['grant', 'revoke'].includes(action)) {
   console.error('Usage: node scripts/grant-admin.js <grant|revoke> <email>');
   process.exit(1);
 }
 
-initializeApp({ projectId: 'citl-baed2' });
-
-const adminAuth = getAuth();
-
-try {
-  const user = await adminAuth.getUserByEmail(email);
-  const newClaims = action === 'grant' ? { admin: true } : { admin: false };
-
-  await adminAuth.setCustomUserClaims(user.uid, newClaims);
-
-  const verb = action === 'grant' ? 'Granted' : 'Revoked';
-  console.log(`${verb} admin claim for ${email} (uid: ${user.uid})`);
-} catch (error) {
-  console.error('Error:', error.message);
-  process.exit(1);
-}
+const role = action === 'grant' ? 'admin' : 'user';
+const child = spawn(
+  process.execPath,
+  ['scripts/set-role.js', 'set', email, role],
+  { stdio: 'inherit' },
+);
+child.on('exit', (code) => process.exit(code ?? 1));

--- a/scripts/set-role.js
+++ b/scripts/set-role.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * set-role.js — Multi-role Firebase Admin SDK CLI for managing the
+ * `role` custom claim + `users/{uid}` mirror + `audit/` log.
+ *
+ * Mirrors the safety machinery of the setUserRole Cloud Function:
+ *   - Claim-first ordering inside a Firestore transaction (see
+ *     .specs/features/002-multi-user-rbac/spec.md §VI Design Decisions)
+ *   - Last-owner guard — refuses to demote the only `owner`
+ *   - Append-only audit entry (actorUid: 'cli')
+ *
+ * Auth: gcloud Application Default Credentials. No service-account key.
+ *   One-time setup: gcloud auth application-default login
+ *
+ * Usage:
+ *   node scripts/set-role.js set <email> <role>    Promote/demote
+ *   node scripts/set-role.js revoke <email>        Alias for `set <email> user`
+ *   node scripts/set-role.js list                  List users + roles
+ *
+ * Roles: owner | admin | user
+ *
+ * Env:
+ *   DRY_RUN=1                          Print plan without writing
+ *   FIREBASE_AUTH_EMULATOR_HOST + FIRESTORE_EMULATOR_HOST
+ *                                      Run against the local emulator
+ *
+ * Required IAM role on your Google account (production):
+ *   Firebase Authentication Admin
+ */
+
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+const PROJECT_ID = 'citl-baed2';
+const ROLES = ['owner', 'admin', 'user'];
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+initializeApp({ projectId: PROJECT_ID });
+const auth = getAuth();
+const db = getFirestore();
+
+function usage(message) {
+  if (message) console.error(`Error: ${message}\n`);
+  console.error(`Usage:
+  node scripts/set-role.js set <email> <role>    Set a user's role
+  node scripts/set-role.js revoke <email>        Demote to user
+  node scripts/set-role.js list                  List all users + roles
+
+Roles: ${ROLES.join(' | ')}
+
+Env:
+  DRY_RUN=1                          Print plan without writing
+  FIREBASE_AUTH_EMULATOR_HOST=...    Use auth emulator
+  FIRESTORE_EMULATOR_HOST=...        Use firestore emulator
+
+One-time setup: gcloud auth application-default login`);
+  process.exit(1);
+}
+
+function fmtDate(ts) {
+  if (!ts) return 'never';
+  const d = typeof ts.toDate === 'function' ? ts.toDate() : new Date(ts);
+  return d.toISOString().slice(0, 16).replace('T', ' ');
+}
+
+async function listCommand() {
+  const snap = await db.collection('users').orderBy('createdAt', 'desc').get();
+  if (snap.empty) {
+    console.log('(no users)');
+    return;
+  }
+  const rows = snap.docs.map((doc) => {
+    const d = doc.data();
+    return {
+      uid: doc.id,
+      email: d.email ?? '',
+      role: d.role ?? '(unset)',
+      lastSignIn: fmtDate(d.lastSignInAt),
+    };
+  });
+  const w = {
+    uid: Math.max(3, ...rows.map((r) => r.uid.length)),
+    email: Math.max(5, ...rows.map((r) => r.email.length)),
+    role: 8,
+  };
+  const header =
+    `${'uid'.padEnd(w.uid)}  ${'email'.padEnd(w.email)}  ${'role'.padEnd(w.role)}  lastSignInAt`;
+  console.log(header);
+  console.log('─'.repeat(header.length));
+  for (const r of rows) {
+    console.log(
+      `${r.uid.padEnd(w.uid)}  ${r.email.padEnd(w.email)}  ${r.role.padEnd(w.role)}  ${r.lastSignIn}`,
+    );
+  }
+  console.log(`\n${rows.length} user${rows.length === 1 ? '' : 's'}`);
+}
+
+async function setRoleCommand(email, newRole) {
+  if (!email) usage('missing <email>');
+  if (!newRole) usage('missing <role>');
+  if (!ROLES.includes(newRole)) {
+    usage(`invalid role "${newRole}" (must be one of: ${ROLES.join(', ')})`);
+  }
+
+  let user;
+  try {
+    user = await auth.getUserByEmail(email);
+  } catch (e) {
+    if (e.code === 'auth/user-not-found') {
+      console.error(`Error: no Firebase Auth user with email ${email}.`);
+      console.error(`The user must sign in to the app at least once before their role can be set.`);
+      process.exit(1);
+    }
+    throw e;
+  }
+
+  const userRef = db.doc(`users/${user.uid}`);
+  const initialSnap = await userRef.get();
+  const fromRole = initialSnap.exists ? (initialSnap.data().role ?? '(unset)') : '(no mirror)';
+
+  console.log('─── set-role ──────────────────────────────────────');
+  console.log(`project   : ${PROJECT_ID}`);
+  console.log(`target    : ${email}`);
+  console.log(`uid       : ${user.uid}`);
+  console.log(`from role : ${fromRole}`);
+  console.log(`to role   : ${newRole}`);
+  console.log(`dry run   : ${DRY_RUN ? 'YES (no writes)' : 'NO'}`);
+  console.log('───────────────────────────────────────────────────');
+
+  if (initialSnap.exists && initialSnap.data().role === newRole) {
+    console.log(`No change: ${email} already has role=${newRole}.`);
+    return;
+  }
+
+  if (DRY_RUN) {
+    console.log('DRY_RUN: would set custom claim, update mirror, and write audit entry.');
+    if (fromRole === 'owner' && newRole !== 'owner') {
+      console.log('DRY_RUN: would also enforce last-owner guard before demotion.');
+    }
+    return;
+  }
+
+  // Mirror the callable's claim-first ordering inside a TX. See
+  // setUserRole.ts header + spec §VI for the full reasoning.
+  await db.runTransaction(async (tx) => {
+    const userSnap = await tx.get(userRef);
+    const txFromRole = userSnap.exists ? (userSnap.data().role ?? null) : null;
+
+    if (txFromRole === 'owner' && newRole !== 'owner') {
+      const owners = await tx.get(db.collection('users').where('role', '==', 'owner'));
+      if (owners.size <= 1) {
+        throw new Error(
+          'Cannot demote the last owner. Promote another user to owner first.',
+        );
+      }
+    }
+
+    // Claim-first: if this throws, queued writes don't apply.
+    await auth.setCustomUserClaims(user.uid, { role: newRole });
+
+    if (userSnap.exists) {
+      tx.update(userRef, {
+        role: newRole,
+        roleChangedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    } else {
+      // Defensive: should normally exist (onUserCreate seeds it). Seed
+      // here if it's missing so the mirror+claim stay in sync.
+      tx.set(userRef, {
+        uid: user.uid,
+        email: user.email ?? email,
+        displayName: user.displayName ?? null,
+        photoURL: user.photoURL ?? null,
+        role: newRole,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        lastSignInAt: null,
+        roleChangedAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    tx.create(db.collection('audit').doc(), {
+      actorUid: 'cli',
+      targetUid: user.uid,
+      fromRole: txFromRole,
+      toRole: newRole,
+      at: FieldValue.serverTimestamp(),
+    });
+  });
+
+  console.log(`✓ set custom claim role=${newRole}`);
+  console.log(`✓ updated users/${user.uid}.role`);
+  console.log(`✓ wrote audit/{auto} (actorUid=cli)`);
+  console.log('───────────────────────────────────────────────────');
+  console.log(`Done. The user must sign out and back in (or wait up to`);
+  console.log(`~1h) for the new token to reflect role=${newRole}.`);
+}
+
+async function main() {
+  const [, , subcommand, ...args] = process.argv;
+
+  switch (subcommand) {
+    case 'set':
+      await setRoleCommand(args[0], args[1]);
+      break;
+    case 'revoke':
+      await setRoleCommand(args[0], 'user');
+      break;
+    case 'list':
+      await listCommand();
+      break;
+    default:
+      usage(subcommand ? `unknown subcommand "${subcommand}"` : null);
+  }
+}
+
+try {
+  await main();
+} catch (e) {
+  console.error(`\nError: ${e.message ?? e}`);
+  process.exit(1);
+}

--- a/src/components/admin-panel.ts
+++ b/src/components/admin-panel.ts
@@ -1,73 +1,54 @@
 /**
- * admin-panel — Custom Element
+ * <admin-panel> — Custom Element
  *
- * Two-tab admin portal:
- *   - Team Management: team list with inline name/captain editing, roster editor
- *   - Score Entry: enter weekly scores, publish results
+ * Thin shell that owns the year selector, the tab strip, and shared
+ * data caches (teams, season, name suggestions). Delegates each tab's
+ * rendering and behavior to a tab module under `./admin-tabs/`.
  *
- * Primary storage: Firestore via ScoreService (requires auth).
+ * Tabs:
+ *   - Team Management — team list with inline editing + roster modal
+ *   - Score Entry     — weekly entry form, date override, publish
+ *   - Announcements   — site banner + per-year announcements
+ *   - Users           — hosts <admin-users-panel> (owner-only dropdown)
+ *
  * No shadow DOM. All user values rendered via textContent (never innerHTML),
- * except static SVG icon markup.
+ * except static SVG icon markup defined in `admin-tabs/admin-shared.ts`.
  */
 
+import './admin-users-panel';
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
-import { showToast } from '@/modules/ui';
 import { normalizeShooterName } from '@/services/scoring-engine';
-import { computeSchedule } from '@/utils/schedule';
 import type { Team } from '@/types/score';
-import type { Shooter } from '@/types/shooter';
 import type { Season } from '@/types/season';
+import { buildOptions } from './admin-tabs/admin-shared';
+import { TeamManagementTab } from './admin-tabs/team-management-tab';
+import { ScoreEntryTab } from './admin-tabs/score-entry-tab';
+import { AnnouncementsTab } from './admin-tabs/announcements-tab';
+import type { AdminTab, AdminTabContext } from './admin-tabs/types';
 
 const factory = createRepositoryFactory({ db });
 const scoreService = new ScoreService(factory.getScoreRepository());
 
 const CURRENT_YEAR = new Date().getFullYear();
-const MAX_WEEKS = 15;
-const MAX_SCORE = 25;
 
-// Sentinel value used to indicate an "add new team" row is open
-const NEW_TEAM_SENTINEL = '__new__';
-
-const PENCIL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="16 3 21 8 8 21 3 21 3 16 16 3"/></svg>`;
-const TRASH_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/></svg>`;
-const ROSTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 512 512" aria-hidden="true"><path fill="currentColor" d="M40 48C26.7 48 16 58.7 16 72v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V72c0-13.3-10.7-24-24-24H40zm152 16c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zM16 232v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V232c0-13.3-10.7-24-24-24H40c-13.3 0-24 10.7-24 24zM40 368c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V392c0-13.3-10.7-24-24-24H40z"/></svg>`;
-const LOCK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
-const WARN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>`;
-
-function buildOptions(min: number, max: number, label: string, selected: number): string {
-  let html = '';
-  for (let i = min; i <= max; i++) {
-    html += `<option value="${i}"${i === selected ? ' selected' : ''}>${label ? `${label} ${i}` : i}</option>`;
-  }
-  return html;
-}
+type TabName = 'team-mgmt' | 'score-entry' | 'announcements' | 'users';
 
 class AdminPanel extends HTMLElement {
   private _teamsData: Team[] | null = null;
   private _seasonData: Season | null = null;
-  private _rosterOriginalShooters: Shooter[] = [];
-  /** null = no edit open; NEW_TEAM_SENTINEL = add row open; else = teamId being edited */
-  private _editingTeamId: string | null = null;
-  /** Shooter names removed from roster DOM but not yet written to Firestore */
-  private _pendingRemovals: string[] = [];
-  /** Whether the date override card is in edit mode */
-  private _dateEditMode = false;
-  /** Whether any entries have been saved for the currently selected week */
-  private _weekHasScores = false;
-  /** null = not editing; else = announcement id being edited */
-  private _editingAnnouncementId: string | null = null;
-  private _bannerLoaded = false;
   private _shooterNameCache: { year: number; names: string[] } | null = null;
   private _teamNameCache: { year: number; names: string[] } | null = null;
 
-  // ── Roster modal state ────────────────────────────────────────────────────
-  private _rosterDialog: HTMLDialogElement | null = null;
-  private _rosterTbody: HTMLTableSectionElement | null = null;
-  private _rosterSaveBtn: HTMLButtonElement | null = null;
-  private _rosterStatusEl: Element | null = null;
-  private _rosterTeamId: string = '';
+  private readonly _teamMgmtTab = new TeamManagementTab(scoreService);
+  private readonly _scoreEntryTab = new ScoreEntryTab(scoreService);
+  private readonly _announcementsTab = new AnnouncementsTab(scoreService);
+
+  /** All tabs that implement the AdminTab lifecycle (excludes self-managed Users tab). */
+  private get _lifecycleTabs(): AdminTab[] {
+    return [this._teamMgmtTab, this._scoreEntryTab, this._announcementsTab];
+  }
 
   connectedCallback(): void {
     this.innerHTML = `
@@ -76,6 +57,7 @@ class AdminPanel extends HTMLElement {
           <button class="admin-tab-btn is-active" data-tab="team-mgmt">Team Management</button>
           <button class="admin-tab-btn" data-tab="score-entry">Score Entry</button>
           <button class="admin-tab-btn" data-tab="announcements">Announcements</button>
+          <button class="admin-tab-btn" data-tab="users">Users</button>
         </div>
 
         <div class="admin-form-row">
@@ -83,153 +65,40 @@ class AdminPanel extends HTMLElement {
           <select id="ap-year">${buildOptions(2019, 2030, '', CURRENT_YEAR)}</select>
         </div>
 
-        <!-- ── Team Management Panel ── -->
-        <div id="ap-panel-team-mgmt" class="admin-tab-content">
-
-          <div id="ap-team-list"></div>
-
-        </div>
-
-        <!-- ── Score Entry Panel ── -->
-        <div id="ap-panel-score-entry" class="admin-tab-content admin-tab-panel--hidden">
-
-          <div class="admin-form-row">
-            <label for="ap-week">Week</label>
-            <select id="ap-week">${buildOptions(1, MAX_WEEKS, 'Week', 1)}</select>
-            <label for="ap-team">Team</label>
-            <select id="ap-team">
-              <option value="">-- Select team --</option>
-            </select>
-          </div>
-
-          <div id="ap-date-section"></div>
-
-          <h3>Shooters</h3>
-          <div class="admin-table-wrapper">
-            <table class="admin-shooters-table">
-              <thead>
-                <tr><th>Name</th><th>Score 1 (0–25)</th><th>Score 2 (0–25)</th><th>Total</th><th></th></tr>
-              </thead>
-              <tbody id="ap-shooters-body"></tbody>
-            </table>
-          </div>
-          <div class="admin-actions">
-            <button id="ap-save" class="btn-primary">Save Entry</button>
-            <span class="tooltip-icon" tabindex="0" role="img" aria-label="Save Entry help"
-              data-tooltip="Stores this team's scores as a draft. You can re-save to overwrite.">?</span>
-          </div>
-          <p id="ap-status" class="admin-status" aria-live="polite"></p>
-          <p class="admin-publish-note">
-            Save stores a draft for this team. Repeat for each team, then Publish when all entries are in.
-          </p>
-
-          <h3>Saved Entries</h3>
-          <ul id="ap-saved-list" class="admin-saved-list"></ul>
-
-          <div class="admin-publish-section">
-            <h3>Publish</h3>
-            <p class="admin-publish-note">Publishing runs the scoring engine over all saved entries and writes computed results to Firestore.</p>
-            <div class="admin-actions">
-              <button id="ap-publish" class="btn-danger">Publish Week</button>
-              <span class="tooltip-icon" tabindex="0" role="img" aria-label="Publish Week help"
-                data-tooltip="Runs the scoring engine over all saved entries and updates live standings. Cannot be undone.">?</span>
-            </div>
-            <p id="ap-publish-status" class="admin-status" aria-live="polite"></p>
-          </div>
-
-        </div>
-
-        <!-- ── Announcements Panel ── -->
-        <div id="ap-panel-announcements" class="admin-tab-content admin-tab-panel--hidden">
-          <h3>Site Banner</h3>
-          <p class="admin-publish-note">
-            Displays a message to all visitors below the navigation bar. Clear the field and save to remove it.
-          </p>
-          <div class="banner-editor ann-editor">
-            <div class="ann-editor__field">
-              <label for="banner-msg">Banner message</label>
-              <textarea id="banner-msg" class="ann-editor__textarea" rows="3"
-                placeholder="e.g. Tonight&#39;s shoot is cancelled due to severe weather."></textarea>
-            </div>
-            <div class="ann-editor__actions">
-              <button id="banner-save-btn" class="btn-primary">Save Banner</button>
-              <button id="banner-clear-btn" class="btn-secondary">Clear Banner</button>
-            </div>
-            <p id="banner-status" class="admin-status" aria-live="polite"></p>
-          </div>
-          <hr class="admin-divider">
-          <h3>Announcements</h3>
-          <div class="ann-editor">
-            <div class="ann-editor__field">
-              <label for="ann-title">Title</label>
-              <input type="text" id="ann-title" class="ann-editor__input" placeholder="Announcement title" />
-            </div>
-            <div class="ann-editor__field">
-              <label for="ann-body">Message (Markdown)</label>
-              <textarea id="ann-body" class="ann-editor__textarea" rows="6"
-                placeholder="Write your announcement..."></textarea>
-            </div>
-            <div class="ann-editor__actions">
-              <button id="ann-post-btn" class="btn-primary">Post Announcement</button>
-              <button id="ann-cancel-btn" class="btn-secondary" style="display:none">Cancel Edit</button>
-            </div>
-            <p id="ann-status" class="admin-status" aria-live="polite"></p>
-          </div>
-          <div id="ann-list"></div>
+        <div id="ap-panel-team-mgmt" class="admin-tab-content"></div>
+        <div id="ap-panel-score-entry" class="admin-tab-content admin-tab-panel--hidden"></div>
+        <div id="ap-panel-announcements" class="admin-tab-content admin-tab-panel--hidden"></div>
+        <div id="ap-panel-users" class="admin-tab-content admin-tab-panel--hidden">
+          <admin-users-panel></admin-users-panel>
         </div>
       </div>`;
 
-    // Tab switching
+    const ctx = this._buildContext();
+    this._teamMgmtTab.mount(this.querySelector<HTMLElement>('#ap-panel-team-mgmt')!, ctx);
+    this._scoreEntryTab.mount(this.querySelector<HTMLElement>('#ap-panel-score-entry')!, ctx);
+    this._announcementsTab.mount(this.querySelector<HTMLElement>('#ap-panel-announcements')!, ctx);
+
     for (const btn of this.querySelectorAll<HTMLButtonElement>('.admin-tab-btn')) {
-      btn.addEventListener('click', () => this._switchTab(btn.dataset['tab'] ?? ''));
+      btn.addEventListener('click', () => this._switchTab((btn.dataset['tab'] ?? '') as TabName));
     }
 
-    // Shared year listener — reset any open edit when year changes
     this.querySelector('#ap-year')!.addEventListener('change', () => {
-      this._editingTeamId = null;
-      this._dateEditMode = false;
-      this._weekHasScores = false;
       this._shooterNameCache = null;
       this._teamNameCache = null;
-      void this._fetchTeamsData();
-      void this._fetchSeasonData();
-      void this._loadSavedEntries();
-      const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-      void this._getTeamNameSuggestions(year);
+      void this._refreshTeams();
+      void this._refreshSeason();
+      for (const tab of this._lifecycleTabs) tab.onYearChange?.();
+      void this._getTeamNameSuggestions(this._getYear());
     });
 
-    // Score entry listeners
-    this.querySelector('#ap-week')!.addEventListener('change', () => {
-      this._dateEditMode = false;
-      this._weekHasScores = false;
-      this._updateDateSection();
-      void this._populateShooterRows();
-      void this._loadSavedEntries();
-    });
-    this.querySelector('#ap-team')!.addEventListener('change', () => void this._populateShooterRows());
-    this.querySelector('#ap-save')!.addEventListener('click', () => void this._saveEntry());
-    this.querySelector('#ap-publish')!.addEventListener('click', () => void this._publishWeek());
-
-    // Banner listeners
-    this.querySelector('#banner-save-btn')!.addEventListener('click', () => void this._saveBanner());
-    this.querySelector('#banner-clear-btn')!.addEventListener('click', () => void this._clearBanner());
-
-    // Announcements listeners
-    this.querySelector('#ann-post-btn')!.addEventListener('click', () => {
-      if (this._editingAnnouncementId) void this._saveEditAnnouncement();
-      else void this._postAnnouncement();
-    });
-    this.querySelector('#ann-cancel-btn')!.addEventListener('click', () => this._clearAnnEditor());
-
-    void this._fetchTeamsData();
-    void this._fetchSeasonData();
-    void this._loadSavedEntries();
+    void this._refreshTeams();
+    void this._refreshSeason();
     void this._getTeamNameSuggestions(CURRENT_YEAR);
   }
 
   // ── Tab switching ────────────────────────────────────────────────────────
 
-  private _switchTab(tab: string): void {
+  private _switchTab(tab: TabName): void {
     for (const btn of this.querySelectorAll<HTMLButtonElement>('.admin-tab-btn')) {
       btn.classList.toggle('is-active', btn.dataset['tab'] === tab);
     }
@@ -237,1365 +106,39 @@ class AdminPanel extends HTMLElement {
       { id: 'ap-panel-team-mgmt', name: 'team-mgmt' },
       { id: 'ap-panel-score-entry', name: 'score-entry' },
       { id: 'ap-panel-announcements', name: 'announcements' },
+      { id: 'ap-panel-users', name: 'users' },
     ]) {
       const el = this.querySelector(`#${id}`);
       if (el) el.classList.toggle('admin-tab-panel--hidden', name !== tab);
     }
-    if (tab === 'score-entry') {
-      const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-      void this._getShooterSuggestions(year);
-    }
-    if (tab === 'announcements') {
-      void this._loadBannerTab();
-      void this._loadAnnouncementsTab();
-    }
+
+    if (tab === 'score-entry') this._scoreEntryTab.onActivate?.();
+    else if (tab === 'announcements') this._announcementsTab.onActivate?.();
   }
 
-  // ── Data loading ─────────────────────────────────────────────────────────
+  // ── Shared data refresh ──────────────────────────────────────────────────
 
-  private async _fetchTeamsData(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    this._pendingRemovals = [];
-    const result = await scoreService.getTeams(year);
+  private async _refreshTeams(): Promise<void> {
+    const result = await scoreService.getTeams(this._getYear());
     if (result.success) {
       this._teamsData = result.data;
     } else {
       console.warn('admin-panel: could not load teams data:', result.error);
       this._teamsData = [];
     }
-    this._renderTeamList();
-    this._populateTeamSelect('#ap-team');
-    void this._populateShooterRows();
+    for (const tab of this._lifecycleTabs) tab.onTeamsChanged?.();
   }
 
-  private _populateTeamSelect(selector: string): void {
-    const select = this.querySelector<HTMLSelectElement>(selector);
-    if (!select) return;
-    const teams = this._teamsData ?? [];
-
-    while (select.firstChild) select.removeChild(select.firstChild);
-
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = teams.length ? '-- Select team --' : 'No teams available for this year';
-    select.appendChild(placeholder);
-
-    for (const team of teams) {
-      const opt = document.createElement('option');
-      opt.value = team.id;
-      opt.textContent = team.name;
-      select.appendChild(opt);
-    }
-  }
-
-  // ── Team list with inline editing ─────────────────────────────────────────
-
-  private _renderTeamList(): void {
-    const container = this.querySelector('#ap-team-list');
-    if (!container) return;
-    while (container.firstChild) container.removeChild(container.firstChild);
-
-    const teams = this._teamsData ?? [];
-    const editing = this._editingTeamId;
-
-    // Section heading
-    const heading = document.createElement('h3');
-    heading.className = 'admin-team-heading';
-    heading.textContent = 'Teams';
-    container.appendChild(heading);
-
-    const hasRows = teams.length > 0 || editing === NEW_TEAM_SENTINEL;
-
-    if (hasRows) {
-      const table = document.createElement('table');
-      table.className = 'admin-team-table';
-
-      const thead = table.createTHead();
-      const hrow = thead.insertRow();
-      for (const label of ['Team Name', 'Captain', '']) {
-        const th = document.createElement('th');
-        th.textContent = label;
-        hrow.appendChild(th);
-      }
-
-      const tbody = table.createTBody();
-
-      for (const team of teams) {
-        const tr = tbody.insertRow();
-        if (editing === team.id) {
-          this._buildEditRow(tr, team.name, team.captain, team.id);
-        } else {
-          this._buildDisplayRow(tr, team.name, team.captain, team.id, editing !== null);
-        }
-      }
-
-      if (editing === NEW_TEAM_SENTINEL) {
-        const tr = tbody.insertRow();
-        this._buildEditRow(tr, '', '', NEW_TEAM_SENTINEL);
-      }
-
-      const tableWrapper = document.createElement('div');
-      tableWrapper.className = 'admin-table-wrapper';
-      tableWrapper.appendChild(table);
-      container.appendChild(tableWrapper);
-    } else {
-      const empty = document.createElement('p');
-      empty.className = 'admin-team-empty';
-      empty.textContent = 'No teams for this year. Click "+ Add Team" to create one.';
-      container.appendChild(empty);
-    }
-
-    // "+ Add Team" button — disabled while any edit is open
-    const addBtn = document.createElement('button');
-    addBtn.type = 'button';
-    addBtn.className = 'btn-secondary admin-add-team-btn';
-    addBtn.textContent = '+ Add Team';
-    addBtn.disabled = editing !== null;
-    addBtn.addEventListener('click', () => {
-      this._editingTeamId = NEW_TEAM_SENTINEL;
-      this._renderTeamList();
-      // Focus the name input after render
-      setTimeout(() => {
-        this.querySelector<HTMLInputElement>('.ap-team-edit-name')?.focus();
-      }, 0);
-    });
-    container.appendChild(addBtn);
-  }
-
-  private _buildDisplayRow(
-    tr: HTMLTableRowElement,
-    name: string,
-    captain: string,
-    teamId: string,
-    otherEditOpen: boolean,
-  ): void {
-    const nameCell = tr.insertCell();
-    nameCell.textContent = name;
-
-    const captainCell = tr.insertCell();
-    captainCell.textContent = captain;
-
-    const actionsCell = tr.insertCell();
-    actionsCell.className = 'admin-team-actions';
-
-    const pencilBtn = document.createElement('button');
-    pencilBtn.type = 'button';
-    pencilBtn.className = 'admin-icon-btn';
-    pencilBtn.setAttribute('aria-label', `Edit ${name}`);
-    pencilBtn.disabled = otherEditOpen;
-    pencilBtn.setAttribute('data-tooltip', 'Edit name & captain');
-    pencilBtn.innerHTML = PENCIL_SVG;
-    pencilBtn.addEventListener('click', () => {
-      this._editingTeamId = teamId;
-      this._renderTeamList();
-      setTimeout(() => {
-        this.querySelector<HTMLInputElement>('.ap-team-edit-name')?.focus();
-      }, 0);
-    });
-    actionsCell.appendChild(pencilBtn);
-
-    const rosterBtn = document.createElement('button');
-    rosterBtn.type = 'button';
-    rosterBtn.className = 'admin-icon-btn';
-    rosterBtn.setAttribute('aria-label', `Edit roster for ${name}`);
-    rosterBtn.disabled = otherEditOpen;
-    rosterBtn.setAttribute('data-tooltip', 'Edit roster');
-    rosterBtn.innerHTML = ROSTER_SVG;
-    rosterBtn.addEventListener('click', () => this._openRosterModal(teamId, name));
-    actionsCell.appendChild(rosterBtn);
-
-    const trashBtn = document.createElement('button');
-    trashBtn.type = 'button';
-    trashBtn.className = 'admin-icon-btn admin-icon-btn--danger';
-    trashBtn.setAttribute('aria-label', `Delete ${name}`);
-    trashBtn.disabled = otherEditOpen;
-    trashBtn.setAttribute('data-tooltip', 'Delete team');
-    trashBtn.innerHTML = TRASH_SVG;
-    trashBtn.addEventListener('click', () => {
-      const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-      void this._confirmDeleteTeam(year, teamId, name);
-    });
-    actionsCell.appendChild(trashBtn);
-  }
-
-  private _buildEditRow(
-    tr: HTMLTableRowElement,
-    name: string,
-    captain: string,
-    teamId: string,
-  ): void {
-    tr.className = 'admin-team-row--editing';
-
-    const nameCell = tr.insertCell();
-    const nameInput = document.createElement('input');
-    nameInput.type = 'text';
-    nameInput.className = 'admin-input ap-team-edit-name';
-    nameInput.value = name;
-    nameInput.placeholder = 'Team name';
-    nameInput.autocomplete = 'off';
-    nameCell.appendChild(nameInput);
-    this._attachAutocomplete(nameInput, () => this._getTeamNames());
-
-    const captainCell = tr.insertCell();
-    const captainInput = document.createElement('input');
-    captainInput.type = 'text';
-    captainInput.className = 'admin-input ap-team-edit-captain';
-    captainInput.value = captain;
-    captainInput.placeholder = 'Captain name';
-    captainInput.autocomplete = 'off';
-    captainCell.appendChild(captainInput);
-    this._attachAutocomplete(captainInput, () => this._getCurrentYearShooterNames());
-
-    const actionsCell = tr.insertCell();
-    actionsCell.className = 'admin-team-actions admin-team-actions--edit';
-
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'button';
-    saveBtn.className = 'btn-primary';
-    saveBtn.textContent = teamId === NEW_TEAM_SENTINEL ? 'Add' : 'Save';
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'btn-secondary';
-    cancelBtn.textContent = 'Cancel';
-
-    const setDisabled = (v: boolean) => {
-      saveBtn.disabled = v;
-      cancelBtn.disabled = v;
-      nameInput.disabled = v;
-      captainInput.disabled = v;
-    };
-
-    saveBtn.addEventListener('click', () => {
-      const n = nameInput.value.trim();
-      const c = captainInput.value.trim();
-      if (!n || (teamId !== NEW_TEAM_SENTINEL && !c)) {
-        showToast('error', 'Team name is required. Captain is required when editing.');
-        nameInput.focus();
-        return;
-      }
-      setDisabled(true);
-      if (teamId === NEW_TEAM_SENTINEL) {
-        void this._submitAddTeam(n, c, setDisabled);
-      } else {
-        void this._submitUpdateTeam(teamId, n, c, setDisabled);
-      }
-    });
-
-    // Allow Enter key to submit
-    const onEnter = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') saveBtn.click();
-    };
-    nameInput.addEventListener('keydown', onEnter);
-    captainInput.addEventListener('keydown', onEnter);
-
-    cancelBtn.addEventListener('click', () => {
-      this._editingTeamId = null;
-      this._renderTeamList();
-    });
-
-    actionsCell.appendChild(saveBtn);
-    actionsCell.appendChild(cancelBtn);
-  }
-
-  private async _submitAddTeam(
-    name: string,
-    captain: string,
-    setDisabled: (v: boolean) => void,
-  ): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const result = await scoreService.createTeam(year, name, captain);
-    setDisabled(false);
-
-    if (result.success) {
-      this._editingTeamId = null;
-      showToast('success', `Team "${result.data.name}" created for ${year}.`);
-      void this._fetchTeamsData();
-    } else {
-      showToast('error', `Failed to create team: ${result.error}`);
-    }
-  }
-
-  private async _submitUpdateTeam(
-    teamId: string,
-    name: string,
-    captain: string,
-    setDisabled: (v: boolean) => void,
-  ): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const result = await scoreService.updateTeamMeta(year, teamId, name, captain);
-    setDisabled(false);
-
-    if (result.success) {
-      this._editingTeamId = null;
-      showToast('success', `Team updated.`);
-      void this._fetchTeamsData();
-    } else {
-      showToast('error', `Failed to update team: ${result.error}`);
-    }
-  }
-
-  // ── Score Entry ──────────────────────────────────────────────────────────
-
-  private async _populateShooterRows(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
-    const teamId = this.querySelector<HTMLSelectElement>('#ap-team')?.value ?? '';
-    const tbody = this.querySelector('#ap-shooters-body');
-    if (!tbody) return;
-
-    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
-
-    // 1. Try to load existing saved entry first
-    if (teamId) {
-      const entryResult = await scoreService.getEntry(year, weekNumber, teamId);
-      if (entryResult.success && entryResult.data !== null) {
-        const team = this._teamsData?.find((t) => t.id === teamId);
-        const rosterNames = team ? new Set(team.shooters.map((s) => s.name)) : null;
-        const entryNames = new Set(entryResult.data.shooters.map((s) => s.name));
-        for (const s of entryResult.data.shooters) {
-          // Skip shooters who have since been removed from the roster
-          if (rosterNames && !rosterNames.has(s.name)) continue;
-          this._addShooterRow(s.name, s.score1 ?? undefined, s.score2 ?? undefined);
-        }
-        // Add any roster members not yet in the saved entry
-        if (team) {
-          for (const shooter of team.shooters) {
-            if (!entryNames.has(shooter.name)) this._addShooterRow(shooter.name);
-          }
-        }
-        return;
-      }
-    }
-
-    // 2. Fall back to roster
-    const team = this._teamsData?.find((t) => t.id === teamId);
-    if (team) {
-      for (const shooter of team.shooters) this._addShooterRow(shooter.name);
-    }
-    // no-team-selected branch: leave tbody empty (user must select a team)
-  }
-
-  private _addShooterRow(prefilledName = '', score1?: number, score2?: number): void {
-    const tbody = this.querySelector('#ap-shooters-body');
-    if (!tbody) return;
-    const row = document.createElement('tr');
-    row.className = 'ap-shooter-row';
-    if (prefilledName) row.dataset['name'] = prefilledName;
-
-    const nameCell = document.createElement('td');
-    if (prefilledName) {
-      nameCell.textContent = prefilledName;
-      nameCell.className = 'ap-shooter-name-cell';
-    } else {
-      const nameInput = document.createElement('input');
-      nameInput.type = 'text';
-      nameInput.className = 'ap-shooter-name';
-      nameInput.placeholder = 'Shooter name';
-      nameInput.autocomplete = 'off';
-      nameCell.appendChild(nameInput);
-      this._attachAutocomplete(nameInput, () => this._shooterNameCache?.names ?? []);
-    }
-
-    const s1 = this._scoreInput();
-    const s2 = this._scoreInput();
-
-    if (score1 !== undefined) s1.value = String(score1);
-    if (score2 !== undefined) s2.value = String(score2);
-
-    const totalCell = document.createElement('td');
-    totalCell.className = 'ap-shooter-total';
-
-    const updateTotal = () => {
-      const v1 = parseInt(s1.value, 10);
-      const v2 = parseInt(s2.value, 10);
-      totalCell.textContent = (!isNaN(v1) && !isNaN(v2)) ? String(v1 + v2) : '—';
-    };
-    s1.addEventListener('input', updateTotal);
-    s2.addEventListener('input', updateTotal);
-    updateTotal();
-
-    const td = (child: HTMLElement) => {
-      const c = document.createElement('td');
-      c.appendChild(child);
-      return c;
-    };
-    row.appendChild(nameCell);
-    row.appendChild(td(s1));
-    row.appendChild(td(s2));
-    row.appendChild(totalCell);
-    if (!prefilledName) {
-      const removeBtn = document.createElement('button');
-      removeBtn.type = 'button';
-      removeBtn.textContent = '✕';
-      removeBtn.className = 'ap-remove-shooter';
-      removeBtn.addEventListener('click', () => tbody.removeChild(row));
-      row.appendChild(td(removeBtn));
-    } else {
-      row.appendChild(document.createElement('td')); // keep column alignment
-    }
-    tbody.appendChild(row);
-  }
-
-  private _scoreInput(): HTMLInputElement {
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.min = '0';
-    input.max = String(MAX_SCORE);
-    input.className = 'ap-score-input';
-    return input;
-  }
-
-  private async _saveEntry(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
-    const teamSelect = this.querySelector<HTMLSelectElement>('#ap-team')!;
-    const teamName = teamSelect.options[teamSelect.selectedIndex]?.text ?? '';
-    const teamId = teamSelect.value;
-
-    if (!teamId) { this._setStatus('Team selection is required.', 'error'); return; }
-
-    const shooters: { name: string; score1: number; score2: number; total: number }[] = [];
-    for (const row of this.querySelectorAll('.ap-shooter-row')) {
-      const rowEl = row as HTMLElement;
-      const name = (rowEl.dataset['name'] ?? row.querySelector<HTMLInputElement>('.ap-shooter-name')?.value ?? '').trim();
-      const inputs = row.querySelectorAll<HTMLInputElement>('.ap-score-input');
-      const score1Raw = inputs[0]?.value ?? '';
-      const score2Raw = inputs[1]?.value ?? '';
-
-      // Both inputs empty → shooter did not shoot; exclude from entry (stays null in scoring engine)
-      if (score1Raw === '' && score2Raw === '') continue;
-      if (!name) { this._setStatus('All shooter rows must have a name.', 'error'); return; }
-
-      const score1 = score1Raw !== '' ? parseInt(score1Raw, 10) : 0;
-      const score2 = score2Raw !== '' ? parseInt(score2Raw, 10) : 0;
-      if (isNaN(score1) || score1 < 0 || score1 > MAX_SCORE) {
-        this._setStatus(`Score 1 for "${name}" must be 0–${MAX_SCORE}.`, 'error'); return;
-      }
-      if (isNaN(score2) || score2 < 0 || score2 > MAX_SCORE) {
-        this._setStatus(`Score 2 for "${name}" must be 0–${MAX_SCORE}.`, 'error'); return;
-      }
-      shooters.push({ name, score1, score2, total: score1 + score2 });
-    }
-
-    if (shooters.length === 0) {
-      this._setStatus('At least one shooter with valid scores is required.', 'error'); return;
-    }
-
-    this._setStatus('', '');
-
-    const entry = {
-      year,
-      weekNumber,
-      teamId,
-      teamName,
-      savedAt: new Date().toISOString(),
-      shooters,
-    };
-
-    const result = await scoreService.saveEntry(year, entry);
-    if (result.success) {
-      showToast('success', `Entry saved — ${teamName}, Week ${weekNumber}.`);
-    } else {
-      showToast('error', `Failed to save entry: ${result.error}`);
-    }
-
-    void this._loadSavedEntries();
-  }
-
-  private async _loadSavedEntries(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')?.value ?? '0', 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')?.value ?? '0', 10);
-    const list = this.querySelector('#ap-saved-list');
-    if (!list) return;
-
-    while (list.firstChild) list.removeChild(list.firstChild);
-
-    const result = await scoreService.getEntries(year, weekNumber);
-
-    if (!result.success) {
-      console.warn('admin-panel: could not load entries:', result.error);
-      const li = document.createElement('li');
-      li.textContent = 'No entries for this season/week for this team.';
-      list.appendChild(li);
-      return;
-    }
-
-    const entries = result.data.filter((e) => e.weekNumber === weekNumber);
-
-    // Update score-presence flag and re-render the date card (locking state may have changed)
-    this._weekHasScores = entries.length > 0;
-    this._updateDateSection();
-
-    if (entries.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'No entries saved for this year/week.';
-      list.appendChild(li);
-      return;
-    }
-
-    for (const entry of entries) {
-      const li = document.createElement('li');
-      li.className = 'admin-saved-item';
-
-      const label = document.createElement('span');
-      label.className = 'admin-saved-key';
-      label.textContent = `${entry.teamName}`;
-
-      const detail = document.createElement('span');
-      detail.textContent = ` — ${entry.shooters?.length ?? 0} shooter(s), saved ${new Date(entry.savedAt).toLocaleString()}`;
-
-      li.appendChild(label);
-      li.appendChild(detail);
-      list.appendChild(li);
-    }
-  }
-
-  private async _publishWeek(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
-    const btn = this.querySelector<HTMLButtonElement>('#ap-publish')!;
-
-    btn.disabled = true;
-    this._setPublishStatus(`Publishing week ${weekNumber}…`, '');
-
-    const result = await scoreService.publishWeek(year, weekNumber);
-
-    btn.disabled = false;
-    this._setPublishStatus('', '');
-
-    if (result.success) {
-      showToast('success', `Week ${weekNumber} published — standings updated.`);
-    } else {
-      showToast('error', `Publish failed: ${result.error}`);
-    }
-  }
-
-  // ── Roster modal ─────────────────────────────────────────────────────────
-
-  private _openRosterModal(teamId: string, teamName: string): void {
-    this._pendingRemovals = [];
-    this._rosterOriginalShooters = [];
-    this._rosterTeamId = teamId;
-
-    // ── Build dialog ──────────────────────────────────────────────────────
-    const dialog = document.createElement('dialog');
-    dialog.className = 'roster-dialog';
-
-    // Header
-    const header = document.createElement('div');
-    header.className = 'roster-dialog__header';
-    const title = document.createElement('h2');
-    title.className = 'roster-dialog__title';
-    title.textContent = `Edit Roster — ${teamName}`;
-    header.appendChild(title);
-
-    // Roster table (reuses existing .admin-roster-table styles)
-    const table = document.createElement('table');
-    table.className = 'admin-roster-table';
-    const thead = table.createTHead();
-    const hrow = thead.insertRow();
-    for (const label of ['Name', 'W0 Avg', 'Rookie', '']) {
-      const th = document.createElement('th');
-      th.textContent = label;
-      hrow.appendChild(th);
-    }
-    const tbody = table.createTBody();
-    this._rosterTbody = tbody;
-
-    const tableWrapper = document.createElement('div');
-    tableWrapper.className = 'admin-table-wrapper';
-    tableWrapper.appendChild(table);
-
-    // Footer
-    const footer = document.createElement('div');
-    footer.className = 'roster-dialog__footer';
-
-    const addBtn = document.createElement('button');
-    addBtn.type = 'button';
-    addBtn.className = 'btn-secondary';
-    addBtn.textContent = 'Add Shooter';
-
-    const rightActions = document.createElement('div');
-    rightActions.className = 'admin-actions';
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'btn-secondary';
-    cancelBtn.textContent = 'Cancel';
-
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'button';
-    saveBtn.className = 'btn-primary';
-    saveBtn.textContent = 'Save Roster';
-    this._rosterSaveBtn = saveBtn;
-
-    rightActions.append(cancelBtn, saveBtn);
-    footer.append(addBtn, rightActions);
-
-    // Status
-    const statusEl = document.createElement('p');
-    statusEl.className = 'admin-status';
-    statusEl.setAttribute('aria-live', 'polite');
-    this._rosterStatusEl = statusEl;
-
-    dialog.append(header, tableWrapper, footer, statusEl);
-    document.body.appendChild(dialog);
-    this._rosterDialog = dialog;
-
-    // ── Wire events ───────────────────────────────────────────────────────
-    addBtn.addEventListener('click', () => this._addRosterRow());
-    cancelBtn.addEventListener('click', () => this._closeRosterModal());
-    saveBtn.addEventListener('click', () => void this._saveRoster());
-    dialog.addEventListener('cancel', () => this._closeRosterModal());
-
-    dialog.showModal();
-
-    // Prefetch shooter name suggestions for autocomplete
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    void this._getShooterSuggestions(year);
-
-    // ── Load roster data (async) ──────────────────────────────────────────
-    void this._loadRosterIntoModal(teamId);
-  }
-
-  private async _loadRosterIntoModal(teamId: string): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    this._setRosterStatus('Loading roster\u2026', 'info');
-
-    const result = await scoreService.computeRosterDefaults(year, teamId);
-    this._setRosterStatus('', '');
-
-    let team: Team;
-    if (result.success) {
-      team = result.data;
-    } else {
-      console.warn('computeRosterDefaults failed, using cached data:', result.error);
-      const fallback = this._teamsData?.find((t) => t.id === teamId);
-      if (!fallback) return;
-      team = fallback;
-    }
-
-    this._rosterOriginalShooters = [...team.shooters];
-    for (let i = 0; i < team.shooters.length; i++) {
-      this._addRosterRow(team.shooters[i], i);
-    }
-  }
-
-  private _closeRosterModal(): void {
-    if (this._rosterDialog) {
-      this._rosterDialog.close();
-      document.body.removeChild(this._rosterDialog);
-    }
-    this._rosterDialog = null;
-    this._rosterTbody = null;
-    this._rosterSaveBtn = null;
-    this._rosterStatusEl = null;
-    this._rosterTeamId = '';
-    this._pendingRemovals = [];
-  }
-
-  private _addRosterRow(shooter?: Shooter, originalIndex?: number): void {
-    const tbody = this._rosterTbody;
-    if (!tbody) return;
-
-    const row = document.createElement('tr');
-    row.className = 'ap-roster-row';
-    if (originalIndex !== undefined) {
-      row.dataset['originalIndex'] = String(originalIndex);
-    }
-
-    if (shooter !== undefined) {
-      row.dataset['startingAvg'] = String(shooter.startingAvg);
-      row.dataset['rookie'] = String(shooter.rookie);
-    } else {
-      // New shooter: league defaults
-      row.dataset['startingAvg'] = '35';
-      row.dataset['rookie'] = 'true';
-    }
-
-    const nameInput = document.createElement('input');
-    nameInput.type = 'text';
-    nameInput.className = 'ap-roster-name';
-    nameInput.placeholder = 'Shooter name';
-    nameInput.autocomplete = 'off';
-    if (shooter) nameInput.value = shooter.name;
-
-    const avgSpan = document.createElement('span');
-    avgSpan.className = 'ap-roster-avg-display';
-    const rookieSpan = document.createElement('span');
-    rookieSpan.className = 'ap-roster-rookie-display';
-
-    if (shooter !== undefined) {
-      avgSpan.textContent = String(shooter.startingAvg);
-      rookieSpan.textContent = shooter.rookie ? 'Yes' : 'No';
-    } else {
-      avgSpan.textContent = '—';
-      rookieSpan.textContent = '—';
-
-      nameInput.addEventListener('blur', () => {
-        const name = nameInput.value.trim();
-        if (!name) return;
-        const year = parseInt(
-          this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10,
-        );
-        avgSpan.textContent = '…';
-        rookieSpan.textContent = '…';
-        void scoreService.computeShooterDefaults(year, name).then((result) => {
-          if (!result.success) {
-            avgSpan.textContent = '35';
-            rookieSpan.textContent = 'Yes';
-            return;
-          }
-          // cross-team duplicate check
-          const currentTeamId = this._rosterTeamId;
-          const conflict = this._teamsData?.find(
-            (t) => t.id !== currentTeamId &&
-              t.shooters.some((s) => normalizeShooterName(s.name) === normalizeShooterName(name)),
-          );
-          if (conflict) {
-            showToast('error', `"${name}" is already on team "${conflict.name}".`);
-            nameInput.value = '';
-            avgSpan.textContent = '—';
-            rookieSpan.textContent = '—';
-            return;
-          }
-          row.dataset['startingAvg'] = String(result.data.startingAvg);
-          row.dataset['rookie']      = String(result.data.rookie);
-          avgSpan.textContent   = String(result.data.startingAvg);
-          rookieSpan.textContent = result.data.rookie ? 'Yes' : 'No';
-        });
-      });
-    }
-
-    const removeBtn = document.createElement('button');
-    removeBtn.type = 'button';
-    removeBtn.textContent = '✕';
-    removeBtn.className = 'ap-remove-shooter';
-    removeBtn.addEventListener('click', () => {
-      const name = nameInput.value.trim();
-      if (name && this._namedRosterCount() <= 5) {
-        this._setRosterStatus('Teams must have at least 5 shooters — cannot remove.', 'error');
-        return;
-      }
-      this._setRosterStatus('', '');
-      // Existing shooter with a name: defer cascade removal to Save Roster
-      if (originalIndex !== undefined && name) {
-        this._pendingRemovals.push(name);
-      }
-      tbody.removeChild(row);
-    });
-
-    const td = (child: HTMLElement) => {
-      const c = document.createElement('td');
-      c.appendChild(child);
-      return c;
-    };
-    row.appendChild(td(nameInput));
-    if (shooter === undefined) {
-      this._attachAutocomplete(nameInput, () => this._shooterNameCache?.names ?? []);
-    }
-    const avgCell = document.createElement('td');
-    avgCell.appendChild(avgSpan);
-    row.appendChild(avgCell);
-    const rookieCell = document.createElement('td');
-    rookieCell.appendChild(rookieSpan);
-    row.appendChild(rookieCell);
-    row.appendChild(td(removeBtn));
-    tbody.appendChild(row);
-  }
-
-  private async _saveRoster(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const teamId = this._rosterTeamId;
-
-    // Captain comes from team data; derive from first shooter row if blank
-    let captain = this._teamsData?.find((t) => t.id === teamId)?.captain ?? '';
-    if (!captain) {
-      captain = this._rosterTbody?.querySelector<HTMLInputElement>('.ap-roster-name')?.value.trim() ?? '';
-    }
-    if (!captain) {
-      this._setRosterStatus('Add at least one shooter to set a captain.', 'error');
-      return;
-    }
-
-    const shooters: Shooter[] = [];
-    for (const rowEl of (this._rosterTbody?.querySelectorAll<HTMLElement>('.ap-roster-row') ?? [])) {
-      const name = rowEl.querySelector<HTMLInputElement>('.ap-roster-name')!.value.trim();
-      if (!name) continue;
-
-      const startingAvgRaw = parseFloat(rowEl.dataset['startingAvg'] ?? '35');
-      const startingAvg = isNaN(startingAvgRaw) ? 35 : startingAvgRaw;
-      const rookie = rowEl.dataset['rookie'] === 'true';
-
-      const origIdxStr = rowEl.dataset['originalIndex'];
-      const origIdx = origIdxStr !== undefined ? parseInt(origIdxStr, 10) : NaN;
-      const original = !isNaN(origIdx) ? this._rosterOriginalShooters[origIdx] : undefined;
-
-      shooters.push({
-        id: original?.id ?? '',
-        name,
-        rookie,
-        startingAvg,
-        finalAvg: original?.finalAvg ?? null,
-        weeksShot: original?.weeksShot ?? null,
-        scores: original?.scores ?? [],
-      });
-    }
-
-    if (shooters.length < 5) {
-      this._setRosterStatus('A team must have at least 5 shooters.', 'error');
-      return;
-    }
-
-    this._setRosterStatus('', '');
-    const teamName = this._teamsData?.find((t) => t.id === teamId)?.name ?? teamId;
-    if (this._rosterSaveBtn) this._rosterSaveBtn.disabled = true;
-
-    // Process deferred shooter removals before saving
-    for (const name of this._pendingRemovals) {
-      await scoreService.removeShooterFromRoster(year, teamId, name);
-    }
-    this._pendingRemovals = [];
-
-    const result = await scoreService.saveTeamRoster(year, teamId, captain, shooters);
-    if (this._rosterSaveBtn) this._rosterSaveBtn.disabled = false;
-
-    if (result.success) {
-      showToast('success', `Roster saved — ${teamName}.`);
-      this._closeRosterModal();
-      void this._fetchTeamsData();
-    } else {
-      showToast('error', `Failed to save roster: ${result.error}`);
-    }
-  }
-
-  // ── Confirmation dialogs ─────────────────────────────────────────────────
-
-  private _showConfirmDialog(opts: {
-    title: string;
-    warning: string;
-    nameToType: string;
-    deleteLabel: string;
-  }): Promise<boolean> {
-    return new Promise((resolve) => {
-      const dialog = document.createElement('dialog');
-      dialog.className = 'confirm-dialog';
-
-      const h2 = document.createElement('h2');
-      h2.className = 'confirm-dialog__title';
-      h2.textContent = opts.title;
-
-      const warn = document.createElement('p');
-      warn.className = 'confirm-dialog__warning';
-      warn.textContent = opts.warning;
-
-      const instr = document.createElement('p');
-      instr.className = 'confirm-dialog__instruction';
-      const strong = document.createElement('strong');
-      strong.textContent = opts.nameToType;
-      instr.append('Type ', strong, ' to confirm:');
-
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.className = 'confirm-dialog__input admin-input';
-      input.autocomplete = 'off';
-      input.placeholder = opts.nameToType;
-      input.setAttribute('aria-label', 'Confirm by typing name');
-
-      const actions = document.createElement('div');
-      actions.className = 'confirm-dialog__actions';
-
-      const cancelBtn = document.createElement('button');
-      cancelBtn.type = 'button';
-      cancelBtn.className = 'btn-secondary';
-      cancelBtn.textContent = 'Cancel';
-
-      const deleteBtn = document.createElement('button');
-      deleteBtn.type = 'button';
-      deleteBtn.className = 'btn-danger';
-      deleteBtn.textContent = opts.deleteLabel;
-      deleteBtn.disabled = true;
-
-      input.addEventListener('input', () => {
-        deleteBtn.disabled = input.value.trim() !== opts.nameToType;
-      });
-
-      const finish = (confirmed: boolean) => {
-        dialog.close();
-        document.body.removeChild(dialog);
-        resolve(confirmed);
-      };
-
-      cancelBtn.addEventListener('click', () => finish(false));
-      deleteBtn.addEventListener('click', () => finish(true));
-      dialog.addEventListener('cancel', () => finish(false));
-
-      actions.appendChild(cancelBtn);
-      actions.appendChild(deleteBtn);
-      dialog.append(h2, warn, instr, input, actions);
-      document.body.appendChild(dialog);
-      dialog.showModal();
-      setTimeout(() => input.focus(), 0);
-    });
-  }
-
-  private async _confirmDeleteTeam(year: number, teamId: string, teamName: string): Promise<void> {
-    const confirmed = await this._showConfirmDialog({
-      title: 'Delete Team',
-      warning: `This will permanently remove "${teamName}" and all its score entries from the ${year} season. This cannot be undone.`,
-      nameToType: teamName,
-      deleteLabel: 'Delete Team',
-    });
-    if (!confirmed) return;
-
-    const result = await scoreService.deleteTeam(year, teamId);
-    if (result.success) {
-      showToast('success', `Team "${teamName}" deleted from ${year}.`);
-      void this._fetchTeamsData();
-    } else {
-      showToast('error', `Failed to delete team: ${result.error}`);
-    }
-  }
-
-  private async _confirmRemoveShooterRow(
-    row: HTMLElement,
-    tbody: Element,
-    shooterName: string,
-    year: number,
-    teamId: string,
-  ): Promise<void> {
-    const confirmed = await this._showConfirmDialog({
-      title: 'Remove Shooter',
-      warning: `This will permanently remove "${shooterName}" and all their saved score entries from the ${year} season. This cannot be undone.`,
-      nameToType: shooterName,
-      deleteLabel: 'Remove Shooter',
-    });
-    if (!confirmed) return;
-
-    const result = await scoreService.removeShooterFromRoster(year, teamId, shooterName);
-    if (result.success) {
-      tbody.removeChild(row);
-      showToast('success', `"${shooterName}" removed from roster.`);
-    } else {
-      showToast('error', `Failed to remove shooter: ${result.error}`);
-    }
-  }
-
-  // ── Roster helpers ───────────────────────────────────────────────────────
-
-  private _namedRosterCount(): number {
-    return [...(this._rosterTbody?.querySelectorAll<HTMLElement>('.ap-roster-row') ?? [])]
-      .filter((r) => Boolean(r.querySelector<HTMLInputElement>('.ap-roster-name')?.value.trim()))
-      .length;
-  }
-
-  // ── Date override ────────────────────────────────────────────────────────
-
-  private async _fetchSeasonData(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const result = await scoreService.getSeason(year);
+  private async _refreshSeason(): Promise<void> {
+    const result = await scoreService.getSeason(this._getYear());
     this._seasonData = (result.success ? result.data : null) ?? null;
-    this._updateDateSection();
+    for (const tab of this._lifecycleTabs) tab.onSeasonChanged?.();
   }
 
-  /**
-   * Rebuild the date override card. Called whenever week, year, season data,
-   * or entry presence changes. Manages all of: view mode, edit mode, locked state.
-   */
-  private _updateDateSection(): void {
-    const container = this.querySelector<HTMLElement>('#ap-date-section');
-    if (!container) return;
+  // ── Year + suggestion helpers ────────────────────────────────────────────
 
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')?.value ?? '0', 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')?.value ?? '1', 10);
-
-    // ── Compute state ──────────────────────────────────────────────────────
-    const overrides = this._seasonData?.weekDateOverrides ?? {};
-    const key = String(weekNumber);
-    const hasOverride = key in overrides;
-    const overrideValue = overrides[key]; // string | null | undefined
-
-    // Scheduled date from the league calendar
-    const shootEvents = computeSchedule(year).filter((e) => e.type === 'shoot');
-    const scheduledEvent = shootEvents.find((e) => e.week === weekNumber);
-    const scheduledDate = scheduledEvent?.date ?? null;
-
-    // Effective date for display + past check
-    let effectiveDate: Date | null;
-    let displayState: 'normal' | 'overridden' | 'cancelled';
-
-    if (hasOverride && overrideValue === null) {
-      displayState = 'cancelled';
-      effectiveDate = scheduledDate; // use original scheduled date for past check
-    } else if (hasOverride && typeof overrideValue === 'string') {
-      displayState = 'overridden';
-      effectiveDate = _parseLocalDate(overrideValue);
-    } else {
-      displayState = 'normal';
-      effectiveDate = scheduledDate;
-    }
-
-    // Lock if past or scores exist
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const isInPast = effectiveDate !== null && effectiveDate < today;
-    const isLocked = isInPast || this._weekHasScores;
-    const lockReason = isInPast
-      ? 'This date is in the past'
-      : this._weekHasScores
-        ? 'Scores have been entered for this week'
-        : '';
-
-    // Force back to view mode if we're now locked
-    if (isLocked && this._dateEditMode) this._dateEditMode = false;
-
-    // ── Format display date ────────────────────────────────────────────────
-    const formattedDate = effectiveDate !== null
-      ? effectiveDate.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
-      : '';
-
-    // ── Badge HTML ─────────────────────────────────────────────────────────
-    const badgeHtml = displayState === 'overridden'
-      ? `<span class="ap-date-badge">overridden</span>`
-      : displayState === 'cancelled'
-        ? `<span class="ap-date-badge ap-date-badge--cancelled">cancelled</span>`
-        : '';
-
-    // ── Date display text ──────────────────────────────────────────────────
-    const dateDisplayHtml = displayState === 'cancelled'
-      ? `<span class="ap-date-display ap-date-display--cancelled">CANCELLED</span>`
-      : `<span class="ap-date-display">${formattedDate || '—'}</span>`;
-
-    // ── View mode ──────────────────────────────────────────────────────────
-    const todayStr = _toInputDate(today);
-
-    if (!this._dateEditMode) {
-      const actionHtml = isLocked
-        ? `<span class="ap-date-lock" data-tooltip="${lockReason}">${LOCK_SVG} Locked</span>`
-        : `<button class="ap-date-edit-btn btn-secondary" id="ap-date-edit-btn">${PENCIL_SVG} Edit date</button>`;
-
-      container.innerHTML = `
-        <div class="ap-date-card">
-          <div class="ap-date-card__header">
-            <span class="ap-date-card__label">Shoot Date</span>
-            ${badgeHtml}
-          </div>
-          <div class="ap-date-card__body">
-            ${dateDisplayHtml}
-            ${actionHtml}
-          </div>
-        </div>`;
-
-      this.querySelector('#ap-date-edit-btn')
-        ?.addEventListener('click', () => {
-          this._dateEditMode = true;
-          this._updateDateSection();
-        });
-      return;
-    }
-
-    // ── Edit mode ──────────────────────────────────────────────────────────
-    // Pre-fill input: use override date or computed date
-    const inputValue = displayState === 'overridden' && typeof overrideValue === 'string'
-      ? overrideValue.substring(0, 10)
-      : scheduledDate !== null ? _toInputDate(scheduledDate) : '';
-
-    const cancelledChecked = displayState === 'cancelled' ? ' checked' : '';
-
-    container.innerHTML = `
-      <div class="ap-date-card ap-date-card--editing">
-        <div class="ap-date-card__header">
-          <span class="ap-date-card__label">Shoot Date</span>
-          ${badgeHtml}
-        </div>
-        <div class="ap-date-warning">
-          ${WARN_SVG}
-          <span>This overrides the scheduled shoot date on the season calendar and printed scoresheets.</span>
-        </div>
-        <div class="ap-date-edit-row">
-          <input type="date" id="ap-shoot-date" class="ap-date-input" value="${inputValue}" min="${todayStr}" />
-          <label class="ap-cancelled-label">
-            <input type="checkbox" id="ap-cancelled"${cancelledChecked} /> Cancelled
-          </label>
-        </div>
-        <div class="ap-date-edit-actions">
-          <button id="ap-cancel-date-edit" class="btn-secondary">Cancel</button>
-          <button id="ap-save-date" class="btn-primary">Save Date</button>
-        </div>
-      </div>`;
-
-    // Cancelled checkbox toggles the date input
-    const cancelledCb = this.querySelector<HTMLInputElement>('#ap-cancelled')!;
-    const dateInput = this.querySelector<HTMLInputElement>('#ap-shoot-date')!;
-    if (cancelledCb.checked) dateInput.disabled = true;
-
-    cancelledCb.addEventListener('change', () => {
-      dateInput.disabled = cancelledCb.checked;
-      if (cancelledCb.checked) dateInput.value = '';
-    });
-
-    this.querySelector('#ap-cancel-date-edit')?.addEventListener('click', () => {
-      this._dateEditMode = false;
-      this._updateDateSection();
-    });
-
-    this.querySelector('#ap-save-date')?.addEventListener('click', () => {
-      void this._saveDateOverride();
-    });
-  }
-
-  private async _saveDateOverride(): Promise<void> {
-    const year = parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-    const weekNumber = parseInt(this.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
-    const cancelledCb = this.querySelector<HTMLInputElement>('#ap-cancelled');
-    const dateInput = this.querySelector<HTMLInputElement>('#ap-shoot-date');
-    const saveBtn = this.querySelector<HTMLButtonElement>('#ap-save-date');
-    const cancelBtn = this.querySelector<HTMLButtonElement>('#ap-cancel-date-edit');
-
-    const isCancelled = cancelledCb?.checked ?? false;
-    const dateValue = dateInput?.value ?? '';
-
-    if (!isCancelled && !dateValue) {
-      showToast('error', 'Enter a date or check Cancelled.');
-      return;
-    }
-
-    if (saveBtn) saveBtn.disabled = true;
-    if (cancelBtn) cancelBtn.disabled = true;
-
-    const result = await scoreService.saveWeekDateOverride(
-      year,
-      weekNumber,
-      isCancelled ? null : dateValue,
-    );
-
-    if (result.success) {
-      this._dateEditMode = false;
-      showToast('success', isCancelled
-        ? `Week ${weekNumber} marked as cancelled.`
-        : `Shoot date for Week ${weekNumber} updated.`);
-      await this._fetchSeasonData(); // refreshes _seasonData and re-renders
-    } else {
-      if (saveBtn) saveBtn.disabled = false;
-      if (cancelBtn) cancelBtn.disabled = false;
-      showToast('error', `Failed to save date: ${result.error}`);
-    }
-  }
-
-  // ── Announcements ────────────────────────────────────────────────────────
-
-  private _annYear(): number {
+  private _getYear(): number {
     return parseInt(this.querySelector<HTMLSelectElement>('#ap-year')!.value, 10);
-  }
-
-  private _setBannerStatus(msg: string, type: '' | 'success' | 'error'): void {
-    const el = this.querySelector('#banner-status');
-    if (!el) return;
-    el.textContent = msg;
-    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
-  }
-
-  private async _loadBannerTab(): Promise<void> {
-    if (this._bannerLoaded) return;
-    const result = await scoreService.getBanner();
-    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
-    const ta = this.querySelector<HTMLTextAreaElement>('#banner-msg');
-    if (ta) ta.value = result.data ?? '';
-    this._bannerLoaded = true;
-  }
-
-  private async _saveBanner(): Promise<void> {
-    const message = this.querySelector<HTMLTextAreaElement>('#banner-msg')!.value.trim();
-    this._setBannerStatus('Saving…', '');
-    const result = await scoreService.setBanner(message || null);
-    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
-    this._bannerLoaded = false;
-    showToast('success', message ? 'Banner updated.' : 'Banner cleared.');
-    this._setBannerStatus('', '');
-  }
-
-  private async _clearBanner(): Promise<void> {
-    const ta = this.querySelector<HTMLTextAreaElement>('#banner-msg');
-    if (ta) ta.value = '';
-    await this._saveBanner();
-  }
-
-  private _setAnnStatus(message: string, type: '' | 'success' | 'error'): void {
-    const el = this.querySelector('#ann-status');
-    if (!el) return;
-    el.textContent = message;
-    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
-  }
-
-  private async _loadAnnouncementsTab(): Promise<void> {
-    const year = this._annYear();
-    const result = await scoreService.getAnnouncements(year);
-    if (!result.success) {
-      this._setAnnStatus(`Error loading announcements: ${result.error}`, 'error');
-      return;
-    }
-    this._renderAnnAdminList(result.data);
-  }
-
-  private _renderAnnAdminList(announcements: import('@/types/announcement').Announcement[]): void {
-    const list = this.querySelector('#ann-list');
-    if (!list) return;
-    list.innerHTML = '';
-
-    if (announcements.length === 0) {
-      list.innerHTML = '<p style="color:var(--c-text-muted);font-size:var(--text-sm)">No announcements for this year.</p>';
-      return;
-    }
-
-    const fmt = (ts: import('firebase/firestore').Timestamp) =>
-      ts.toDate().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-
-    for (const ann of announcements) {
-      const card = document.createElement('div');
-      card.className = 'ann-admin-card';
-
-      const editedMeta = ann.lastEditedAt
-        ? `<span> · Edited ${fmt(ann.lastEditedAt)}</span>`
-        : '';
-
-      card.innerHTML = `
-        <div class="ann-admin-card__header">
-          <span class="ann-admin-card__title"></span>
-          <span class="ann-admin-card__meta">Posted ${fmt(ann.postedAt)}${editedMeta}</span>
-        </div>
-        <pre class="ann-admin-card__body"></pre>
-        <div class="ann-admin-card__actions">
-          <button class="btn-secondary ann-edit-btn" data-id="${ann.id}" data-year="${ann.year}">Edit</button>
-          <button class="btn-danger ann-delete-btn" data-id="${ann.id}" data-year="${ann.year}">Delete</button>
-        </div>`;
-
-      card.querySelector('.ann-admin-card__title')!.textContent = ann.title;
-      card.querySelector('.ann-admin-card__body')!.textContent = ann.body;
-
-      list.appendChild(card);
-    }
-
-    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-edit-btn')) {
-      btn.addEventListener('click', () => {
-        const ann = announcements.find((a) => a.id === btn.dataset['id']);
-        if (ann) this._startEditAnnouncement(ann.id, ann.title, ann.body);
-      });
-    }
-
-    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-delete-btn')) {
-      btn.addEventListener('click', () => {
-        const id = btn.dataset['id'] ?? '';
-        const year = parseInt(btn.dataset['year'] ?? '0', 10);
-        const ann = announcements.find((a) => a.id === id);
-        void this._deleteAnnouncement(id, year, ann?.title ?? id);
-      });
-    }
-  }
-
-  private async _postAnnouncement(): Promise<void> {
-    const year = this._annYear();
-    const title = (this.querySelector<HTMLInputElement>('#ann-title')!.value).trim();
-    const body = (this.querySelector<HTMLTextAreaElement>('#ann-body')!.value).trim();
-
-    if (!title || !body) {
-      this._setAnnStatus('Title and message are required.', 'error');
-      return;
-    }
-
-    this._setAnnStatus('Posting…', '');
-    const result = await scoreService.createAnnouncement(year, title, body);
-    if (!result.success) {
-      this._setAnnStatus(`Error: ${result.error}`, 'error');
-      return;
-    }
-    this._clearAnnEditor();
-    void this._loadAnnouncementsTab();
-  }
-
-  private _startEditAnnouncement(id: string, title: string, body: string): void {
-    this.querySelector<HTMLInputElement>('#ann-title')!.value = title;
-    this.querySelector<HTMLTextAreaElement>('#ann-body')!.value = body;
-    this._editingAnnouncementId = id;
-    this.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Save Changes';
-    (this.querySelector<HTMLButtonElement>('#ann-cancel-btn')!).style.display = '';
-    this.querySelector('#ann-status')!.textContent = '';
-    this.querySelector('#ann-title')!.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
-
-  private async _saveEditAnnouncement(): Promise<void> {
-    const id = this._editingAnnouncementId!;
-    const year = this._annYear();
-    const title = (this.querySelector<HTMLInputElement>('#ann-title')!.value).trim();
-    const body = (this.querySelector<HTMLTextAreaElement>('#ann-body')!.value).trim();
-
-    if (!title || !body) {
-      this._setAnnStatus('Title and message are required.', 'error');
-      return;
-    }
-
-    this._setAnnStatus('Saving…', '');
-    const result = await scoreService.updateAnnouncement(id, year, title, body);
-    if (!result.success) {
-      this._setAnnStatus(`Error: ${result.error}`, 'error');
-      return;
-    }
-    this._clearAnnEditor();
-    void this._loadAnnouncementsTab();
-  }
-
-  private async _deleteAnnouncement(id: string, year: number, title: string): Promise<void> {
-    const confirmed = await this._showConfirmDialog({
-      title: 'Delete Announcement',
-      warning: `This will permanently delete "${title}". This cannot be undone.`,
-      nameToType: title,
-      deleteLabel: 'Delete Announcement',
-    });
-    if (!confirmed) return;
-    const result = await scoreService.deleteAnnouncement(id, year);
-    if (result.success) {
-      showToast('success', `Announcement "${title}" deleted.`);
-      void this._loadAnnouncementsTab();
-    } else {
-      showToast('error', `Failed to delete announcement: ${result.error}`);
-    }
-  }
-
-  private _clearAnnEditor(): void {
-    this.querySelector<HTMLInputElement>('#ann-title')!.value = '';
-    this.querySelector<HTMLTextAreaElement>('#ann-body')!.value = '';
-    this._editingAnnouncementId = null;
-    this.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Post Announcement';
-    (this.querySelector<HTMLButtonElement>('#ann-cancel-btn')!).style.display = 'none';
-    this.querySelector('#ann-status')!.textContent = '';
-  }
-
-  // ── Status helpers ───────────────────────────────────────────────────────
-
-  private _setStatus(message: string, type: '' | 'success' | 'error'): void {
-    const el = this.querySelector('#ap-status');
-    if (!el) return;
-    el.textContent = message;
-    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
-  }
-
-  private _setPublishStatus(message: string, type: '' | 'success' | 'error'): void {
-    const el = this.querySelector('#ap-publish-status');
-    if (!el) return;
-    el.textContent = message;
-    el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
-  }
-
-  private _setRosterStatus(message: string, type: '' | 'success' | 'error' | 'info'): void {
-    if (!this._rosterStatusEl) return;
-    this._rosterStatusEl.textContent = message;
-    this._rosterStatusEl.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
-  }
-
-  // ── Autocomplete helpers ────────────────────────────────────────────────
-
-  private _getTeamNames(): string[] {
-    return this._teamNameCache?.names ?? this._teamsData?.map((t) => t.name) ?? [];
   }
 
   private async _getTeamNameSuggestions(year: number): Promise<string[]> {
@@ -1619,18 +162,6 @@ class AdminPanel extends HTMLElement {
     const names = [...seen.values()].sort((a, b) => a.localeCompare(b));
     this._teamNameCache = { year, names };
     return names;
-  }
-
-  private _getCurrentYearShooterNames(): string[] {
-    if (!this._teamsData) return [];
-    const seen = new Map<string, string>();
-    for (const team of this._teamsData) {
-      for (const s of team.shooters) {
-        const key = normalizeShooterName(s.name);
-        if (!seen.has(key)) seen.set(key, s.name);
-      }
-    }
-    return [...seen.values()].sort((a, b) => a.localeCompare(b));
   }
 
   private async _getShooterSuggestions(year: number): Promise<string[]> {
@@ -1659,123 +190,40 @@ class AdminPanel extends HTMLElement {
     return names;
   }
 
-  private _attachAutocomplete(
-    input: HTMLInputElement,
-    getSuggestions: () => string[],
-  ): void {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'ac-wrapper';
-    input.parentNode!.insertBefore(wrapper, input);
-    wrapper.appendChild(input);
-
-    const dropdown = document.createElement('div');
-    dropdown.className = 'ac-dropdown';
-    wrapper.appendChild(dropdown);
-
-    let activeIndex = -1;
-
-    const close = () => {
-      dropdown.classList.remove('ac-dropdown--open');
-      dropdown.innerHTML = '';
-      activeIndex = -1;
-    };
-
-    const render = (items: string[]) => {
-      dropdown.innerHTML = '';
-      activeIndex = -1;
-      if (items.length === 0) {
-        close();
-        return;
+  private _getCurrentYearShooterNames(): string[] {
+    if (!this._teamsData) return [];
+    const seen = new Map<string, string>();
+    for (const team of this._teamsData) {
+      for (const s of team.shooters) {
+        const key = normalizeShooterName(s.name);
+        if (!seen.has(key)) seen.set(key, s.name);
       }
-      for (const name of items) {
-        const item = document.createElement('div');
-        item.className = 'ac-dropdown__item';
-        item.textContent = name;
-        item.addEventListener('mousedown', (e) => {
-          e.preventDefault(); // prevent blur from firing before selection
-          input.value = name;
-          close();
-          input.blur(); // trigger any existing blur handlers (e.g. roster defaults)
-        });
-        dropdown.appendChild(item);
-      }
-      dropdown.classList.add('ac-dropdown--open');
+    }
+    return [...seen.values()].sort((a, b) => a.localeCompare(b));
+  }
+
+  private _getTeamNames(): string[] {
+    return this._teamNameCache?.names ?? this._teamsData?.map((t) => t.name) ?? [];
+  }
+
+  // ── Tab context factory ──────────────────────────────────────────────────
+
+  private _buildContext(): AdminTabContext {
+    return {
+      getYear: () => this._getYear(),
+      getTeamsData: () => this._teamsData,
+      getSeasonData: () => this._seasonData,
+      refreshTeams: () => this._refreshTeams(),
+      refreshSeason: () => this._refreshSeason(),
+      getShooterSuggestions: (year) => this._getShooterSuggestions(year),
+      getTeamNameSuggestions: (year) => this._getTeamNameSuggestions(year),
+      getCurrentYearShooterNames: () => this._getCurrentYearShooterNames(),
+      getTeamNames: () => this._getTeamNames(),
+      getCachedShooterNames: () => this._shooterNameCache?.names ?? [],
     };
-
-    const update = () => {
-      const query = normalizeShooterName(input.value);
-      if (!query) { close(); return; }
-
-      const all = getSuggestions();
-      const matches = all.filter((n) => {
-        const norm = normalizeShooterName(n);
-        return norm !== query && norm.includes(query);
-      }).slice(0, 8);
-
-      render(matches);
-    };
-
-    const setActive = (idx: number) => {
-      const items = dropdown.querySelectorAll<HTMLElement>('.ac-dropdown__item');
-      for (const it of items) it.classList.remove('ac-dropdown__item--active');
-      activeIndex = idx;
-      if (idx >= 0 && idx < items.length) {
-        items[idx]!.classList.add('ac-dropdown__item--active');
-        items[idx]!.scrollIntoView({ block: 'nearest' });
-      }
-    };
-
-    input.addEventListener('input', update);
-
-    input.addEventListener('keydown', (e: KeyboardEvent) => {
-      const isOpen = dropdown.classList.contains('ac-dropdown--open');
-      if (!isOpen) return;
-
-      const items = dropdown.querySelectorAll('.ac-dropdown__item');
-      const count = items.length;
-
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setActive(activeIndex < count - 1 ? activeIndex + 1 : 0);
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setActive(activeIndex > 0 ? activeIndex - 1 : count - 1);
-      } else if (e.key === 'Enter' && activeIndex >= 0) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        const selected = items[activeIndex]?.textContent ?? '';
-        input.value = selected;
-        close();
-        input.blur();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        close();
-      } else if (e.key === 'Tab') {
-        close();
-      }
-    });
-
-    wrapper.addEventListener('focusout', (e: FocusEvent) => {
-      // Close only if focus left the wrapper entirely
-      if (!wrapper.contains(e.relatedTarget as Node)) close();
-    });
   }
 }
 
-customElements.define('admin-panel', AdminPanel);
-
-// ── Module-level helpers ─────────────────────────────────────────────────────
-
-/** Parse a YYYY-MM-DD string as a local date (avoids UTC midnight offset). */
-function _parseLocalDate(iso: string): Date {
-  const [y, m, d] = iso.split('-').map(Number);
-  return new Date(y!, (m ?? 1) - 1, d ?? 1);
-}
-
-/** Format a Date as YYYY-MM-DD for use as an <input type="date"> value. */
-function _toInputDate(date: Date): string {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
+if (!customElements.get('admin-panel')) {
+  customElements.define('admin-panel', AdminPanel);
 }

--- a/src/components/admin-tabs/admin-shared.ts
+++ b/src/components/admin-tabs/admin-shared.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared utilities for admin-panel tab modules.
+ *
+ * Pure DOM helpers and small format/parse utilities. No tab-module
+ * dependencies, no Firestore calls — safe to import from any tab.
+ */
+
+import { normalizeShooterName } from '@/services/scoring-engine';
+import type { ConfirmDialogOptions } from './types';
+
+// ── Shared SVG icons ────────────────────────────────────────────────────────
+
+export const PENCIL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="16 3 21 8 8 21 3 21 3 16 16 3"/></svg>`;
+export const TRASH_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/></svg>`;
+export const ROSTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 512 512" aria-hidden="true"><path fill="currentColor" d="M40 48C26.7 48 16 58.7 16 72v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V72c0-13.3-10.7-24-24-24H40zm152 16c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H488c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zM16 232v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V232c0-13.3-10.7-24-24-24H40c-13.3 0-24 10.7-24 24zM40 368c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V392c0-13.3-10.7-24-24-24H40z"/></svg>`;
+export const LOCK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
+export const WARN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>`;
+
+// ── Build option list helper (used by Year + Week selects) ─────────────────
+
+export function buildOptions(min: number, max: number, label: string, selected: number): string {
+  let html = '';
+  for (let i = min; i <= max; i++) {
+    html += `<option value="${i}"${i === selected ? ' selected' : ''}>${label ? `${label} ${i}` : i}</option>`;
+  }
+  return html;
+}
+
+// ── Date utilities (shared by score-entry date override) ────────────────────
+
+/** Parse a YYYY-MM-DD string as a local date (avoids UTC midnight offset). */
+export function parseLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y!, (m ?? 1) - 1, d ?? 1);
+}
+
+/** Format a Date as YYYY-MM-DD for use as an <input type="date"> value. */
+export function toInputDate(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+// ── Confirm-by-typing dialog (used for delete confirmations) ────────────────
+
+export function showConfirmDialog(opts: ConfirmDialogOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    const dialog = document.createElement('dialog');
+    dialog.className = 'confirm-dialog';
+
+    const h2 = document.createElement('h2');
+    h2.className = 'confirm-dialog__title';
+    h2.textContent = opts.title;
+
+    const warn = document.createElement('p');
+    warn.className = 'confirm-dialog__warning';
+    warn.textContent = opts.warning;
+
+    const instr = document.createElement('p');
+    instr.className = 'confirm-dialog__instruction';
+    const strong = document.createElement('strong');
+    strong.textContent = opts.nameToType;
+    instr.append('Type ', strong, ' to confirm:');
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'confirm-dialog__input admin-input';
+    input.autocomplete = 'off';
+    input.placeholder = opts.nameToType;
+    input.setAttribute('aria-label', 'Confirm by typing name');
+
+    const actions = document.createElement('div');
+    actions.className = 'confirm-dialog__actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'btn-danger';
+    deleteBtn.textContent = opts.deleteLabel;
+    deleteBtn.disabled = true;
+
+    input.addEventListener('input', () => {
+      deleteBtn.disabled = input.value.trim() !== opts.nameToType;
+    });
+
+    const finish = (confirmed: boolean) => {
+      dialog.close();
+      document.body.removeChild(dialog);
+      resolve(confirmed);
+    };
+
+    cancelBtn.addEventListener('click', () => finish(false));
+    deleteBtn.addEventListener('click', () => finish(true));
+    dialog.addEventListener('cancel', () => finish(false));
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(deleteBtn);
+    dialog.append(h2, warn, instr, input, actions);
+    document.body.appendChild(dialog);
+    dialog.showModal();
+    setTimeout(() => input.focus(), 0);
+  });
+}
+
+// ── Autocomplete (text input with filtered dropdown) ────────────────────────
+
+export function attachAutocomplete(
+  input: HTMLInputElement,
+  getSuggestions: () => string[],
+): void {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'ac-wrapper';
+  input.parentNode!.insertBefore(wrapper, input);
+  wrapper.appendChild(input);
+
+  const dropdown = document.createElement('div');
+  dropdown.className = 'ac-dropdown';
+  wrapper.appendChild(dropdown);
+
+  let activeIndex = -1;
+
+  const close = () => {
+    dropdown.classList.remove('ac-dropdown--open');
+    dropdown.innerHTML = '';
+    activeIndex = -1;
+  };
+
+  const render = (items: string[]) => {
+    dropdown.innerHTML = '';
+    activeIndex = -1;
+    if (items.length === 0) {
+      close();
+      return;
+    }
+    for (const name of items) {
+      const item = document.createElement('div');
+      item.className = 'ac-dropdown__item';
+      item.textContent = name;
+      item.addEventListener('mousedown', (e) => {
+        e.preventDefault(); // prevent blur from firing before selection
+        input.value = name;
+        close();
+        input.blur(); // trigger any existing blur handlers (e.g. roster defaults)
+      });
+      dropdown.appendChild(item);
+    }
+    dropdown.classList.add('ac-dropdown--open');
+  };
+
+  const update = () => {
+    const query = normalizeShooterName(input.value);
+    if (!query) { close(); return; }
+
+    const all = getSuggestions();
+    const matches = all.filter((n) => {
+      const norm = normalizeShooterName(n);
+      return norm !== query && norm.includes(query);
+    }).slice(0, 8);
+
+    render(matches);
+  };
+
+  const setActive = (idx: number) => {
+    const items = dropdown.querySelectorAll<HTMLElement>('.ac-dropdown__item');
+    for (const it of items) it.classList.remove('ac-dropdown__item--active');
+    activeIndex = idx;
+    if (idx >= 0 && idx < items.length) {
+      items[idx]!.classList.add('ac-dropdown__item--active');
+      items[idx]!.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
+  input.addEventListener('input', update);
+
+  input.addEventListener('keydown', (e: KeyboardEvent) => {
+    const isOpen = dropdown.classList.contains('ac-dropdown--open');
+    if (!isOpen) return;
+
+    const items = dropdown.querySelectorAll('.ac-dropdown__item');
+    const count = items.length;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive(activeIndex < count - 1 ? activeIndex + 1 : 0);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive(activeIndex > 0 ? activeIndex - 1 : count - 1);
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const selected = items[activeIndex]?.textContent ?? '';
+      input.value = selected;
+      close();
+      input.blur();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    } else if (e.key === 'Tab') {
+      close();
+    }
+  });
+
+  wrapper.addEventListener('focusout', (e: FocusEvent) => {
+    // Close only if focus left the wrapper entirely
+    if (!wrapper.contains(e.relatedTarget as Node)) close();
+  });
+}
+
+// ── Status helper (admin-status element pattern) ────────────────────────────
+
+export function setStatus(
+  el: Element | null,
+  message: string,
+  type: '' | 'success' | 'error' | 'info',
+): void {
+  if (!el) return;
+  el.textContent = message;
+  el.className = `admin-status${type ? ` admin-status--${type}` : ''}`;
+}

--- a/src/components/admin-tabs/announcements-tab.ts
+++ b/src/components/admin-tabs/announcements-tab.ts
@@ -1,0 +1,276 @@
+/**
+ * Announcements tab — site banner editor + per-year announcements list.
+ *
+ * Banner is a singleton document (no year scoping); announcements are
+ * per-year and rendered as cards with edit/delete buttons. Both share
+ * a status line per editor for inline feedback.
+ */
+
+import { ScoreService } from '@/services/score-service';
+import { showToast } from '@/modules/ui';
+import type { Announcement } from '@/types/announcement';
+import type { Timestamp } from 'firebase/firestore';
+import { setStatus, showConfirmDialog } from './admin-shared';
+import type { AdminTab, AdminTabContext } from './types';
+
+export class AnnouncementsTab implements AdminTab {
+  private _host: HTMLElement | null = null;
+  private _ctx: AdminTabContext | null = null;
+  private readonly _scoreService: ScoreService;
+
+  private _bannerLoaded = false;
+  /** null = not editing; else = announcement id being edited. */
+  private _editingAnnouncementId: string | null = null;
+
+  constructor(scoreService: ScoreService) {
+    this._scoreService = scoreService;
+  }
+
+  mount(host: HTMLElement, ctx: AdminTabContext): void {
+    this._host = host;
+    this._ctx = ctx;
+
+    host.innerHTML = `
+      <h3>Site Banner</h3>
+      <p class="admin-publish-note">
+        Displays a message to all visitors below the navigation bar. Clear the field and save to remove it.
+      </p>
+      <div class="banner-editor ann-editor">
+        <div class="ann-editor__field">
+          <label for="banner-msg">Banner message</label>
+          <textarea id="banner-msg" class="ann-editor__textarea" rows="3"
+            placeholder="e.g. Tonight&#39;s shoot is cancelled due to severe weather."></textarea>
+        </div>
+        <div class="ann-editor__actions">
+          <button id="banner-save-btn" class="btn-primary">Save Banner</button>
+          <button id="banner-clear-btn" class="btn-secondary">Clear Banner</button>
+        </div>
+        <p id="banner-status" class="admin-status" aria-live="polite"></p>
+      </div>
+      <hr class="admin-divider">
+      <h3>Announcements</h3>
+      <div class="ann-editor">
+        <div class="ann-editor__field">
+          <label for="ann-title">Title</label>
+          <input type="text" id="ann-title" class="ann-editor__input" placeholder="Announcement title" />
+        </div>
+        <div class="ann-editor__field">
+          <label for="ann-body">Message (Markdown)</label>
+          <textarea id="ann-body" class="ann-editor__textarea" rows="6"
+            placeholder="Write your announcement..."></textarea>
+        </div>
+        <div class="ann-editor__actions">
+          <button id="ann-post-btn" class="btn-primary">Post Announcement</button>
+          <button id="ann-cancel-btn" class="btn-secondary" style="display:none">Cancel Edit</button>
+        </div>
+        <p id="ann-status" class="admin-status" aria-live="polite"></p>
+      </div>
+      <div id="ann-list"></div>`;
+
+    host.querySelector('#banner-save-btn')!.addEventListener('click', () => void this._saveBanner());
+    host.querySelector('#banner-clear-btn')!.addEventListener('click', () => void this._clearBanner());
+
+    host.querySelector('#ann-post-btn')!.addEventListener('click', () => {
+      if (this._editingAnnouncementId) void this._saveEditAnnouncement();
+      else void this._postAnnouncement();
+    });
+    host.querySelector('#ann-cancel-btn')!.addEventListener('click', () => this._clearAnnEditor());
+  }
+
+  onYearChange(): void {
+    // Banner is global, but announcements are per-year — reload if visible.
+    void this._loadAnnouncementsTab();
+  }
+
+  onActivate(): void {
+    void this._loadBannerTab();
+    void this._loadAnnouncementsTab();
+  }
+
+  // ── Banner ──────────────────────────────────────────────────────────────
+
+  private async _loadBannerTab(): Promise<void> {
+    if (this._bannerLoaded) return;
+    const result = await this._scoreService.getBanner();
+    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
+    const ta = this._host?.querySelector<HTMLTextAreaElement>('#banner-msg');
+    if (ta) ta.value = result.data ?? '';
+    this._bannerLoaded = true;
+  }
+
+  private async _saveBanner(): Promise<void> {
+    const message = this._host?.querySelector<HTMLTextAreaElement>('#banner-msg')!.value.trim() ?? '';
+    this._setBannerStatus('Saving…', '');
+    const result = await this._scoreService.setBanner(message || null);
+    if (!result.success) { this._setBannerStatus(`Error: ${result.error}`, 'error'); return; }
+    this._bannerLoaded = false;
+    showToast('success', message ? 'Banner updated.' : 'Banner cleared.');
+    this._setBannerStatus('', '');
+  }
+
+  private async _clearBanner(): Promise<void> {
+    const ta = this._host?.querySelector<HTMLTextAreaElement>('#banner-msg');
+    if (ta) ta.value = '';
+    await this._saveBanner();
+  }
+
+  private _setBannerStatus(message: string, type: '' | 'success' | 'error'): void {
+    setStatus(this._host?.querySelector('#banner-status') ?? null, message, type);
+  }
+
+  // ── Announcements ───────────────────────────────────────────────────────
+
+  private async _loadAnnouncementsTab(): Promise<void> {
+    const year = this._ctx?.getYear() ?? 0;
+    const result = await this._scoreService.getAnnouncements(year);
+    if (!result.success) {
+      this._setAnnStatus(`Error loading announcements: ${result.error}`, 'error');
+      return;
+    }
+    this._renderAnnAdminList(result.data);
+  }
+
+  private _renderAnnAdminList(announcements: Announcement[]): void {
+    const list = this._host?.querySelector('#ann-list');
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (announcements.length === 0) {
+      list.innerHTML = '<p style="color:var(--c-text-muted);font-size:var(--text-sm)">No announcements for this year.</p>';
+      return;
+    }
+
+    const fmt = (ts: Timestamp) =>
+      ts.toDate().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+    for (const ann of announcements) {
+      const card = document.createElement('div');
+      card.className = 'ann-admin-card';
+
+      const editedMeta = ann.lastEditedAt
+        ? `<span> · Edited ${fmt(ann.lastEditedAt)}</span>`
+        : '';
+
+      card.innerHTML = `
+        <div class="ann-admin-card__header">
+          <span class="ann-admin-card__title"></span>
+          <span class="ann-admin-card__meta">Posted ${fmt(ann.postedAt)}${editedMeta}</span>
+        </div>
+        <pre class="ann-admin-card__body"></pre>
+        <div class="ann-admin-card__actions">
+          <button class="btn-secondary ann-edit-btn" data-id="${ann.id}" data-year="${ann.year}">Edit</button>
+          <button class="btn-danger ann-delete-btn" data-id="${ann.id}" data-year="${ann.year}">Delete</button>
+        </div>`;
+
+      card.querySelector('.ann-admin-card__title')!.textContent = ann.title;
+      card.querySelector('.ann-admin-card__body')!.textContent = ann.body;
+
+      list.appendChild(card);
+    }
+
+    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-edit-btn')) {
+      btn.addEventListener('click', () => {
+        const ann = announcements.find((a) => a.id === btn.dataset['id']);
+        if (ann) this._startEditAnnouncement(ann.id, ann.title, ann.body);
+      });
+    }
+
+    for (const btn of list.querySelectorAll<HTMLButtonElement>('.ann-delete-btn')) {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset['id'] ?? '';
+        const year = parseInt(btn.dataset['year'] ?? '0', 10);
+        const ann = announcements.find((a) => a.id === id);
+        void this._deleteAnnouncement(id, year, ann?.title ?? id);
+      });
+    }
+  }
+
+  private async _postAnnouncement(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const title = host.querySelector<HTMLInputElement>('#ann-title')!.value.trim();
+    const body = host.querySelector<HTMLTextAreaElement>('#ann-body')!.value.trim();
+
+    if (!title || !body) {
+      this._setAnnStatus('Title and message are required.', 'error');
+      return;
+    }
+
+    this._setAnnStatus('Posting…', '');
+    const result = await this._scoreService.createAnnouncement(year, title, body);
+    if (!result.success) {
+      this._setAnnStatus(`Error: ${result.error}`, 'error');
+      return;
+    }
+    this._clearAnnEditor();
+    void this._loadAnnouncementsTab();
+  }
+
+  private _startEditAnnouncement(id: string, title: string, body: string): void {
+    const host = this._host;
+    if (!host) return;
+    host.querySelector<HTMLInputElement>('#ann-title')!.value = title;
+    host.querySelector<HTMLTextAreaElement>('#ann-body')!.value = body;
+    this._editingAnnouncementId = id;
+    host.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Save Changes';
+    host.querySelector<HTMLButtonElement>('#ann-cancel-btn')!.style.display = '';
+    host.querySelector('#ann-status')!.textContent = '';
+    host.querySelector('#ann-title')!.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  private async _saveEditAnnouncement(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const id = this._editingAnnouncementId!;
+    const year = this._ctx?.getYear() ?? 0;
+    const title = host.querySelector<HTMLInputElement>('#ann-title')!.value.trim();
+    const body = host.querySelector<HTMLTextAreaElement>('#ann-body')!.value.trim();
+
+    if (!title || !body) {
+      this._setAnnStatus('Title and message are required.', 'error');
+      return;
+    }
+
+    this._setAnnStatus('Saving…', '');
+    const result = await this._scoreService.updateAnnouncement(id, year, title, body);
+    if (!result.success) {
+      this._setAnnStatus(`Error: ${result.error}`, 'error');
+      return;
+    }
+    this._clearAnnEditor();
+    void this._loadAnnouncementsTab();
+  }
+
+  private async _deleteAnnouncement(id: string, year: number, title: string): Promise<void> {
+    const confirmed = await showConfirmDialog({
+      title: 'Delete Announcement',
+      warning: `This will permanently delete "${title}". This cannot be undone.`,
+      nameToType: title,
+      deleteLabel: 'Delete Announcement',
+    });
+    if (!confirmed) return;
+    const result = await this._scoreService.deleteAnnouncement(id, year);
+    if (result.success) {
+      showToast('success', `Announcement "${title}" deleted.`);
+      void this._loadAnnouncementsTab();
+    } else {
+      showToast('error', `Failed to delete announcement: ${result.error}`);
+    }
+  }
+
+  private _clearAnnEditor(): void {
+    const host = this._host;
+    if (!host) return;
+    host.querySelector<HTMLInputElement>('#ann-title')!.value = '';
+    host.querySelector<HTMLTextAreaElement>('#ann-body')!.value = '';
+    this._editingAnnouncementId = null;
+    host.querySelector<HTMLButtonElement>('#ann-post-btn')!.textContent = 'Post Announcement';
+    host.querySelector<HTMLButtonElement>('#ann-cancel-btn')!.style.display = 'none';
+    host.querySelector('#ann-status')!.textContent = '';
+  }
+
+  private _setAnnStatus(message: string, type: '' | 'success' | 'error'): void {
+    setStatus(this._host?.querySelector('#ann-status') ?? null, message, type);
+  }
+}

--- a/src/components/admin-tabs/roster-modal.ts
+++ b/src/components/admin-tabs/roster-modal.ts
@@ -1,0 +1,305 @@
+/**
+ * Roster modal — Team Management's per-team shooter editor.
+ *
+ * Self-contained: each `openRosterModal()` call builds and shows a
+ * single `<dialog>`, mutates internal state for the duration of the
+ * edit, and tears down on save/cancel. State lives in the closure so
+ * the dialog has no shared lifetime with the parent tab.
+ */
+
+import { ScoreService } from '@/services/score-service';
+import { showToast } from '@/modules/ui';
+import { normalizeShooterName } from '@/services/scoring-engine';
+import type { Shooter } from '@/types/shooter';
+import type { Team } from '@/types/score';
+import { attachAutocomplete, setStatus } from './admin-shared';
+import type { AdminTabContext } from './types';
+
+export interface RosterModalOptions {
+  teamId: string;
+  teamName: string;
+  ctx: AdminTabContext;
+  scoreService: ScoreService;
+  /** Called after a successful save so the parent can refresh its team list. */
+  onSaved: () => void;
+}
+
+export function openRosterModal(opts: RosterModalOptions): void {
+  const { teamId, teamName, ctx, scoreService, onSaved } = opts;
+  let originalShooters: Shooter[] = [];
+  /** Shooter names removed from roster DOM but not yet written to Firestore. */
+  const pendingRemovals: string[] = [];
+
+  // ── Build dialog ───────────────────────────────────────────────────────
+  const dialog = document.createElement('dialog');
+  dialog.className = 'roster-dialog';
+
+  const header = document.createElement('div');
+  header.className = 'roster-dialog__header';
+  const title = document.createElement('h2');
+  title.className = 'roster-dialog__title';
+  title.textContent = `Edit Roster — ${teamName}`;
+  header.appendChild(title);
+
+  const table = document.createElement('table');
+  table.className = 'admin-roster-table';
+  const thead = table.createTHead();
+  const hrow = thead.insertRow();
+  for (const label of ['Name', 'W0 Avg', 'Rookie', '']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    hrow.appendChild(th);
+  }
+  const tbody = table.createTBody();
+
+  const tableWrapper = document.createElement('div');
+  tableWrapper.className = 'admin-table-wrapper';
+  tableWrapper.appendChild(table);
+
+  const footer = document.createElement('div');
+  footer.className = 'roster-dialog__footer';
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'btn-secondary';
+  addBtn.textContent = 'Add Shooter';
+
+  const rightActions = document.createElement('div');
+  rightActions.className = 'admin-actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'btn-secondary';
+  cancelBtn.textContent = 'Cancel';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'btn-primary';
+  saveBtn.textContent = 'Save Roster';
+
+  rightActions.append(cancelBtn, saveBtn);
+  footer.append(addBtn, rightActions);
+
+  const statusEl = document.createElement('p');
+  statusEl.className = 'admin-status';
+  statusEl.setAttribute('aria-live', 'polite');
+
+  dialog.append(header, tableWrapper, footer, statusEl);
+  document.body.appendChild(dialog);
+
+  const setRosterStatus = (message: string, type: '' | 'success' | 'error' | 'info') => {
+    setStatus(statusEl, message, type);
+  };
+
+  const close = () => {
+    dialog.close();
+    document.body.removeChild(dialog);
+  };
+
+  const namedRosterCount = () =>
+    [...tbody.querySelectorAll<HTMLElement>('.ap-roster-row')]
+      .filter((r) => Boolean(r.querySelector<HTMLInputElement>('.ap-roster-name')?.value.trim()))
+      .length;
+
+  const addRosterRow = (shooter?: Shooter, originalIndex?: number) => {
+    const row = document.createElement('tr');
+    row.className = 'ap-roster-row';
+    if (originalIndex !== undefined) {
+      row.dataset['originalIndex'] = String(originalIndex);
+    }
+
+    if (shooter !== undefined) {
+      row.dataset['startingAvg'] = String(shooter.startingAvg);
+      row.dataset['rookie'] = String(shooter.rookie);
+    } else {
+      // New shooter: league defaults
+      row.dataset['startingAvg'] = '35';
+      row.dataset['rookie'] = 'true';
+    }
+
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'ap-roster-name';
+    nameInput.placeholder = 'Shooter name';
+    nameInput.autocomplete = 'off';
+    if (shooter) nameInput.value = shooter.name;
+
+    const avgSpan = document.createElement('span');
+    avgSpan.className = 'ap-roster-avg-display';
+    const rookieSpan = document.createElement('span');
+    rookieSpan.className = 'ap-roster-rookie-display';
+
+    if (shooter !== undefined) {
+      avgSpan.textContent = String(shooter.startingAvg);
+      rookieSpan.textContent = shooter.rookie ? 'Yes' : 'No';
+    } else {
+      avgSpan.textContent = '—';
+      rookieSpan.textContent = '—';
+
+      nameInput.addEventListener('blur', () => {
+        const name = nameInput.value.trim();
+        if (!name) return;
+        const year = ctx.getYear();
+        avgSpan.textContent = '…';
+        rookieSpan.textContent = '…';
+        void scoreService.computeShooterDefaults(year, name).then((result) => {
+          if (!result.success) {
+            avgSpan.textContent = '35';
+            rookieSpan.textContent = 'Yes';
+            return;
+          }
+          // cross-team duplicate check
+          const conflict = ctx.getTeamsData()?.find(
+            (t) => t.id !== teamId &&
+              t.shooters.some((s) => normalizeShooterName(s.name) === normalizeShooterName(name)),
+          );
+          if (conflict) {
+            showToast('error', `"${name}" is already on team "${conflict.name}".`);
+            nameInput.value = '';
+            avgSpan.textContent = '—';
+            rookieSpan.textContent = '—';
+            return;
+          }
+          row.dataset['startingAvg'] = String(result.data.startingAvg);
+          row.dataset['rookie']      = String(result.data.rookie);
+          avgSpan.textContent   = String(result.data.startingAvg);
+          rookieSpan.textContent = result.data.rookie ? 'Yes' : 'No';
+        });
+      });
+    }
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '✕';
+    removeBtn.className = 'ap-remove-shooter';
+    removeBtn.addEventListener('click', () => {
+      const name = nameInput.value.trim();
+      if (name && namedRosterCount() <= 5) {
+        setRosterStatus('Teams must have at least 5 shooters — cannot remove.', 'error');
+        return;
+      }
+      setRosterStatus('', '');
+      // Existing shooter with a name: defer cascade removal to Save Roster
+      if (originalIndex !== undefined && name) {
+        pendingRemovals.push(name);
+      }
+      tbody.removeChild(row);
+    });
+
+    const td = (child: HTMLElement) => {
+      const c = document.createElement('td');
+      c.appendChild(child);
+      return c;
+    };
+    row.appendChild(td(nameInput));
+    if (shooter === undefined) {
+      attachAutocomplete(nameInput, () => ctx.getCachedShooterNames());
+    }
+    const avgCell = document.createElement('td');
+    avgCell.appendChild(avgSpan);
+    row.appendChild(avgCell);
+    const rookieCell = document.createElement('td');
+    rookieCell.appendChild(rookieSpan);
+    row.appendChild(rookieCell);
+    row.appendChild(td(removeBtn));
+    tbody.appendChild(row);
+  };
+
+  const saveRoster = async () => {
+    const year = ctx.getYear();
+    const teams = ctx.getTeamsData();
+
+    // Captain comes from team data; derive from first shooter row if blank
+    let captain = teams?.find((t) => t.id === teamId)?.captain ?? '';
+    if (!captain) {
+      captain = tbody.querySelector<HTMLInputElement>('.ap-roster-name')?.value.trim() ?? '';
+    }
+    if (!captain) {
+      setRosterStatus('Add at least one shooter to set a captain.', 'error');
+      return;
+    }
+
+    const shooters: Shooter[] = [];
+    for (const rowEl of tbody.querySelectorAll<HTMLElement>('.ap-roster-row')) {
+      const name = rowEl.querySelector<HTMLInputElement>('.ap-roster-name')!.value.trim();
+      if (!name) continue;
+
+      const startingAvgRaw = parseFloat(rowEl.dataset['startingAvg'] ?? '35');
+      const startingAvg = isNaN(startingAvgRaw) ? 35 : startingAvgRaw;
+      const rookie = rowEl.dataset['rookie'] === 'true';
+
+      const origIdxStr = rowEl.dataset['originalIndex'];
+      const origIdx = origIdxStr !== undefined ? parseInt(origIdxStr, 10) : NaN;
+      const original = !isNaN(origIdx) ? originalShooters[origIdx] : undefined;
+
+      shooters.push({
+        id: original?.id ?? '',
+        name,
+        rookie,
+        startingAvg,
+        finalAvg: original?.finalAvg ?? null,
+        weeksShot: original?.weeksShot ?? null,
+        scores: original?.scores ?? [],
+      });
+    }
+
+    if (shooters.length < 5) {
+      setRosterStatus('A team must have at least 5 shooters.', 'error');
+      return;
+    }
+
+    setRosterStatus('', '');
+    const displayName = teams?.find((t) => t.id === teamId)?.name ?? teamId;
+    saveBtn.disabled = true;
+
+    // Process deferred shooter removals before saving
+    for (const name of pendingRemovals) {
+      await scoreService.removeShooterFromRoster(year, teamId, name);
+    }
+    pendingRemovals.length = 0;
+
+    const result = await scoreService.saveTeamRoster(year, teamId, captain, shooters);
+    saveBtn.disabled = false;
+
+    if (result.success) {
+      showToast('success', `Roster saved — ${displayName}.`);
+      close();
+      onSaved();
+    } else {
+      showToast('error', `Failed to save roster: ${result.error}`);
+    }
+  };
+
+  // ── Wire events ─────────────────────────────────────────────────────────
+  addBtn.addEventListener('click', () => addRosterRow());
+  cancelBtn.addEventListener('click', close);
+  saveBtn.addEventListener('click', () => void saveRoster());
+  dialog.addEventListener('cancel', close);
+
+  dialog.showModal();
+
+  // Prefetch shooter name suggestions for autocomplete
+  void ctx.getShooterSuggestions(ctx.getYear());
+
+  // ── Load roster data (async) ────────────────────────────────────────────
+  void (async () => {
+    setRosterStatus('Loading roster…', 'info');
+    const result = await scoreService.computeRosterDefaults(ctx.getYear(), teamId);
+    setRosterStatus('', '');
+
+    let team: Team;
+    if (result.success) {
+      team = result.data;
+    } else {
+      console.warn('computeRosterDefaults failed, using cached data:', result.error);
+      const fallback = ctx.getTeamsData()?.find((t) => t.id === teamId);
+      if (!fallback) return;
+      team = fallback;
+    }
+
+    originalShooters = [...team.shooters];
+    for (let i = 0; i < team.shooters.length; i++) {
+      addRosterRow(team.shooters[i], i);
+    }
+  })();
+}

--- a/src/components/admin-tabs/score-entry-tab.ts
+++ b/src/components/admin-tabs/score-entry-tab.ts
@@ -1,0 +1,583 @@
+/**
+ * Score Entry tab — week/team picker, date override, shooter rows,
+ * save/publish flow.
+ *
+ * Owns the date override card (`#ap-date-section`) too: locking and
+ * cancellation are interleaved with score-entry state (presence of
+ * saved entries, past-date detection), so the two pieces stay together.
+ */
+
+import { ScoreService } from '@/services/score-service';
+import { showToast } from '@/modules/ui';
+import { computeSchedule } from '@/utils/schedule';
+import {
+  LOCK_SVG,
+  PENCIL_SVG,
+  WARN_SVG,
+  attachAutocomplete,
+  buildOptions,
+  parseLocalDate,
+  setStatus,
+  toInputDate,
+} from './admin-shared';
+import type { AdminTab, AdminTabContext } from './types';
+
+const MAX_WEEKS = 15;
+const MAX_SCORE = 25;
+
+export class ScoreEntryTab implements AdminTab {
+  private _host: HTMLElement | null = null;
+  private _ctx: AdminTabContext | null = null;
+  private readonly _scoreService: ScoreService;
+
+  /** Whether the date override card is in edit mode. */
+  private _dateEditMode = false;
+  /** Whether any entries have been saved for the currently selected week. */
+  private _weekHasScores = false;
+
+  constructor(scoreService: ScoreService) {
+    this._scoreService = scoreService;
+  }
+
+  mount(host: HTMLElement, ctx: AdminTabContext): void {
+    this._host = host;
+    this._ctx = ctx;
+
+    host.innerHTML = `
+      <div class="admin-form-row">
+        <label for="ap-week">Week</label>
+        <select id="ap-week">${buildOptions(1, MAX_WEEKS, 'Week', 1)}</select>
+        <label for="ap-team">Team</label>
+        <select id="ap-team">
+          <option value="">-- Select team --</option>
+        </select>
+      </div>
+
+      <div id="ap-date-section"></div>
+
+      <h3>Shooters</h3>
+      <div class="admin-table-wrapper">
+        <table class="admin-shooters-table">
+          <thead>
+            <tr><th>Name</th><th>Score 1 (0–25)</th><th>Score 2 (0–25)</th><th>Total</th><th></th></tr>
+          </thead>
+          <tbody id="ap-shooters-body"></tbody>
+        </table>
+      </div>
+      <div class="admin-actions">
+        <button id="ap-save" class="btn-primary">Save Entry</button>
+        <span class="tooltip-icon" tabindex="0" role="img" aria-label="Save Entry help"
+          data-tooltip="Stores this team's scores as a draft. You can re-save to overwrite.">?</span>
+      </div>
+      <p id="ap-status" class="admin-status" aria-live="polite"></p>
+      <p class="admin-publish-note">
+        Save stores a draft for this team. Repeat for each team, then Publish when all entries are in.
+      </p>
+
+      <h3>Saved Entries</h3>
+      <ul id="ap-saved-list" class="admin-saved-list"></ul>
+
+      <div class="admin-publish-section">
+        <h3>Publish</h3>
+        <p class="admin-publish-note">Publishing runs the scoring engine over all saved entries and writes computed results to Firestore.</p>
+        <div class="admin-actions">
+          <button id="ap-publish" class="btn-danger">Publish Week</button>
+          <span class="tooltip-icon" tabindex="0" role="img" aria-label="Publish Week help"
+            data-tooltip="Runs the scoring engine over all saved entries and updates live standings. Cannot be undone.">?</span>
+        </div>
+        <p id="ap-publish-status" class="admin-status" aria-live="polite"></p>
+      </div>`;
+
+    host.querySelector('#ap-week')!.addEventListener('change', () => {
+      this._dateEditMode = false;
+      this._weekHasScores = false;
+      this._updateDateSection();
+      void this._populateShooterRows();
+      void this._loadSavedEntries();
+    });
+    host.querySelector('#ap-team')!.addEventListener('change', () => void this._populateShooterRows());
+    host.querySelector('#ap-save')!.addEventListener('click', () => void this._saveEntry());
+    host.querySelector('#ap-publish')!.addEventListener('click', () => void this._publishWeek());
+
+    this._populateTeamSelect();
+    this._updateDateSection();
+    void this._loadSavedEntries();
+  }
+
+  onYearChange(): void {
+    this._dateEditMode = false;
+    this._weekHasScores = false;
+    void this._loadSavedEntries();
+  }
+
+  onTeamsChanged(): void {
+    this._populateTeamSelect();
+    void this._populateShooterRows();
+  }
+
+  onSeasonChanged(): void {
+    this._updateDateSection();
+  }
+
+  onActivate(): void {
+    const year = this._ctx?.getYear() ?? 0;
+    void this._ctx?.getShooterSuggestions(year);
+  }
+
+  // ── Team select ─────────────────────────────────────────────────────────
+
+  private _populateTeamSelect(): void {
+    const select = this._host?.querySelector<HTMLSelectElement>('#ap-team');
+    if (!select) return;
+    const teams = this._ctx?.getTeamsData() ?? [];
+
+    while (select.firstChild) select.removeChild(select.firstChild);
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = teams.length ? '-- Select team --' : 'No teams available for this year';
+    select.appendChild(placeholder);
+
+    for (const team of teams) {
+      const opt = document.createElement('option');
+      opt.value = team.id;
+      opt.textContent = team.name;
+      select.appendChild(opt);
+    }
+  }
+
+  // ── Shooter rows ────────────────────────────────────────────────────────
+
+  private async _populateShooterRows(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
+    const teamId = host.querySelector<HTMLSelectElement>('#ap-team')?.value ?? '';
+    const tbody = host.querySelector('#ap-shooters-body');
+    if (!tbody) return;
+
+    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
+
+    // 1. Try to load existing saved entry first
+    if (teamId) {
+      const entryResult = await this._scoreService.getEntry(year, weekNumber, teamId);
+      if (entryResult.success && entryResult.data !== null) {
+        const team = this._ctx?.getTeamsData()?.find((t) => t.id === teamId);
+        const rosterNames = team ? new Set(team.shooters.map((s) => s.name)) : null;
+        const entryNames = new Set(entryResult.data.shooters.map((s) => s.name));
+        for (const s of entryResult.data.shooters) {
+          // Skip shooters who have since been removed from the roster
+          if (rosterNames && !rosterNames.has(s.name)) continue;
+          this._addShooterRow(s.name, s.score1 ?? undefined, s.score2 ?? undefined);
+        }
+        // Add any roster members not yet in the saved entry
+        if (team) {
+          for (const shooter of team.shooters) {
+            if (!entryNames.has(shooter.name)) this._addShooterRow(shooter.name);
+          }
+        }
+        return;
+      }
+    }
+
+    // 2. Fall back to roster
+    const team = this._ctx?.getTeamsData()?.find((t) => t.id === teamId);
+    if (team) {
+      for (const shooter of team.shooters) this._addShooterRow(shooter.name);
+    }
+    // no-team-selected branch: leave tbody empty (user must select a team)
+  }
+
+  private _addShooterRow(prefilledName = '', score1?: number, score2?: number): void {
+    const tbody = this._host?.querySelector('#ap-shooters-body');
+    if (!tbody) return;
+    const row = document.createElement('tr');
+    row.className = 'ap-shooter-row';
+    if (prefilledName) row.dataset['name'] = prefilledName;
+
+    const nameCell = document.createElement('td');
+    if (prefilledName) {
+      nameCell.textContent = prefilledName;
+      nameCell.className = 'ap-shooter-name-cell';
+    } else {
+      const nameInput = document.createElement('input');
+      nameInput.type = 'text';
+      nameInput.className = 'ap-shooter-name';
+      nameInput.placeholder = 'Shooter name';
+      nameInput.autocomplete = 'off';
+      nameCell.appendChild(nameInput);
+      attachAutocomplete(nameInput, () => this._ctx?.getCachedShooterNames() ?? []);
+    }
+
+    const s1 = this._scoreInput();
+    const s2 = this._scoreInput();
+
+    if (score1 !== undefined) s1.value = String(score1);
+    if (score2 !== undefined) s2.value = String(score2);
+
+    const totalCell = document.createElement('td');
+    totalCell.className = 'ap-shooter-total';
+
+    const updateTotal = () => {
+      const v1 = parseInt(s1.value, 10);
+      const v2 = parseInt(s2.value, 10);
+      totalCell.textContent = (!isNaN(v1) && !isNaN(v2)) ? String(v1 + v2) : '—';
+    };
+    s1.addEventListener('input', updateTotal);
+    s2.addEventListener('input', updateTotal);
+    updateTotal();
+
+    const td = (child: HTMLElement) => {
+      const c = document.createElement('td');
+      c.appendChild(child);
+      return c;
+    };
+    row.appendChild(nameCell);
+    row.appendChild(td(s1));
+    row.appendChild(td(s2));
+    row.appendChild(totalCell);
+    if (!prefilledName) {
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = '✕';
+      removeBtn.className = 'ap-remove-shooter';
+      removeBtn.addEventListener('click', () => tbody.removeChild(row));
+      row.appendChild(td(removeBtn));
+    } else {
+      row.appendChild(document.createElement('td')); // keep column alignment
+    }
+    tbody.appendChild(row);
+  }
+
+  private _scoreInput(): HTMLInputElement {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '0';
+    input.max = String(MAX_SCORE);
+    input.className = 'ap-score-input';
+    return input;
+  }
+
+  // ── Save / publish flow ─────────────────────────────────────────────────
+
+  private async _saveEntry(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
+    const teamSelect = host.querySelector<HTMLSelectElement>('#ap-team')!;
+    const teamName = teamSelect.options[teamSelect.selectedIndex]?.text ?? '';
+    const teamId = teamSelect.value;
+
+    if (!teamId) { this._setStatus('Team selection is required.', 'error'); return; }
+
+    const shooters: { name: string; score1: number; score2: number; total: number }[] = [];
+    for (const row of host.querySelectorAll('.ap-shooter-row')) {
+      const rowEl = row as HTMLElement;
+      const name = (rowEl.dataset['name'] ?? row.querySelector<HTMLInputElement>('.ap-shooter-name')?.value ?? '').trim();
+      const inputs = row.querySelectorAll<HTMLInputElement>('.ap-score-input');
+      const score1Raw = inputs[0]?.value ?? '';
+      const score2Raw = inputs[1]?.value ?? '';
+
+      // Both inputs empty → shooter did not shoot; exclude from entry (stays null in scoring engine)
+      if (score1Raw === '' && score2Raw === '') continue;
+      if (!name) { this._setStatus('All shooter rows must have a name.', 'error'); return; }
+
+      const score1 = score1Raw !== '' ? parseInt(score1Raw, 10) : 0;
+      const score2 = score2Raw !== '' ? parseInt(score2Raw, 10) : 0;
+      if (isNaN(score1) || score1 < 0 || score1 > MAX_SCORE) {
+        this._setStatus(`Score 1 for "${name}" must be 0–${MAX_SCORE}.`, 'error'); return;
+      }
+      if (isNaN(score2) || score2 < 0 || score2 > MAX_SCORE) {
+        this._setStatus(`Score 2 for "${name}" must be 0–${MAX_SCORE}.`, 'error'); return;
+      }
+      shooters.push({ name, score1, score2, total: score1 + score2 });
+    }
+
+    if (shooters.length === 0) {
+      this._setStatus('At least one shooter with valid scores is required.', 'error'); return;
+    }
+
+    this._setStatus('', '');
+
+    const entry = {
+      year,
+      weekNumber,
+      teamId,
+      teamName,
+      savedAt: new Date().toISOString(),
+      shooters,
+    };
+
+    const result = await this._scoreService.saveEntry(year, entry);
+    if (result.success) {
+      showToast('success', `Entry saved — ${teamName}, Week ${weekNumber}.`);
+    } else {
+      showToast('error', `Failed to save entry: ${result.error}`);
+    }
+
+    void this._loadSavedEntries();
+  }
+
+  private async _loadSavedEntries(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')?.value ?? '0', 10);
+    const list = host.querySelector('#ap-saved-list');
+    if (!list) return;
+
+    while (list.firstChild) list.removeChild(list.firstChild);
+
+    const result = await this._scoreService.getEntries(year, weekNumber);
+
+    if (!result.success) {
+      console.warn('admin-panel: could not load entries:', result.error);
+      const li = document.createElement('li');
+      li.textContent = 'No entries for this season/week for this team.';
+      list.appendChild(li);
+      return;
+    }
+
+    const entries = result.data.filter((e) => e.weekNumber === weekNumber);
+
+    // Update score-presence flag and re-render the date card (locking state may have changed)
+    this._weekHasScores = entries.length > 0;
+    this._updateDateSection();
+
+    if (entries.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'No entries saved for this year/week.';
+      list.appendChild(li);
+      return;
+    }
+
+    for (const entry of entries) {
+      const li = document.createElement('li');
+      li.className = 'admin-saved-item';
+
+      const label = document.createElement('span');
+      label.className = 'admin-saved-key';
+      label.textContent = `${entry.teamName}`;
+
+      const detail = document.createElement('span');
+      detail.textContent = ` — ${entry.shooters?.length ?? 0} shooter(s), saved ${new Date(entry.savedAt).toLocaleString()}`;
+
+      li.appendChild(label);
+      li.appendChild(detail);
+      list.appendChild(li);
+    }
+  }
+
+  private async _publishWeek(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
+    const btn = host.querySelector<HTMLButtonElement>('#ap-publish')!;
+
+    btn.disabled = true;
+    this._setPublishStatus(`Publishing week ${weekNumber}…`, '');
+
+    const result = await this._scoreService.publishWeek(year, weekNumber);
+
+    btn.disabled = false;
+    this._setPublishStatus('', '');
+
+    if (result.success) {
+      showToast('success', `Week ${weekNumber} published — standings updated.`);
+    } else {
+      showToast('error', `Publish failed: ${result.error}`);
+    }
+  }
+
+  // ── Date override ────────────────────────────────────────────────────────
+
+  /**
+   * Rebuild the date override card. Called whenever week, year, season data,
+   * or entry presence changes. Manages all of: view mode, edit mode, locked state.
+   */
+  private _updateDateSection(): void {
+    const host = this._host;
+    if (!host) return;
+    const container = host.querySelector<HTMLElement>('#ap-date-section');
+    if (!container) return;
+
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')?.value ?? '1', 10);
+
+    const overrides = this._ctx?.getSeasonData()?.weekDateOverrides ?? {};
+    const key = String(weekNumber);
+    const hasOverride = key in overrides;
+    const overrideValue = overrides[key]; // string | null | undefined
+
+    const shootEvents = computeSchedule(year).filter((e) => e.type === 'shoot');
+    const scheduledEvent = shootEvents.find((e) => e.week === weekNumber);
+    const scheduledDate = scheduledEvent?.date ?? null;
+
+    let effectiveDate: Date | null;
+    let displayState: 'normal' | 'overridden' | 'cancelled';
+
+    if (hasOverride && overrideValue === null) {
+      displayState = 'cancelled';
+      effectiveDate = scheduledDate;
+    } else if (hasOverride && typeof overrideValue === 'string') {
+      displayState = 'overridden';
+      effectiveDate = parseLocalDate(overrideValue);
+    } else {
+      displayState = 'normal';
+      effectiveDate = scheduledDate;
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const isInPast = effectiveDate !== null && effectiveDate < today;
+    const isLocked = isInPast || this._weekHasScores;
+    const lockReason = isInPast
+      ? 'This date is in the past'
+      : this._weekHasScores
+        ? 'Scores have been entered for this week'
+        : '';
+
+    if (isLocked && this._dateEditMode) this._dateEditMode = false;
+
+    const formattedDate = effectiveDate !== null
+      ? effectiveDate.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+      : '';
+
+    const badgeHtml = displayState === 'overridden'
+      ? `<span class="ap-date-badge">overridden</span>`
+      : displayState === 'cancelled'
+        ? `<span class="ap-date-badge ap-date-badge--cancelled">cancelled</span>`
+        : '';
+
+    const dateDisplayHtml = displayState === 'cancelled'
+      ? `<span class="ap-date-display ap-date-display--cancelled">CANCELLED</span>`
+      : `<span class="ap-date-display">${formattedDate || '—'}</span>`;
+
+    const todayStr = toInputDate(today);
+
+    if (!this._dateEditMode) {
+      const actionHtml = isLocked
+        ? `<span class="ap-date-lock" data-tooltip="${lockReason}">${LOCK_SVG} Locked</span>`
+        : `<button class="ap-date-edit-btn btn-secondary" id="ap-date-edit-btn">${PENCIL_SVG} Edit date</button>`;
+
+      container.innerHTML = `
+        <div class="ap-date-card">
+          <div class="ap-date-card__header">
+            <span class="ap-date-card__label">Shoot Date</span>
+            ${badgeHtml}
+          </div>
+          <div class="ap-date-card__body">
+            ${dateDisplayHtml}
+            ${actionHtml}
+          </div>
+        </div>`;
+
+      host.querySelector('#ap-date-edit-btn')
+        ?.addEventListener('click', () => {
+          this._dateEditMode = true;
+          this._updateDateSection();
+        });
+      return;
+    }
+
+    // Edit mode: pre-fill input with override or computed date
+    const inputValue = displayState === 'overridden' && typeof overrideValue === 'string'
+      ? overrideValue.substring(0, 10)
+      : scheduledDate !== null ? toInputDate(scheduledDate) : '';
+
+    const cancelledChecked = displayState === 'cancelled' ? ' checked' : '';
+
+    container.innerHTML = `
+      <div class="ap-date-card ap-date-card--editing">
+        <div class="ap-date-card__header">
+          <span class="ap-date-card__label">Shoot Date</span>
+          ${badgeHtml}
+        </div>
+        <div class="ap-date-warning">
+          ${WARN_SVG}
+          <span>This overrides the scheduled shoot date on the season calendar and printed scoresheets.</span>
+        </div>
+        <div class="ap-date-edit-row">
+          <input type="date" id="ap-shoot-date" class="ap-date-input" value="${inputValue}" min="${todayStr}" />
+          <label class="ap-cancelled-label">
+            <input type="checkbox" id="ap-cancelled"${cancelledChecked} /> Cancelled
+          </label>
+        </div>
+        <div class="ap-date-edit-actions">
+          <button id="ap-cancel-date-edit" class="btn-secondary">Cancel</button>
+          <button id="ap-save-date" class="btn-primary">Save Date</button>
+        </div>
+      </div>`;
+
+    const cancelledCb = host.querySelector<HTMLInputElement>('#ap-cancelled')!;
+    const dateInput = host.querySelector<HTMLInputElement>('#ap-shoot-date')!;
+    if (cancelledCb.checked) dateInput.disabled = true;
+
+    cancelledCb.addEventListener('change', () => {
+      dateInput.disabled = cancelledCb.checked;
+      if (cancelledCb.checked) dateInput.value = '';
+    });
+
+    host.querySelector('#ap-cancel-date-edit')?.addEventListener('click', () => {
+      this._dateEditMode = false;
+      this._updateDateSection();
+    });
+
+    host.querySelector('#ap-save-date')?.addEventListener('click', () => {
+      void this._saveDateOverride();
+    });
+  }
+
+  private async _saveDateOverride(): Promise<void> {
+    const host = this._host;
+    if (!host) return;
+    const year = this._ctx?.getYear() ?? 0;
+    const weekNumber = parseInt(host.querySelector<HTMLSelectElement>('#ap-week')!.value, 10);
+    const cancelledCb = host.querySelector<HTMLInputElement>('#ap-cancelled');
+    const dateInput = host.querySelector<HTMLInputElement>('#ap-shoot-date');
+    const saveBtn = host.querySelector<HTMLButtonElement>('#ap-save-date');
+    const cancelBtn = host.querySelector<HTMLButtonElement>('#ap-cancel-date-edit');
+
+    const isCancelled = cancelledCb?.checked ?? false;
+    const dateValue = dateInput?.value ?? '';
+
+    if (!isCancelled && !dateValue) {
+      showToast('error', 'Enter a date or check Cancelled.');
+      return;
+    }
+
+    if (saveBtn) saveBtn.disabled = true;
+    if (cancelBtn) cancelBtn.disabled = true;
+
+    const result = await this._scoreService.saveWeekDateOverride(
+      year,
+      weekNumber,
+      isCancelled ? null : dateValue,
+    );
+
+    if (result.success) {
+      this._dateEditMode = false;
+      showToast('success', isCancelled
+        ? `Week ${weekNumber} marked as cancelled.`
+        : `Shoot date for Week ${weekNumber} updated.`);
+      await this._ctx?.refreshSeason(); // triggers onSeasonChanged → re-render
+    } else {
+      if (saveBtn) saveBtn.disabled = false;
+      if (cancelBtn) cancelBtn.disabled = false;
+      showToast('error', `Failed to save date: ${result.error}`);
+    }
+  }
+
+  // ── Status helpers ───────────────────────────────────────────────────────
+
+  private _setStatus(message: string, type: '' | 'success' | 'error'): void {
+    setStatus(this._host?.querySelector('#ap-status') ?? null, message, type);
+  }
+
+  private _setPublishStatus(message: string, type: '' | 'success' | 'error'): void {
+    setStatus(this._host?.querySelector('#ap-publish-status') ?? null, message, type);
+  }
+}

--- a/src/components/admin-tabs/team-management-tab.ts
+++ b/src/components/admin-tabs/team-management-tab.ts
@@ -1,0 +1,331 @@
+/**
+ * Team Management tab — team list with inline edit + roster modal launcher.
+ *
+ * Owns the team table (name + captain + actions per row) and the inline
+ * add/edit row for team meta. The roster editor is its own self-contained
+ * dialog — see `./roster-modal.ts`.
+ *
+ * Reads shared teams cache from the shell via `ctx.getTeamsData()` and
+ * triggers refreshes via `ctx.refreshTeams()`. Re-renders on
+ * `onTeamsChanged()`.
+ */
+
+import { ScoreService } from '@/services/score-service';
+import { showToast } from '@/modules/ui';
+import {
+  PENCIL_SVG,
+  ROSTER_SVG,
+  TRASH_SVG,
+  attachAutocomplete,
+  showConfirmDialog,
+} from './admin-shared';
+import { openRosterModal } from './roster-modal';
+import type { AdminTab, AdminTabContext } from './types';
+
+/** Sentinel value used to indicate an "add new team" row is open. */
+const NEW_TEAM_SENTINEL = '__new__';
+
+export class TeamManagementTab implements AdminTab {
+  private _host: HTMLElement | null = null;
+  private _ctx: AdminTabContext | null = null;
+  private readonly _scoreService: ScoreService;
+
+  /** null = no edit open; NEW_TEAM_SENTINEL = add row open; else = teamId being edited */
+  private _editingTeamId: string | null = null;
+
+  constructor(scoreService: ScoreService) {
+    this._scoreService = scoreService;
+  }
+
+  mount(host: HTMLElement, ctx: AdminTabContext): void {
+    this._host = host;
+    this._ctx = ctx;
+    host.innerHTML = `<div id="ap-team-list"></div>`;
+    this._renderTeamList();
+  }
+
+  onYearChange(): void {
+    this._editingTeamId = null;
+    // Re-render after teams cache refresh — handled in onTeamsChanged.
+  }
+
+  onTeamsChanged(): void {
+    this._renderTeamList();
+  }
+
+  // ── Team list with inline editing ─────────────────────────────────────────
+
+  private _renderTeamList(): void {
+    const host = this._host;
+    if (!host) return;
+    const container = host.querySelector('#ap-team-list');
+    if (!container) return;
+    while (container.firstChild) container.removeChild(container.firstChild);
+
+    const teams = this._ctx?.getTeamsData() ?? [];
+    const editing = this._editingTeamId;
+
+    const heading = document.createElement('h3');
+    heading.className = 'admin-team-heading';
+    heading.textContent = 'Teams';
+    container.appendChild(heading);
+
+    const hasRows = teams.length > 0 || editing === NEW_TEAM_SENTINEL;
+
+    if (hasRows) {
+      const table = document.createElement('table');
+      table.className = 'admin-team-table';
+
+      const thead = table.createTHead();
+      const hrow = thead.insertRow();
+      for (const label of ['Team Name', 'Captain', '']) {
+        const th = document.createElement('th');
+        th.textContent = label;
+        hrow.appendChild(th);
+      }
+
+      const tbody = table.createTBody();
+
+      for (const team of teams) {
+        const tr = tbody.insertRow();
+        if (editing === team.id) {
+          this._buildEditRow(tr, team.name, team.captain, team.id);
+        } else {
+          this._buildDisplayRow(tr, team.name, team.captain, team.id, editing !== null);
+        }
+      }
+
+      if (editing === NEW_TEAM_SENTINEL) {
+        const tr = tbody.insertRow();
+        this._buildEditRow(tr, '', '', NEW_TEAM_SENTINEL);
+      }
+
+      const tableWrapper = document.createElement('div');
+      tableWrapper.className = 'admin-table-wrapper';
+      tableWrapper.appendChild(table);
+      container.appendChild(tableWrapper);
+    } else {
+      const empty = document.createElement('p');
+      empty.className = 'admin-team-empty';
+      empty.textContent = 'No teams for this year. Click "+ Add Team" to create one.';
+      container.appendChild(empty);
+    }
+
+    // "+ Add Team" button — disabled while any edit is open
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'btn-secondary admin-add-team-btn';
+    addBtn.textContent = '+ Add Team';
+    addBtn.disabled = editing !== null;
+    addBtn.addEventListener('click', () => {
+      this._editingTeamId = NEW_TEAM_SENTINEL;
+      this._renderTeamList();
+      setTimeout(() => {
+        this._host?.querySelector<HTMLInputElement>('.ap-team-edit-name')?.focus();
+      }, 0);
+    });
+    container.appendChild(addBtn);
+  }
+
+  private _buildDisplayRow(
+    tr: HTMLTableRowElement,
+    name: string,
+    captain: string,
+    teamId: string,
+    otherEditOpen: boolean,
+  ): void {
+    const nameCell = tr.insertCell();
+    nameCell.textContent = name;
+
+    const captainCell = tr.insertCell();
+    captainCell.textContent = captain;
+
+    const actionsCell = tr.insertCell();
+    actionsCell.className = 'admin-team-actions';
+
+    const pencilBtn = document.createElement('button');
+    pencilBtn.type = 'button';
+    pencilBtn.className = 'admin-icon-btn';
+    pencilBtn.setAttribute('aria-label', `Edit ${name}`);
+    pencilBtn.disabled = otherEditOpen;
+    pencilBtn.setAttribute('data-tooltip', 'Edit name & captain');
+    pencilBtn.innerHTML = PENCIL_SVG;
+    pencilBtn.addEventListener('click', () => {
+      this._editingTeamId = teamId;
+      this._renderTeamList();
+      setTimeout(() => {
+        this._host?.querySelector<HTMLInputElement>('.ap-team-edit-name')?.focus();
+      }, 0);
+    });
+    actionsCell.appendChild(pencilBtn);
+
+    const rosterBtn = document.createElement('button');
+    rosterBtn.type = 'button';
+    rosterBtn.className = 'admin-icon-btn';
+    rosterBtn.setAttribute('aria-label', `Edit roster for ${name}`);
+    rosterBtn.disabled = otherEditOpen;
+    rosterBtn.setAttribute('data-tooltip', 'Edit roster');
+    rosterBtn.innerHTML = ROSTER_SVG;
+    rosterBtn.addEventListener('click', () => this._launchRosterModal(teamId, name));
+    actionsCell.appendChild(rosterBtn);
+
+    const trashBtn = document.createElement('button');
+    trashBtn.type = 'button';
+    trashBtn.className = 'admin-icon-btn admin-icon-btn--danger';
+    trashBtn.setAttribute('aria-label', `Delete ${name}`);
+    trashBtn.disabled = otherEditOpen;
+    trashBtn.setAttribute('data-tooltip', 'Delete team');
+    trashBtn.innerHTML = TRASH_SVG;
+    trashBtn.addEventListener('click', () => {
+      const year = this._ctx?.getYear() ?? 0;
+      void this._confirmDeleteTeam(year, teamId, name);
+    });
+    actionsCell.appendChild(trashBtn);
+  }
+
+  private _buildEditRow(
+    tr: HTMLTableRowElement,
+    name: string,
+    captain: string,
+    teamId: string,
+  ): void {
+    tr.className = 'admin-team-row--editing';
+
+    const nameCell = tr.insertCell();
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'admin-input ap-team-edit-name';
+    nameInput.value = name;
+    nameInput.placeholder = 'Team name';
+    nameInput.autocomplete = 'off';
+    nameCell.appendChild(nameInput);
+    attachAutocomplete(nameInput, () => this._ctx?.getTeamNames() ?? []);
+
+    const captainCell = tr.insertCell();
+    const captainInput = document.createElement('input');
+    captainInput.type = 'text';
+    captainInput.className = 'admin-input ap-team-edit-captain';
+    captainInput.value = captain;
+    captainInput.placeholder = 'Captain name';
+    captainInput.autocomplete = 'off';
+    captainCell.appendChild(captainInput);
+    attachAutocomplete(captainInput, () => this._ctx?.getCurrentYearShooterNames() ?? []);
+
+    const actionsCell = tr.insertCell();
+    actionsCell.className = 'admin-team-actions admin-team-actions--edit';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'btn-primary';
+    saveBtn.textContent = teamId === NEW_TEAM_SENTINEL ? 'Add' : 'Save';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+
+    const setDisabled = (v: boolean) => {
+      saveBtn.disabled = v;
+      cancelBtn.disabled = v;
+      nameInput.disabled = v;
+      captainInput.disabled = v;
+    };
+
+    saveBtn.addEventListener('click', () => {
+      const n = nameInput.value.trim();
+      const c = captainInput.value.trim();
+      if (!n || (teamId !== NEW_TEAM_SENTINEL && !c)) {
+        showToast('error', 'Team name is required. Captain is required when editing.');
+        nameInput.focus();
+        return;
+      }
+      setDisabled(true);
+      if (teamId === NEW_TEAM_SENTINEL) {
+        void this._submitAddTeam(n, c, setDisabled);
+      } else {
+        void this._submitUpdateTeam(teamId, n, c, setDisabled);
+      }
+    });
+
+    const onEnter = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') saveBtn.click();
+    };
+    nameInput.addEventListener('keydown', onEnter);
+    captainInput.addEventListener('keydown', onEnter);
+
+    cancelBtn.addEventListener('click', () => {
+      this._editingTeamId = null;
+      this._renderTeamList();
+    });
+
+    actionsCell.appendChild(saveBtn);
+    actionsCell.appendChild(cancelBtn);
+  }
+
+  private async _submitAddTeam(
+    name: string,
+    captain: string,
+    setDisabled: (v: boolean) => void,
+  ): Promise<void> {
+    const year = this._ctx?.getYear() ?? 0;
+    const result = await this._scoreService.createTeam(year, name, captain);
+    setDisabled(false);
+
+    if (result.success) {
+      this._editingTeamId = null;
+      showToast('success', `Team "${result.data.name}" created for ${year}.`);
+      void this._ctx?.refreshTeams();
+    } else {
+      showToast('error', `Failed to create team: ${result.error}`);
+    }
+  }
+
+  private async _submitUpdateTeam(
+    teamId: string,
+    name: string,
+    captain: string,
+    setDisabled: (v: boolean) => void,
+  ): Promise<void> {
+    const year = this._ctx?.getYear() ?? 0;
+    const result = await this._scoreService.updateTeamMeta(year, teamId, name, captain);
+    setDisabled(false);
+
+    if (result.success) {
+      this._editingTeamId = null;
+      showToast('success', `Team updated.`);
+      void this._ctx?.refreshTeams();
+    } else {
+      showToast('error', `Failed to update team: ${result.error}`);
+    }
+  }
+
+  private async _confirmDeleteTeam(year: number, teamId: string, teamName: string): Promise<void> {
+    const confirmed = await showConfirmDialog({
+      title: 'Delete Team',
+      warning: `This will permanently remove "${teamName}" and all its score entries from the ${year} season. This cannot be undone.`,
+      nameToType: teamName,
+      deleteLabel: 'Delete Team',
+    });
+    if (!confirmed) return;
+
+    const result = await this._scoreService.deleteTeam(year, teamId);
+    if (result.success) {
+      showToast('success', `Team "${teamName}" deleted from ${year}.`);
+      void this._ctx?.refreshTeams();
+    } else {
+      showToast('error', `Failed to delete team: ${result.error}`);
+    }
+  }
+
+  private _launchRosterModal(teamId: string, teamName: string): void {
+    const ctx = this._ctx;
+    if (!ctx) return;
+    openRosterModal({
+      teamId,
+      teamName,
+      ctx,
+      scoreService: this._scoreService,
+      onSaved: () => void ctx.refreshTeams(),
+    });
+  }
+}

--- a/src/components/admin-tabs/types.ts
+++ b/src/components/admin-tabs/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Tab module contracts for <admin-panel>.
+ *
+ * The shell (`src/components/admin-panel.ts`) owns shared state — current
+ * year, teams cache, season cache, name suggestion caches — and notifies
+ * each tab of relevant changes via the lifecycle hooks below. Tabs render
+ * their own DOM into a host `<div>` provided at mount time.
+ */
+
+import type { Team } from '@/types/score';
+import type { Season } from '@/types/season';
+
+export interface ConfirmDialogOptions {
+  title: string;
+  warning: string;
+  nameToType: string;
+  deleteLabel: string;
+}
+
+export interface AdminTabContext {
+  /** Current year selected in the shared #ap-year selector. */
+  getYear(): number;
+  /** Cached teams for the current year (null until first refresh). */
+  getTeamsData(): Team[] | null;
+  /** Cached season metadata for the current year (null until first refresh). */
+  getSeasonData(): Season | null;
+  /** Refetch teams and notify all tabs that teams data changed. */
+  refreshTeams(): Promise<void>;
+  /** Refetch season metadata and notify all tabs that season data changed. */
+  refreshSeason(): Promise<void>;
+  /** Suggestion list of shooter names across the current + 2 prior years. */
+  getShooterSuggestions(year: number): Promise<string[]>;
+  /** Suggestion list of team names across the current + 2 prior years. */
+  getTeamNameSuggestions(year: number): Promise<string[]>;
+  /** Synchronously read shooter names from the cached current-year teams. */
+  getCurrentYearShooterNames(): string[];
+  /** Synchronously read cached team-name suggestions (or current-year teams as fallback). */
+  getTeamNames(): string[];
+  /** Synchronously read the cached cross-year shooter suggestions (no fetch). */
+  getCachedShooterNames(): string[];
+}
+
+export interface AdminTab {
+  /** Render initial DOM into `host` and attach event listeners. */
+  mount(host: HTMLElement, ctx: AdminTabContext): void;
+  /** Year selector changed — reset transient state, refresh local data. */
+  onYearChange?(): void;
+  /** Teams cache was refetched — re-render dependent UI. */
+  onTeamsChanged?(): void;
+  /** Season cache was refetched — re-render dependent UI. */
+  onSeasonChanged?(): void;
+  /** Tab became the active visible tab. */
+  onActivate?(): void;
+}

--- a/src/components/admin-users-panel.ts
+++ b/src/components/admin-users-panel.ts
@@ -1,0 +1,241 @@
+/**
+ * <admin-users-panel> — Custom Element rendering the Users tab.
+ *
+ * Visible to owner + admin (gated upstream by main.ts route guard +
+ * the admin-panel-container DOM toggle in main.ts._applyAdminViewState).
+ *
+ * Responsibilities:
+ *   - Render a paginated user list with displayName / email / role /
+ *     last sign-in / created.
+ *   - For owner: render a role <select> per row that calls
+ *     setUserRole; for admin: plain-text role.
+ *   - Confirmation dialog before any role change; toast feedback on
+ *     success or callable error (mapped to operator-friendly text).
+ *
+ * Lifecycle: subscribes to onRoleChange in connectedCallback so the
+ * dropdown vs. text rendering updates live if the current user's
+ * role changes mid-session. Unsubscribes in disconnectedCallback to
+ * comply with constitution §IV.2 (no leaked listeners).
+ */
+
+import type { Timestamp, DocumentSnapshot } from 'firebase/firestore';
+import { onRoleChange } from '@/modules/role';
+import { escapeHtml, showToast } from '@/modules/ui';
+import {
+  listUsers,
+  setUserRole,
+  setUserRoleErrorMessage,
+} from '@/services/admin-user-service';
+import type { Role, UserDoc } from '@/types/user';
+import { ROLES } from '@/types/user';
+
+const PAGE_SIZE = 20;
+
+function fmtTimestamp(ts: Timestamp | null | undefined, withTime: boolean): string {
+  if (!ts || typeof ts.toDate !== 'function') return '—';
+  const iso = ts.toDate().toISOString();
+  return withTime ? iso.slice(0, 16).replace('T', ' ') : iso.slice(0, 10);
+}
+
+class AdminUsersPanel extends HTMLElement {
+  private _users: UserDoc[] = [];
+  private _nextCursor: DocumentSnapshot | null = null;
+  private _currentRole: Role | null = null;
+  private _roleUnsub: (() => void) | null = null;
+  private _loading = false;
+  private _initialized = false;
+
+  connectedCallback(): void {
+    this.innerHTML = `
+      <section class="users-panel">
+        <h2>Users</h2>
+        <div class="users-panel__status" aria-live="polite"></div>
+        <table class="users-table" hidden>
+          <thead>
+            <tr>
+              <th scope="col">Display name</th>
+              <th scope="col">Email</th>
+              <th scope="col">Role</th>
+              <th scope="col">Last sign-in</th>
+              <th scope="col">Created</th>
+            </tr>
+          </thead>
+          <tbody class="users-table__body"></tbody>
+        </table>
+        <div class="users-panel__empty" hidden>No users yet.</div>
+        <div class="users-panel__error" hidden role="alert"></div>
+        <button type="button" class="users-panel__load-more btn-secondary" hidden>Load more</button>
+      </section>
+    `;
+
+    this.querySelector('.users-table__body')
+      ?.addEventListener('change', (e) => this._handleRoleChange(e));
+    this.querySelector('.users-panel__load-more')
+      ?.addEventListener('click', () => void this._fetch(true));
+
+    this._roleUnsub = onRoleChange((role) => {
+      const previous = this._currentRole;
+      this._currentRole = role;
+      if (this._initialized) {
+        // Only owner/admin should see this component, but the role
+        // observer still fires; if owner ↔ admin, re-render rows so
+        // the dropdown vs. text changes accordingly.
+        if (previous !== role) this._renderRows();
+      } else if (role === 'owner' || role === 'admin') {
+        // First fire with elevated role — initial fetch.
+        this._initialized = true;
+        void this._fetch(false);
+      }
+    });
+  }
+
+  disconnectedCallback(): void {
+    this._roleUnsub?.();
+    this._roleUnsub = null;
+  }
+
+  // ─── Data flow ──────────────────────────────────────────────────────────────
+
+  private async _fetch(append: boolean): Promise<void> {
+    if (this._loading) return;
+    this._loading = true;
+    this._setStatus(append ? 'Loading more…' : 'Loading users…');
+    this._setError(null);
+
+    try {
+      const page = await listUsers({
+        pageSize: PAGE_SIZE,
+        cursor: append ? this._nextCursor : null,
+      });
+      if (append) {
+        this._users.push(...page.users);
+      } else {
+        this._users = page.users;
+      }
+      this._nextCursor = page.nextCursor;
+      this._renderRows();
+      this._setStatus('');
+    } catch (e) {
+      console.error('[admin-users-panel] fetch error:', e);
+      this._setError('Could not load users. See console for details.');
+      this._setStatus('');
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  private _renderRows(): void {
+    const tbody = this.querySelector<HTMLTableSectionElement>('.users-table__body');
+    const table = this.querySelector<HTMLTableElement>('.users-table');
+    const empty = this.querySelector<HTMLElement>('.users-panel__empty');
+    const loadMore = this.querySelector<HTMLButtonElement>('.users-panel__load-more');
+    if (!tbody || !table || !empty || !loadMore) return;
+
+    if (this._users.length === 0) {
+      table.hidden = true;
+      empty.hidden = false;
+      loadMore.hidden = true;
+      return;
+    }
+
+    table.hidden = false;
+    empty.hidden = true;
+    loadMore.hidden = this._nextCursor === null;
+
+    const isOwner = this._currentRole === 'owner';
+    tbody.innerHTML = this._users.map((u) => this._rowHtml(u, isOwner)).join('');
+  }
+
+  private _rowHtml(user: UserDoc, isOwner: boolean): string {
+    const uid = escapeHtml(user.uid);
+    const display = escapeHtml(user.displayName ?? '—');
+    const email = escapeHtml(user.email ?? '—');
+    const lastSignIn = escapeHtml(fmtTimestamp(user.lastSignInAt ?? null, true));
+    const createdAt = escapeHtml(fmtTimestamp(user.createdAt ?? null, false));
+
+    const roleCell = isOwner
+      ? `<select class="users-table__role-select" data-uid="${uid}" data-current="${user.role}" aria-label="Role for ${display}">
+          ${ROLES.map((r) => `<option value="${r}"${r === user.role ? ' selected' : ''}>${r}</option>`).join('')}
+        </select>`
+      : escapeHtml(user.role);
+
+    return `
+      <tr data-uid="${uid}">
+        <td>${display}</td>
+        <td>${email}</td>
+        <td>${roleCell}</td>
+        <td>${lastSignIn}</td>
+        <td>${createdAt}</td>
+      </tr>
+    `;
+  }
+
+  // ─── Role change handling ───────────────────────────────────────────────────
+
+  private async _handleRoleChange(e: Event): Promise<void> {
+    const target = e.target as HTMLElement | null;
+    if (!target?.classList.contains('users-table__role-select')) return;
+    const select = target as HTMLSelectElement;
+
+    const targetUid = select.dataset['uid'];
+    const previousRole = select.dataset['current'] as Role | undefined;
+    const newRole = select.value as Role;
+
+    if (!targetUid || !previousRole || previousRole === newRole) return;
+
+    const user = this._users.find((u) => u.uid === targetUid);
+    const display = user?.displayName ?? user?.email ?? targetUid;
+
+    const ok = window.confirm(
+      `Change ${display}'s role from ${previousRole} to ${newRole}?`,
+    );
+    if (!ok) {
+      select.value = previousRole;
+      return;
+    }
+
+    select.disabled = true;
+    const result = await setUserRole(targetUid, newRole);
+    select.disabled = false;
+
+    if (result.ok) {
+      showToast('success', `Role changed: ${display} → ${newRole}`);
+      // Update local state so subsequent dropdown changes have the
+      // correct from-role baseline. Mirror writes are propagated by
+      // the server but we don't refetch the whole page.
+      if (user) {
+        user.role = newRole;
+      }
+      select.dataset['current'] = newRole;
+    } else {
+      const message = setUserRoleErrorMessage(result.code);
+      showToast('error', message);
+      // Revert the dropdown so it stays in sync with reality.
+      select.value = previousRole;
+      console.error('[admin-users-panel] setUserRole failed:', result);
+    }
+  }
+
+  // ─── DOM helpers ────────────────────────────────────────────────────────────
+
+  private _setStatus(message: string): void {
+    const el = this.querySelector('.users-panel__status');
+    if (el) el.textContent = message;
+  }
+
+  private _setError(message: string | null): void {
+    const el = this.querySelector<HTMLElement>('.users-panel__error');
+    if (!el) return;
+    if (message) {
+      el.textContent = message;
+      el.hidden = false;
+    } else {
+      el.textContent = '';
+      el.hidden = true;
+    }
+  }
+}
+
+if (!customElements.get('admin-users-panel')) {
+  customElements.define('admin-users-panel', AdminUsersPanel);
+}

--- a/src/firebase-config.ts
+++ b/src/firebase-config.ts
@@ -3,11 +3,16 @@
  *
  * Reads config values from VITE_FIREBASE_* environment variables.
  * Copy .env.example to .env and fill in values from Firebase console.
+ *
+ * Emulator-aware: when VITE_USE_EMULATOR=true, the Auth and Firestore
+ * SDKs connect to the local emulator suite instead of production.
+ * Set automatically by `npm run dev` (which invokes `firebase
+ * emulators:exec`) — never manually for production builds.
  */
 
 import { initializeApp } from 'firebase/app';
-import { getFirestore, type Firestore } from 'firebase/firestore';
-import { getAuth, type Auth } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator, type Firestore } from 'firebase/firestore';
+import { getAuth, connectAuthEmulator, type Auth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -21,6 +26,7 @@ const firebaseConfig = {
 
 export const isDevelopment = import.meta.env.DEV;
 export const isProduction = import.meta.env.PROD;
+export const useEmulator = import.meta.env['VITE_USE_EMULATOR'] === 'true';
 
 /**
  * Validates that all required Firebase config values are present.
@@ -39,3 +45,10 @@ const app = initializeApp(firebaseConfig);
 
 export const db: Firestore = getFirestore(app);
 export const auth: Auth = getAuth(app);
+
+if (useEmulator) {
+  connectAuthEmulator(auth, 'http://127.0.0.1:9099', { disableWarnings: true });
+  connectFirestoreEmulator(db, '127.0.0.1', 8080);
+  // eslint-disable-next-line no-console
+  console.info('[firebase] Connected to local emulator suite (auth:9099, firestore:8080).');
+}

--- a/src/infrastructure/appcheck.ts
+++ b/src/infrastructure/appcheck.ts
@@ -1,0 +1,45 @@
+/**
+ * Firebase App Check initialization.
+ *
+ * Skipped entirely under VITE_USE_EMULATOR (the emulator suite does
+ * not implement the App Check exchange endpoint, and the Cloud
+ * Function gates enforceAppCheck on FUNCTIONS_EMULATOR server-side).
+ *
+ * In staging/prod, requires VITE_APPCHECK_SITE_KEY to be a registered
+ * reCAPTCHA Enterprise site key for the project's hostnames. Without
+ * it, App Check init is skipped and a console warning is emitted —
+ * the deployed Cloud Function will reject calls without an App Check
+ * token, so the warning is operational, not silent.
+ */
+
+import { getApp } from 'firebase/app';
+import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
+import { useEmulator } from '@/firebase-config';
+
+let initialized = false;
+
+export function initAppCheck(): void {
+  if (initialized) return;
+
+  if (useEmulator) {
+    initialized = true;
+    return;
+  }
+
+  const siteKey = import.meta.env['VITE_APPCHECK_SITE_KEY'];
+  if (!siteKey) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[appcheck] VITE_APPCHECK_SITE_KEY not set; App Check init skipped. ' +
+        'setUserRole and other enforced callables will reject this client.',
+    );
+    initialized = true;
+    return;
+  }
+
+  initializeAppCheck(getApp(), {
+    provider: new ReCaptchaEnterpriseProvider(siteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+  initialized = true;
+}

--- a/src/infrastructure/appcheck.ts
+++ b/src/infrastructure/appcheck.ts
@@ -5,7 +5,7 @@
  * not implement the App Check exchange endpoint, and the Cloud
  * Function gates enforceAppCheck on FUNCTIONS_EMULATOR server-side).
  *
- * In staging/prod, requires VITE_APPCHECK_SITE_KEY to be a registered
+ * In staging/prod, requires VITE_RECAPTCHA_ENTERPRISE_SITE_KEY to be a registered
  * reCAPTCHA Enterprise site key for the project's hostnames. Without
  * it, App Check init is skipped and a console warning is emitted —
  * the deployed Cloud Function will reject calls without an App Check
@@ -26,11 +26,11 @@ export function initAppCheck(): void {
     return;
   }
 
-  const siteKey = import.meta.env['VITE_APPCHECK_SITE_KEY'];
+  const siteKey = import.meta.env['VITE_RECAPTCHA_ENTERPRISE_SITE_KEY'];
   if (!siteKey) {
     // eslint-disable-next-line no-console
     console.warn(
-      '[appcheck] VITE_APPCHECK_SITE_KEY not set; App Check init skipped. ' +
+      '[appcheck] VITE_RECAPTCHA_ENTERPRISE_SITE_KEY not set; App Check init skipped. ' +
         'setUserRole and other enforced callables will reject this client.',
     );
     initialized = true;

--- a/src/infrastructure/functions.ts
+++ b/src/infrastructure/functions.ts
@@ -1,0 +1,39 @@
+/**
+ * Cloud Functions client wrapper.
+ *
+ * Lazy-init: getFunctions runs once on first callable invocation.
+ * Emulator-aware: when VITE_USE_EMULATOR=true, callable invocations
+ * go to the functions emulator at 127.0.0.1:5001 instead of the live
+ * us-central1 deployment.
+ */
+
+import { getApp } from 'firebase/app';
+import {
+  getFunctions,
+  connectFunctionsEmulator,
+  httpsCallable,
+  type Functions,
+  type HttpsCallable,
+} from 'firebase/functions';
+import { useEmulator } from '@/firebase-config';
+
+const REGION = 'us-central1';
+
+let _functions: Functions | null = null;
+
+function getFunctionsInstance(): Functions {
+  if (_functions) return _functions;
+  _functions = getFunctions(getApp(), REGION);
+  if (useEmulator) {
+    connectFunctionsEmulator(_functions, '127.0.0.1', 5001);
+  }
+  return _functions;
+}
+
+/**
+ * Wrap a callable Cloud Function by name. Caller-supplied generics
+ * type the request and response payloads.
+ */
+export function callable<TIn = unknown, TOut = unknown>(name: string): HttpsCallable<TIn, TOut> {
+  return httpsCallable<TIn, TOut>(getFunctionsInstance(), name);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,12 +107,18 @@ class App {
     this._router!.register('/admin', () => this._showAdmin());
 
     this._router!.onBeforeNavigate((path) => {
-      // Route guard: /admin requires owner|admin. Non-elevated callers
-      // are redirected to / (rules + the callable still enforce server-
-      // side; this is just a UX nicety).
-      if (path === '/admin' && !this._isElevated()) {
-        window.location.hash = '#/';
-        return false;
+      // Route guard: /admin is the SOLE entry point for sign-in, so
+      // signed-out users must be allowed through (they'll see the
+      // sign-in view via _applyAdminViewState DOM toggle). Only bounce
+      // signed-in users whose role is 'user' — they can't act on
+      // /admin and the redirect avoids a dead-end "unauthorized" view.
+      // Server-side rules + the callable still enforce; this is UX.
+      if (path === '/admin') {
+        const signedIn = !!this._auth!.currentUser;
+        if (signedIn && !this._isElevated()) {
+          window.location.hash = '#/';
+          return false;
+        }
       }
       return true;
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import './components/season-calendar';
 import { NavigationModule } from './modules/navigation';
 import { RouterModule } from './modules/router';
 import { AuthModule } from './modules/auth';
+import { initAppCheck } from './infrastructure/appcheck';
 
 import { homeView } from './views/home';
 import { scorecardsView } from './views/scorecards';
@@ -36,6 +37,8 @@ class App {
   private _adminAuthUnsubscribe: (() => void) | null = null;
 
   init(): void {
+    initAppCheck();
+
     this._mainContent = document.getElementById('main-content');
     this._navigation = new NavigationModule();
     this._router = new RouterModule();

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import './components/home-announcements';
 import './components/site-banner';
 import './components/season-scorecards';
 import './components/admin-panel';
+import './components/admin-users-panel';
 import './components/scoresheet-generator';
 import './components/yardage-table';
 import './components/season-calendar';

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,6 @@ import './components/home-announcements';
 import './components/site-banner';
 import './components/season-scorecards';
 import './components/admin-panel';
-import './components/admin-users-panel';
 import './components/scoresheet-generator';
 import './components/yardage-table';
 import './components/season-calendar';
@@ -95,16 +94,18 @@ class App {
       userDisplay.textContent = this._auth!.currentUser?.email ?? '';
     }
 
-    // Lazy-mount admin Custom Elements only when the viewer is
-    // elevated. Web Components run connectedCallback the moment they
-    // exist in the DOM (even inside a hidden parent), and admin-panel
-    // fetches data eagerly — keeping it out of the DOM avoids spurious
-    // rule denials in the console for non-elevated viewers.
+    // Lazy-mount <admin-panel> only when the viewer is elevated. Web
+    // Components run connectedCallback the moment they exist in the
+    // DOM (even inside a hidden parent), and admin-panel fetches data
+    // eagerly — keeping it out of the DOM avoids spurious rule denials
+    // in the console for non-elevated viewers. The Users tab inside
+    // admin-panel hosts <admin-users-panel> as a child element, so it
+    // mounts/unmounts together with the shell.
     const mount = document.getElementById('admin-panel-mount');
     if (mount) {
       const isMounted = mount.querySelector('admin-panel') !== null;
       if (elevated && !isMounted) {
-        mount.innerHTML = '<admin-panel></admin-panel><admin-users-panel></admin-users-panel>';
+        mount.innerHTML = '<admin-panel></admin-panel>';
       } else if (!elevated && isMounted) {
         // Clearing innerHTML disconnects the components, firing their
         // disconnectedCallback so they tear down listeners cleanly.

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,23 @@ class App {
     if (userDisplay) {
       userDisplay.textContent = this._auth!.currentUser?.email ?? '';
     }
+
+    // Lazy-mount admin Custom Elements only when the viewer is
+    // elevated. Web Components run connectedCallback the moment they
+    // exist in the DOM (even inside a hidden parent), and admin-panel
+    // fetches data eagerly — keeping it out of the DOM avoids spurious
+    // rule denials in the console for non-elevated viewers.
+    const mount = document.getElementById('admin-panel-mount');
+    if (mount) {
+      const isMounted = mount.querySelector('admin-panel') !== null;
+      if (elevated && !isMounted) {
+        mount.innerHTML = '<admin-panel></admin-panel><admin-users-panel></admin-users-panel>';
+      } else if (!elevated && isMounted) {
+        // Clearing innerHTML disconnects the components, firing their
+        // disconnectedCallback so they tear down listeners cleanly.
+        mount.innerHTML = '';
+      }
+    }
   }
 
   // ─── Routing ────────────────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,11 @@
  * main.ts — Application entry point
  *
  * Initializes navigation, router, and renders the correct view
- * based on the current URL hash.
+ * based on the current URL hash. Maintains a single role observer
+ * (modules/role.ts onRoleChange) for the page lifetime so the
+ * navigation, admin-view DOM toggle, and route guard all react to
+ * sign-in/out and server-driven role changes (via AuthModule's
+ * roleChangedAt snapshot listener — see modules/auth.ts).
  */
 
 import './styles/main.css';
@@ -18,6 +22,8 @@ import './components/season-calendar';
 import { NavigationModule } from './modules/navigation';
 import { RouterModule } from './modules/router';
 import { AuthModule } from './modules/auth';
+import { onRoleChange } from './modules/role';
+import type { Role } from './types/user';
 import { initAppCheck } from './infrastructure/appcheck';
 
 import { homeView } from './views/home';
@@ -27,16 +33,15 @@ import { aboutView } from './views/about';
 import { downloadsView } from './views/downloads';
 import { adminView } from './views/admin';
 
-import type { User } from 'firebase/auth';
-
 class App {
   private _navigation: NavigationModule | null = null;
   private _router: RouterModule | null = null;
   private _mainContent: HTMLElement | null = null;
   private _auth: AuthModule | null = null;
-  private _adminAuthUnsubscribe: (() => void) | null = null;
+  private _roleUnsubscribe: (() => void) | null = null;
+  private _currentRole: Role | null = null;
 
-  init(): void {
+  async init(): Promise<void> {
     initAppCheck();
 
     this._mainContent = document.getElementById('main-content');
@@ -45,9 +50,52 @@ class App {
     this._auth = new AuthModule();
 
     this._navigation.init();
+
+    // Wait for the initial role read (sign-in restore from local
+    // persistence, or null) before registering routes so the /admin
+    // guard sees a valid value on first deep-link.
+    await this._initRoleObserver();
+
     this._setupRoutes();
     this._router.init();
   }
+
+  // ─── Role observation ───────────────────────────────────────────────────────
+
+  private _initRoleObserver(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let resolved = false;
+      this._roleUnsubscribe = onRoleChange((role) => {
+        this._currentRole = role;
+        this._navigation!.updateAuthState(this._auth!.currentUser, role);
+        this._applyAdminViewState();
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      });
+    });
+  }
+
+  private _isElevated(): boolean {
+    return this._currentRole === 'owner' || this._currentRole === 'admin';
+  }
+
+  private _applyAdminViewState(): void {
+    const elevated = this._isElevated();
+    const signedIn = !!this._auth!.currentUser;
+
+    document.getElementById('admin-login')?.toggleAttribute('hidden', signedIn);
+    document.getElementById('admin-unauthorized')?.toggleAttribute('hidden', !signedIn || elevated);
+    document.getElementById('admin-panel-container')?.toggleAttribute('hidden', !signedIn || !elevated);
+
+    const userDisplay = document.getElementById('admin-user-display');
+    if (userDisplay) {
+      userDisplay.textContent = this._auth!.currentUser?.email ?? '';
+    }
+  }
+
+  // ─── Routing ────────────────────────────────────────────────────────────────
 
   private _setupRoutes(): void {
     this._router!.register('/', () => this._showHome());
@@ -58,9 +106,14 @@ class App {
     this._router!.register('/admin', () => this._showAdmin());
 
     this._router!.onBeforeNavigate((path) => {
-      if (this._router!.getCurrentRoute() === '/admin' && path !== '/admin') {
-        this._cleanupAdmin();
+      // Route guard: /admin requires owner|admin. Non-elevated callers
+      // are redirected to / (rules + the callable still enforce server-
+      // side; this is just a UX nicety).
+      if (path === '/admin' && !this._isElevated()) {
+        window.location.hash = '#/';
+        return false;
       }
+      return true;
     });
   }
 
@@ -111,48 +164,20 @@ class App {
     this._navigation!.setActiveLink('/admin');
     this._navigation!.closeDropdown();
     this._navigation!.closeBurgerNav();
-    this._initAdminAuth();
+    this._wireAdminAuthButtons();
+    this._applyAdminViewState();
     window.scrollTo(0, 0);
   }
 
-  // ─── Admin auth ──────────────────────────────────────────────────────────────
+  // ─── Admin auth buttons (wired each time the view is rendered) ──────────────
 
-  private _initAdminAuth(): void {
-    const applyAuthState = async (user: User | null): Promise<void> => {
-      this._navigation!.updateAuthState(user);
-
-      let isAdmin = false;
-      if (user) {
-        isAdmin = await this._auth!.isAdmin();
-      }
-
-      document.getElementById('admin-login')?.toggleAttribute('hidden', !!user);
-      document.getElementById('admin-unauthorized')?.toggleAttribute('hidden', !user || isAdmin);
-      document.getElementById('admin-panel-container')?.toggleAttribute('hidden', !user || !isAdmin);
-
-      const userDisplay = document.getElementById('admin-user-display');
-      if (userDisplay) {
-        userDisplay.textContent = user ? (user.email ?? '') : '';
-      }
-    };
-
-    void applyAuthState(this._auth!.currentUser);
-
-    this._adminAuthUnsubscribe = this._auth!.onAuthStateChanged((user) => void applyAuthState(user));
-
+  private _wireAdminAuthButtons(): void {
     document.getElementById('admin-sign-in')
       ?.addEventListener('click', () => void this._auth!.signIn());
     document.getElementById('admin-sign-out')
       ?.addEventListener('click', () => void this._auth!.signOut());
     document.getElementById('admin-sign-out-unauth')
       ?.addEventListener('click', () => void this._auth!.signOut());
-  }
-
-  private _cleanupAdmin(): void {
-    if (this._adminAuthUnsubscribe) {
-      this._adminAuthUnsubscribe();
-      this._adminAuthUnsubscribe = null;
-    }
   }
 
   // ─── Private helpers ─────────────────────────────────────────────────────────
@@ -166,5 +191,5 @@ class App {
 
 document.addEventListener('DOMContentLoaded', () => {
   const app = new App();
-  app.init();
+  void app.init();
 });

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,10 +1,27 @@
 /**
- * AuthModule — Firebase Auth wrapper
+ * AuthModule — Firebase Auth wrapper.
  *
- * Provides Google sign-in/out and auth-state observation.
+ * Responsibilities:
+ *   - Google sign-in/out via popup
+ *   - Auth-state observation (onAuthStateChanged)
+ *   - Reading the role custom claim (delegates to modules/role.ts)
+ *   - Forced token refresh in response to server-driven role changes
+ *
+ * Role-change propagation:
+ *   When a user is signed in, AuthModule maintains an internal
+ *   onSnapshot listener on `users/{currentUid}` and watches the
+ *   `roleChangedAt` field. When the server bumps it (because
+ *   setUserRole or set-role.js ran), AuthModule calls refreshRole
+ *   to force a token refresh; the new claim then propagates to all
+ *   subscribers of `onIdTokenChanged` (including modules/role.ts'
+ *   onRoleChange).
+ *
+ *   The snapshot listener is owned by AuthModule and lives only while
+ *   a user is signed in — it tears down on sign-out so we don't leak
+ *   listeners (per constitution §IV.2).
  */
 
-import { auth } from '@/firebase-config';
+import { auth, db } from '@/firebase-config';
 import {
   GoogleAuthProvider,
   signInWithPopup,
@@ -13,10 +30,26 @@ import {
   type User,
   type UserCredential,
 } from 'firebase/auth';
+import { doc, onSnapshot, type Unsubscribe } from 'firebase/firestore';
 import { type Result, success, failure } from '@/repositories/score-repository';
+import { getRole, refreshRole } from '@/modules/role';
+import type { Role } from '@/types/user';
 
 export class AuthModule {
   private readonly _provider = new GoogleAuthProvider();
+  private _snapshotUnsub: Unsubscribe | null = null;
+  private _lastRoleChangedAtMs: number | null = null;
+  private _internalAuthUnsub: () => void;
+
+  constructor() {
+    // Internal: keep the role-change snapshot listener in sync with
+    // sign-in/sign-out lifecycle. Exposed onAuthStateChanged is for
+    // consumers; this internal subscription is independent of it.
+    this._internalAuthUnsub = firebaseOnAuthStateChanged(auth, (user) => {
+      this._teardownSnapshot();
+      if (user) this._setupSnapshot(user.uid);
+    });
+  }
 
   get currentUser(): User | null {
     return auth.currentUser;
@@ -42,13 +75,69 @@ export class AuthModule {
     }
   }
 
-  async isAdmin(): Promise<boolean> {
-    if (!auth.currentUser) return false;
-    const tokenResult = await auth.currentUser.getIdTokenResult();
-    return tokenResult.claims['admin'] === true;
+  /**
+   * Read the current user's role from the ID token claim. Returns
+   * null if signed out or if the claim is missing/invalid.
+   *
+   * @param force pass true to force a token refresh before reading
+   */
+  async getRole(force = false): Promise<Role | null> {
+    return getRole(force);
+  }
+
+  /**
+   * Force a token refresh and return the freshly-read role. Used
+   * imperatively (e.g. after a known role change) when waiting for
+   * the snapshot-driven refresh isn't acceptable.
+   */
+  async refreshTokenAndRole(): Promise<Role | null> {
+    return refreshRole();
   }
 
   onAuthStateChanged(callback: (user: User | null) => void): () => void {
     return firebaseOnAuthStateChanged(auth, callback);
+  }
+
+  /**
+   * Tear down the AuthModule. Currently only useful in tests; the
+   * production app keeps a single AuthModule for the page lifetime.
+   */
+  destroy(): void {
+    this._teardownSnapshot();
+    this._internalAuthUnsub();
+  }
+
+  // ─── Internal: roleChangedAt snapshot listener ──────────────────────────
+
+  private _setupSnapshot(uid: string): void {
+    this._snapshotUnsub = onSnapshot(doc(db, 'users', uid), async (snap) => {
+      if (!snap.exists()) return;
+      const ts = snap.data()?.['roleChangedAt'];
+      const tsMs = (ts && typeof ts.toMillis === 'function') ? (ts.toMillis() as number) : null;
+
+      if (this._lastRoleChangedAtMs === null) {
+        // First snapshot after sign-in — establish baseline. Don't
+        // force-refresh; the token's claim is already up to date.
+        this._lastRoleChangedAtMs = tsMs ?? 0;
+        return;
+      }
+
+      if (tsMs !== null && tsMs !== this._lastRoleChangedAtMs) {
+        // Server bumped the role mid-session. Force token refresh so
+        // the rules engine sees the new claim immediately and
+        // onIdTokenChanged subscribers (modules/role.ts) propagate
+        // the change to UI consumers.
+        await refreshRole();
+        this._lastRoleChangedAtMs = tsMs;
+      }
+    });
+  }
+
+  private _teardownSnapshot(): void {
+    if (this._snapshotUnsub) {
+      this._snapshotUnsub();
+      this._snapshotUnsub = null;
+    }
+    this._lastRoleChangedAtMs = null;
   }
 }

--- a/src/modules/navigation.ts
+++ b/src/modules/navigation.ts
@@ -9,6 +9,7 @@
  */
 
 import type { User } from 'firebase/auth';
+import type { Role } from '@/types/user';
 
 const MOON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
 const SUN_SVG  = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>`;
@@ -78,8 +79,19 @@ export class NavigationModule {
     }
   }
 
-  updateAuthState(_user: User | null): void {
-    // no-op — wired in main.ts for admin sign-in display
+  /**
+   * React to changes in sign-in state and role. Currently scoped to the
+   * footer Admin link visibility:
+   *   - shown when signed out (so users can find the sign-in page)
+   *   - shown when role is owner or admin (legitimate access)
+   *   - hidden when role is user (the unauthorized case — keeps the
+   *     link from being a dead-end click for non-elevated users)
+   */
+  updateAuthState(_user: User | null, role: Role | null): void {
+    const link = document.querySelector<HTMLAnchorElement>('.footer__admin-link');
+    if (!link) return;
+    const hide = role === 'user';
+    link.toggleAttribute('hidden', hide);
   }
 
   destroy(): void {

--- a/src/modules/role.ts
+++ b/src/modules/role.ts
@@ -1,0 +1,52 @@
+/**
+ * RoleModule — single source of role state on the client.
+ *
+ * Reads the `role` claim from the current ID token; subscribes to
+ * onIdTokenChanged so consumers learn about role changes immediately
+ * after a forced token refresh (Group 6 wires the refresh trigger via
+ * a snapshot listener on users/{uid}.roleChangedAt).
+ *
+ * The token claim is the rules-engine source of truth. The Firestore
+ * mirror is the admin-UI source of truth and may briefly lag the
+ * claim if a setUserRole TX commit failed post-claim — see spec §VI.
+ */
+
+import { auth } from '@/firebase-config';
+import { isRole, type Role } from '@/types/user';
+
+export type RoleChangeCallback = (role: Role | null) => void;
+
+export async function getRole(force = false): Promise<Role | null> {
+  if (!auth.currentUser) return null;
+  const token = await auth.currentUser.getIdTokenResult(force);
+  return isRole(token.claims['role']) ? (token.claims['role'] as Role) : null;
+}
+
+/**
+ * Subscribe to role changes. Fires:
+ *   - on sign-in (with current role)
+ *   - on sign-out (with null)
+ *   - whenever the ID token refreshes with a different `role` claim
+ *
+ * Returns an unsubscribe function.
+ */
+export function onRoleChange(cb: RoleChangeCallback): () => void {
+  return auth.onIdTokenChanged(async (user) => {
+    if (!user) {
+      cb(null);
+      return;
+    }
+    const token = await user.getIdTokenResult();
+    cb(isRole(token.claims['role']) ? (token.claims['role'] as Role) : null);
+  });
+}
+
+/**
+ * Force a token refresh and return the freshly-read role. Used after a
+ * roleChangedAt snapshot bump indicates the server has updated the
+ * caller's role and we need the new value to propagate to UI guards
+ * before the natural ~1-hour token lifetime expires.
+ */
+export async function refreshRole(): Promise<Role | null> {
+  return getRole(true);
+}

--- a/src/repositories/repository-factory.ts
+++ b/src/repositories/repository-factory.ts
@@ -6,6 +6,7 @@
 
 import type { Firestore } from 'firebase/firestore';
 import { ScoreRepository } from '@/repositories/score-repository';
+import { UserRepository } from '@/repositories/user-repository';
 
 interface FactoryConfig {
   db: Firestore;
@@ -30,6 +31,20 @@ export class RepositoryFactory {
 
     const repo = new ScoreRepository(this.config.db);
     this.instances.set('score', repo);
+    return repo;
+  }
+
+  getUserRepository(): UserRepository {
+    if (this.instances.has('user')) return this.instances.get('user') as UserRepository;
+
+    if (!this.config.db) {
+      throw new Error(
+        'RepositoryFactory: db is required. Pass { db } from firebase-config.ts.',
+      );
+    }
+
+    const repo = new UserRepository(this.config.db);
+    this.instances.set('user', repo);
     return repo;
   }
 

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -1,0 +1,68 @@
+/**
+ * UserRepository — Firestore reads of `users/{uid}`.
+ *
+ * Responsibilities:
+ *   - findById: single-doc fetch
+ *   - listPaginated: cursor-paginated list ordered by createdAt desc
+ *     (per constitution §III.3 / §IV.2 — never unbounded reads)
+ *   - observeSelf: real-time listener on the current user's doc, used
+ *     to detect roleChangedAt bumps and force token refresh
+ *
+ * Never writes the `role` field. Self-update of non-role fields is
+ * permitted by rules but currently unused — clients should not write
+ * the mirror outside the server-managed flow.
+ */
+
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  startAfter,
+  type DocumentSnapshot,
+  type Firestore,
+  type Unsubscribe,
+} from 'firebase/firestore';
+import type { UserDoc } from '@/types/user';
+
+export interface ListPage {
+  users: UserDoc[];
+  nextCursor: DocumentSnapshot | null;
+}
+
+export class UserRepository {
+  constructor(private readonly db: Firestore) {}
+
+  async findById(uid: string): Promise<UserDoc | null> {
+    const snap = await getDoc(doc(this.db, 'users', uid));
+    return snap.exists() ? (snap.data() as UserDoc) : null;
+  }
+
+  async listPaginated(opts: { pageSize?: number; cursor?: DocumentSnapshot | null } = {}): Promise<ListPage> {
+    const pageSize = opts.pageSize ?? 20;
+    const baseConstraints = [orderBy('createdAt', 'desc'), limit(pageSize)];
+    const q = opts.cursor
+      ? query(collection(this.db, 'users'), orderBy('createdAt', 'desc'), startAfter(opts.cursor), limit(pageSize))
+      : query(collection(this.db, 'users'), ...baseConstraints);
+
+    const snap = await getDocs(q);
+    const users = snap.docs.map((d) => d.data() as UserDoc);
+    const nextCursor = snap.docs.length === pageSize ? (snap.docs[snap.docs.length - 1] ?? null) : null;
+    return { users, nextCursor };
+  }
+
+  /**
+   * Subscribe to changes on the given user's mirror doc. Caller must
+   * invoke the returned Unsubscribe on sign-out / teardown to avoid
+   * leaking listeners.
+   */
+  observeSelf(uid: string, cb: (doc: UserDoc | null) => void): Unsubscribe {
+    return onSnapshot(doc(this.db, 'users', uid), (snap) => {
+      cb(snap.exists() ? (snap.data() as UserDoc) : null);
+    });
+  }
+}

--- a/src/services/admin-user-service.ts
+++ b/src/services/admin-user-service.ts
@@ -1,0 +1,84 @@
+/**
+ * AdminUserService — facade for the Users tab.
+ *
+ * Wraps:
+ *   - UserRepository.listPaginated for the user table
+ *   - setUserRole callable for owner-driven role changes
+ *
+ * The service strips Firestore-specific types from its return shape
+ * so the component layer doesn't need to import from firebase/firestore.
+ */
+
+import type { DocumentSnapshot } from 'firebase/firestore';
+import type { FunctionsError } from 'firebase/functions';
+import { db } from '@/firebase-config';
+import { createRepositoryFactory } from '@/repositories/repository-factory';
+import { callable } from '@/infrastructure/functions';
+import type { Role, UserDoc } from '@/types/user';
+
+const factory = createRepositoryFactory({ db });
+const userRepo = factory.getUserRepository();
+
+const setUserRoleCallable = callable<
+  { targetUid: string; role: Role },
+  { ok: true; fromRole: Role; toRole: Role }
+>('setUserRole');
+
+export interface ListUsersPage {
+  users: UserDoc[];
+  nextCursor: DocumentSnapshot | null;
+}
+
+export type SetUserRoleResult =
+  | { ok: true; fromRole: Role; toRole: Role }
+  | { ok: false; code: string; message: string };
+
+export async function listUsers(
+  opts: { pageSize?: number; cursor?: DocumentSnapshot | null } = {},
+): Promise<ListUsersPage> {
+  return userRepo.listPaginated(opts);
+}
+
+export async function setUserRole(targetUid: string, role: Role): Promise<SetUserRoleResult> {
+  try {
+    const result = await setUserRoleCallable({ targetUid, role });
+    return { ok: true, fromRole: result.data.fromRole, toRole: result.data.toRole };
+  } catch (e) {
+    const err = e as FunctionsError;
+    return {
+      ok: false,
+      code: err.code ?? 'unknown',
+      message: err.message ?? String(e),
+    };
+  }
+}
+
+/**
+ * Map a callable error code to the operator-facing message that the
+ * Users tab should display in a toast. Centralized so the component
+ * doesn't grow its own copy.
+ */
+export function setUserRoleErrorMessage(code: string): string {
+  switch (code) {
+    case 'permission-denied':
+    case 'functions/permission-denied':
+      return 'Only the owner can change roles.';
+    case 'failed-precondition':
+    case 'functions/failed-precondition':
+      return 'Cannot demote the last owner. Promote another user to owner first.';
+    case 'resource-exhausted':
+    case 'functions/resource-exhausted':
+      return 'Rate limit reached. Please wait before changing more roles.';
+    case 'invalid-argument':
+    case 'functions/invalid-argument':
+      return 'Invalid role.';
+    case 'not-found':
+    case 'functions/not-found':
+      return 'Target user not found.';
+    case 'unauthenticated':
+    case 'functions/unauthenticated':
+      return 'You must be signed in to change roles.';
+    default:
+      return 'Could not change role. See console for details.';
+  }
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,29 @@
+/**
+ * User + role types shared across the RBAC client surfaces.
+ */
+
+import type { Timestamp } from 'firebase/firestore';
+
+export type Role = 'owner' | 'admin' | 'user';
+
+export const ROLES: readonly Role[] = ['owner', 'admin', 'user'] as const;
+
+export function isRole(value: unknown): value is Role {
+  return value === 'owner' || value === 'admin' || value === 'user';
+}
+
+/**
+ * Shape of a `users/{uid}` document. The `role` field is server-managed
+ * (written by onUserCreate or setUserRole — never by the client SDK).
+ */
+export interface UserDoc {
+  uid: string;
+  email: string | null;
+  displayName: string | null;
+  photoURL: string | null;
+  role: Role;
+  createdAt?: Timestamp;
+  updatedAt?: Timestamp;
+  lastSignInAt?: Timestamp | null;
+  roleChangedAt?: Timestamp;
+}

--- a/src/views/admin.ts
+++ b/src/views/admin.ts
@@ -27,6 +27,7 @@ export function adminView(): string {
         <button id="admin-sign-out" class="btn-secondary">Sign out</button>
       </div>
       <admin-panel></admin-panel>
+      <admin-users-panel></admin-users-panel>
     </div>
   `;
 }

--- a/src/views/admin.ts
+++ b/src/views/admin.ts
@@ -26,8 +26,14 @@ export function adminView(): string {
         <span id="admin-user-display"></span>
         <button id="admin-sign-out" class="btn-secondary">Sign out</button>
       </div>
-      <admin-panel></admin-panel>
-      <admin-users-panel></admin-users-panel>
+      <!--
+        Admin Custom Elements are mounted lazily by main.ts when the
+        signed-in user's role becomes owner|admin. Keeping them out of
+        the DOM until then avoids their connectedCallback firing with
+        a non-elevated viewer, which would trigger Firestore rule
+        denials for their initial data fetches.
+      -->
+      <div id="admin-panel-mount"></div>
     </div>
   `;
 }

--- a/tests/functions/_helpers.ts
+++ b/tests/functions/_helpers.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for function unit tests.
+ *
+ * IMPORTANT: env vars are set in _setup.ts (vitest setupFile) which runs
+ * before this module is loaded. Initializes the Admin SDK once, exposes
+ * helpers for seeding + clearing emulator state, and lazy-imports the
+ * function modules so environment-gated decisions (enforceAppCheck) are
+ * captured correctly.
+ */
+
+import { initializeApp, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+if (getApps().length === 0) {
+  initializeApp({ projectId: process.env['GCLOUD_PROJECT'] ?? 'citl-fn-test' });
+}
+
+export const adminAuth = () => getAuth();
+export const adminDb = () => getFirestore();
+
+const PROJECT = process.env['GCLOUD_PROJECT'] ?? 'citl-fn-test';
+const FIRESTORE_HOST = process.env['FIRESTORE_EMULATOR_HOST'] ?? '127.0.0.1:8080';
+const AUTH_HOST = process.env['FIREBASE_AUTH_EMULATOR_HOST'] ?? '127.0.0.1:9099';
+
+export async function clearFirestore(): Promise<void> {
+  const url = `http://${FIRESTORE_HOST}/emulator/v1/projects/${PROJECT}/databases/(default)/documents`;
+  const res = await fetch(url, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`clearFirestore failed: ${res.status} ${res.statusText}`);
+}
+
+export async function clearAuth(): Promise<void> {
+  // Use Admin SDK rather than the emulator REST endpoint — REST is flaky
+  // for repeated DELETE calls and sometimes leaves stale state.
+  const result = await adminAuth().listUsers(1000);
+  const uids = result.users.map((u) => u.uid);
+  if (uids.length > 0) {
+    await adminAuth().deleteUsers(uids);
+  }
+}
+
+export async function seedUser(
+  uid: string,
+  role: 'owner' | 'admin' | 'user',
+  extras: Record<string, unknown> = {},
+): Promise<void> {
+  await adminAuth().createUser({ uid, email: `${uid}@example.com`, displayName: uid });
+  await adminAuth().setCustomUserClaims(uid, { role });
+  await adminDb().doc(`users/${uid}`).set({
+    uid,
+    email: `${uid}@example.com`,
+    displayName: uid,
+    photoURL: null,
+    role,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    lastSignInAt: FieldValue.serverTimestamp(),
+    ...extras,
+  });
+}
+
+/**
+ * Lazy-load the function module after env vars are set, so the module's
+ * top-level `enforceAppCheck: !isEmulator` reads the right value.
+ */
+export async function loadSetUserRole() {
+  const mod = await import('../../functions/src/setUserRole.js');
+  return mod.setUserRole;
+}
+
+export async function loadOnUserCreate() {
+  const mod = await import('../../functions/src/onUserCreate.js');
+  return mod.onUserCreate;
+}
+
+export async function loadHandleUserCreated() {
+  const mod = await import('../../functions/src/onUserCreate.js');
+  return mod.handleUserCreated;
+}

--- a/tests/functions/_setup.ts
+++ b/tests/functions/_setup.ts
@@ -1,0 +1,10 @@
+/**
+ * Vitest setup file for function tests. Runs BEFORE any test file imports
+ * so environment variables are in place before the function module is
+ * loaded (and captures `enforceAppCheck: !isEmulator` correctly).
+ */
+
+process.env['FUNCTIONS_EMULATOR'] = 'true';
+process.env['GCLOUD_PROJECT'] ??= 'citl-fn-test';
+process.env['FIREBASE_AUTH_EMULATOR_HOST'] ??= '127.0.0.1:9099';
+process.env['FIRESTORE_EMULATOR_HOST'] ??= '127.0.0.1:8080';

--- a/tests/functions/onUserCreate.test.ts
+++ b/tests/functions/onUserCreate.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Function unit tests for the onUserCreate auth trigger handler.
+ *
+ * Each test uses a unique uid so we don't need to clear emulator state
+ * between tests — sidesteps fragile clearAuth/clearFirestore behavior.
+ */
+
+import { beforeAll, expect, it } from 'vitest';
+import { adminAuth, adminDb, loadHandleUserCreated } from './_helpers.js';
+
+let handleUserCreated: Awaited<ReturnType<typeof loadHandleUserCreated>>;
+
+beforeAll(async () => {
+  handleUserCreated = await loadHandleUserCreated();
+});
+
+let counter = 0;
+const newUid = (): string => `ouc-${Date.now()}-${++counter}`;
+
+it('is idempotent — does not overwrite an existing users/{uid} doc', async () => {
+  const uid = newUid();
+  await adminAuth().createUser({ uid, email: `${uid}@example.com` });
+  await adminDb().doc(`users/${uid}`).set({
+    uid, role: 'admin', email: `${uid}@example.com`, displayName: 'Existing',
+  });
+
+  await handleUserCreated({ uid, email: `${uid}@example.com` });
+
+  const mirror = (await adminDb().doc(`users/${uid}`).get()).data();
+  expect(mirror?.['role']).toBe('admin');
+});
+
+it('handles missing email/displayName/photoURL gracefully', async () => {
+  const uid = newUid();
+  await adminAuth().createUser({ uid });
+  await handleUserCreated({ uid });
+
+  const mirror = (await adminDb().doc(`users/${uid}`).get()).data();
+  expect(mirror?.['role']).toBe('user');
+  expect(mirror?.['email']).toBeNull();
+  expect(mirror?.['displayName']).toBeNull();
+  expect(mirror?.['photoURL']).toBeNull();
+});

--- a/tests/functions/setUserRole.test.ts
+++ b/tests/functions/setUserRole.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Function unit tests for setUserRole callable.
+ * Run via: firebase emulators:exec --only auth,firestore,functions
+ *          'vitest run --config tests/functions/vitest.config.ts'
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import functionsTest from 'firebase-functions-test';
+import {
+  adminAuth,
+  adminDb,
+  clearAuth,
+  clearFirestore,
+  loadSetUserRole,
+  seedUser,
+} from './_helpers.js';
+
+const fft = functionsTest({ projectId: process.env['GCLOUD_PROJECT'] ?? 'citl-fn-test' });
+let setUserRoleFn: Awaited<ReturnType<typeof loadSetUserRole>>;
+let wrapped: ReturnType<typeof fft.wrap>;
+
+const OWNER = 'uOwner';
+const ADMIN = 'uAdmin';
+const USER = 'uUser';
+
+beforeAll(async () => {
+  setUserRoleFn = await loadSetUserRole();
+  wrapped = fft.wrap(setUserRoleFn);
+});
+
+afterAll(() => {
+  fft.cleanup();
+});
+
+beforeEach(async () => {
+  await clearFirestore();
+  await clearAuth();
+  await seedUser(OWNER, 'owner');
+  await seedUser(ADMIN, 'admin');
+  await seedUser(USER, 'user');
+});
+
+function call(args: { actorUid: string | null; actorRole?: string; data: unknown }) {
+  const auth = args.actorUid
+    ? { uid: args.actorUid, token: { role: args.actorRole, sub: args.actorUid, aud: 'citl-fn-test' } as any }
+    : undefined;
+  return wrapped({ data: args.data, auth } as any);
+}
+
+describe('auth gate', () => {
+  it('rejects unauthenticated calls with permission-denied', async () => {
+    await expect(call({ actorUid: null, data: { targetUid: USER, role: 'admin' } }))
+      .rejects.toMatchObject({ code: 'permission-denied' });
+  });
+
+  it('rejects user role with permission-denied', async () => {
+    await expect(call({ actorUid: USER, actorRole: 'user', data: { targetUid: ADMIN, role: 'user' } }))
+      .rejects.toMatchObject({ code: 'permission-denied' });
+  });
+
+  it('rejects admin role with permission-denied', async () => {
+    await expect(call({ actorUid: ADMIN, actorRole: 'admin', data: { targetUid: USER, role: 'admin' } }))
+      .rejects.toMatchObject({ code: 'permission-denied' });
+  });
+});
+
+describe('input validation', () => {
+  it('rejects unknown role with invalid-argument', async () => {
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: USER, role: 'superuser' },
+    })).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  it('rejects missing targetUid with invalid-argument', async () => {
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { role: 'admin' },
+    })).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  it('rejects empty targetUid with invalid-argument', async () => {
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: '', role: 'admin' },
+    })).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+describe('happy path', () => {
+  it('promotes a user to admin: claim + mirror + audit all updated', async () => {
+    const result = await call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: USER, role: 'admin' },
+    }) as { ok: true; fromRole: string; toRole: string };
+
+    expect(result).toEqual({ ok: true, fromRole: 'user', toRole: 'admin' });
+
+    const refreshed = await adminAuth().getUser(USER);
+    expect(refreshed.customClaims?.['role']).toBe('admin');
+
+    const mirror = await adminDb().doc(`users/${USER}`).get();
+    expect(mirror.data()?.['role']).toBe('admin');
+    expect(mirror.data()?.['roleChangedAt']).toBeDefined();
+
+    const audit = await adminDb().collection('audit').get();
+    expect(audit.size).toBe(1);
+    const entry = audit.docs[0]!.data();
+    expect(entry['actorUid']).toBe(OWNER);
+    expect(entry['targetUid']).toBe(USER);
+    expect(entry['fromRole']).toBe('user');
+    expect(entry['toRole']).toBe('admin');
+  });
+
+  it('demotes admin back to user', async () => {
+    const result = await call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: ADMIN, role: 'user' },
+    }) as { ok: true; fromRole: string; toRole: string };
+    expect(result.fromRole).toBe('admin');
+    expect(result.toRole).toBe('user');
+  });
+});
+
+describe('last-owner guard', () => {
+  it('refuses to demote the only owner', async () => {
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: OWNER, role: 'user' },
+    })).rejects.toMatchObject({ code: 'failed-precondition' });
+  });
+
+  it('allows demoting an owner when another owner exists', async () => {
+    const SECOND_OWNER = 'uOwner2';
+    await seedUser(SECOND_OWNER, 'owner');
+    const result = await call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: SECOND_OWNER, role: 'user' },
+    }) as { ok: true; fromRole: string; toRole: string };
+    expect(result.toRole).toBe('user');
+  });
+});
+
+describe('rate limit', () => {
+  it('returns resource-exhausted on the 21st call within an hour', async () => {
+    // Seed counter at LIMIT to short-circuit the test (no need to make 20 actual calls)
+    await adminDb()
+      .doc(`rateLimits/setUserRole/actors/${OWNER}`)
+      .set({ windowStart: Date.now(), count: 20 });
+
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: USER, role: 'admin' },
+    })).rejects.toMatchObject({ code: 'resource-exhausted' });
+  });
+
+  it('resets the window when windowStart is older than 1 hour', async () => {
+    await adminDb()
+      .doc(`rateLimits/setUserRole/actors/${OWNER}`)
+      .set({ windowStart: Date.now() - 2 * 60 * 60 * 1000, count: 20 });
+
+    const result = await call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: USER, role: 'admin' },
+    }) as { ok: true };
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('not-found', () => {
+  it('returns not-found when target user doc does not exist', async () => {
+    await expect(call({
+      actorUid: OWNER, actorRole: 'owner',
+      data: { targetUid: 'nonexistent-uid', role: 'admin' },
+    })).rejects.toMatchObject({ code: 'not-found' });
+  });
+});

--- a/tests/functions/vitest.config.ts
+++ b/tests/functions/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/functions/**/*.test.ts'],
+    root: repoRoot,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    setupFiles: ['tests/functions/_setup.ts'],
+  },
+});

--- a/tests/rules/_helpers.ts
+++ b/tests/rules/_helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared setup for Firestore rules tests.
+ *
+ * Boots a single TestEnvironment per file (via initializeTestEnvironment),
+ * exposes typed helpers to mint authenticated contexts with role claims,
+ * and provides withSecurityRulesDisabled-based seed helpers so tests can
+ * pre-populate documents that the rules under test would forbid.
+ *
+ * Run via: firebase emulators:exec --only firestore 'vitest run tests/rules'
+ * (which sets FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 in env).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+  type RulesTestContext,
+} from '@firebase/rules-unit-testing';
+import {
+  doc,
+  setDoc,
+  type Firestore,
+} from 'firebase/firestore';
+
+export const PROJECT_ID = 'citl-rules-test';
+
+const RULES_PATH = resolve(__dirname, '..', '..', 'firestore.rules');
+const HOST_PORT = (process.env['FIRESTORE_EMULATOR_HOST'] ?? '127.0.0.1:8080')
+  .split(':');
+const FIRESTORE_HOST = HOST_PORT[0] ?? '127.0.0.1';
+const FIRESTORE_PORT = Number.parseInt(HOST_PORT[1] ?? '8080', 10);
+
+export async function setupTestEnv(): Promise<RulesTestEnvironment> {
+  return initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: FIRESTORE_HOST,
+      port: FIRESTORE_PORT,
+    },
+  });
+}
+
+export type Role = 'owner' | 'admin' | 'user';
+
+/** Returns a Firestore client whose ID-token claim role === the given role. */
+export function asRole(
+  env: RulesTestEnvironment,
+  uid: string,
+  role: Role,
+): Firestore {
+  const ctx: RulesTestContext = env.authenticatedContext(uid, { role });
+  return ctx.firestore() as unknown as Firestore;
+}
+
+/** Authenticated client with no role claim (e.g. brand-new user pre-trigger). */
+export function asNoRole(
+  env: RulesTestEnvironment,
+  uid: string,
+): Firestore {
+  const ctx: RulesTestContext = env.authenticatedContext(uid);
+  return ctx.firestore() as unknown as Firestore;
+}
+
+/** Unauthenticated client. */
+export function asAnon(env: RulesTestEnvironment): Firestore {
+  const ctx: RulesTestContext = env.unauthenticatedContext();
+  return ctx.firestore() as unknown as Firestore;
+}
+
+/** Seed data via the privileged context (bypasses rules). */
+export async function seed(
+  env: RulesTestEnvironment,
+  fn: (db: Firestore) => Promise<void>,
+): Promise<void> {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await fn(ctx.firestore() as unknown as Firestore);
+  });
+}
+
+/** Seed a users/{uid} doc with the given role. */
+export async function seedUser(
+  env: RulesTestEnvironment,
+  uid: string,
+  role: Role,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  await seed(env, async (db) => {
+    await setDoc(doc(db, 'users', uid), {
+      uid,
+      role,
+      email: `${uid}@example.com`,
+      displayName: uid,
+      photoURL: null,
+      createdAt: new Date(),
+      lastSignInAt: new Date(),
+      ...extra,
+    });
+  });
+}

--- a/tests/rules/audit.test.ts
+++ b/tests/rules/audit.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Firestore rules: audit/{id}
+ *
+ * Read by owner only; writes denied for everyone (Admin SDK only via the
+ * setUserRole callable / set-role.js CLI).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { asAnon, asRole, seed, setupTestEnv } from './_helpers.js';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => { env = await setupTestEnv(); });
+beforeEach(async () => {
+  await env.clearFirestore();
+  await seed(env, async (db) => {
+    await setDoc(doc(db, 'audit', 'a1'), {
+      actorUid: 'cli',
+      targetUid: 'u',
+      fromRole: 'user',
+      toRole: 'admin',
+      at: new Date(),
+    });
+  });
+});
+afterAll(async () => { await env.cleanup(); });
+
+it('owner can read audit entries', async () => {
+  await assertSucceeds(getDoc(doc(asRole(env, 'o', 'owner'), 'audit', 'a1')));
+});
+
+it('admin CANNOT read audit entries', async () => {
+  await assertFails(getDoc(doc(asRole(env, 'a', 'admin'), 'audit', 'a1')));
+});
+
+it('user CANNOT read audit entries', async () => {
+  await assertFails(getDoc(doc(asRole(env, 'u', 'user'), 'audit', 'a1')));
+});
+
+it('anon CANNOT read audit entries', async () => {
+  await assertFails(getDoc(doc(asAnon(env), 'audit', 'a1')));
+});
+
+it('no role can write to audit (Admin SDK only)', async () => {
+  await assertFails(setDoc(doc(asRole(env, 'o', 'owner'), 'audit', 'new'), { x: 1 }));
+  await assertFails(setDoc(doc(asRole(env, 'a', 'admin'), 'audit', 'new'), { x: 1 }));
+  await assertFails(setDoc(doc(asRole(env, 'u', 'user'), 'audit', 'new'), { x: 1 }));
+});

--- a/tests/rules/content.test.ts
+++ b/tests/rules/content.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Firestore rules: config/{doc} and announcements/{docId}.
+ *
+ * Both are public-read; owner+admin write. Announcements support delete;
+ * config is create/update only (banner config is permanent).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { asAnon, asRole, seed, setupTestEnv } from './_helpers.js';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => { env = await setupTestEnv(); });
+beforeEach(async () => { await env.clearFirestore(); });
+afterAll(async () => { await env.cleanup(); });
+
+describe('config/{doc}', () => {
+  beforeEach(async () => {
+    await seed(env, async (db) => {
+      await setDoc(doc(db, 'config', 'banner'), { message: 'hello' });
+    });
+  });
+
+  it('anyone can read config (public banner)', async () => {
+    await assertSucceeds(getDoc(doc(asAnon(env), 'config', 'banner')));
+    await assertSucceeds(getDoc(doc(asRole(env, 'u', 'user'), 'config', 'banner')));
+  });
+
+  it('user CANNOT write config', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertFails(updateDoc(doc(db, 'config', 'banner'), { message: 'x' }));
+  });
+
+  it('admin can create + update config', async () => {
+    const db = asRole(env, 'a', 'admin');
+    // Both create and update are gated by `isOwnerOrAdmin()`. setDoc against a
+    // missing doc creates; against an existing doc updates. Either path is
+    // valid here.
+    await assertSucceeds(setDoc(doc(db, 'config', 'new-doc'), { x: 1 }));
+    await assertSucceeds(setDoc(doc(db, 'config', 'banner'), { message: 'updated' }));
+  });
+
+  it('owner CANNOT delete config (rule is create+update only)', async () => {
+    const db = asRole(env, 'o', 'owner');
+    await assertFails(deleteDoc(doc(db, 'config', 'banner')));
+  });
+});
+
+describe('announcements/{docId}', () => {
+  beforeEach(async () => {
+    await seed(env, async (db) => {
+      await setDoc(doc(db, 'announcements', 'a1'), { title: 'hi' });
+    });
+  });
+
+  it('anyone can read announcements', async () => {
+    await assertSucceeds(getDoc(doc(asAnon(env), 'announcements', 'a1')));
+  });
+
+  it('user CANNOT write announcements', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertFails(updateDoc(doc(db, 'announcements', 'a1'), { title: 'x' }));
+    await assertFails(deleteDoc(doc(db, 'announcements', 'a1')));
+  });
+
+  it('admin + owner can full-CRUD announcements', async () => {
+    const adb = asRole(env, 'a', 'admin');
+    const odb = asRole(env, 'o', 'owner');
+    await assertSucceeds(setDoc(doc(adb, 'announcements', 'a2'), { title: 'b' }));
+    // setDoc tests the same `create, update, delete` rule as updateDoc.
+    await assertSucceeds(setDoc(doc(adb, 'announcements', 'a2'), { title: 'edit' }));
+    await assertSucceeds(deleteDoc(doc(odb, 'announcements', 'a2')));
+  });
+});

--- a/tests/rules/rateLimits.test.ts
+++ b/tests/rules/rateLimits.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Firestore rules: rateLimits/** counters used by setUserRole.
+ *
+ * Read by owner only; no client writes (Function-internal counter).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { assertFails, assertSucceeds, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { asAnon, asRole, seed, setupTestEnv } from './_helpers.js';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => { env = await setupTestEnv(); });
+beforeEach(async () => {
+  await env.clearFirestore();
+  await seed(env, async (db) => {
+    await setDoc(doc(db, 'rateLimits', 'setUserRole', 'actors', 'uOwner'), {
+      windowStart: new Date(),
+      count: 5,
+    });
+  });
+});
+afterAll(async () => { await env.cleanup(); });
+
+it('owner can read rate-limit counters', async () => {
+  await assertSucceeds(
+    getDoc(doc(asRole(env, 'o', 'owner'), 'rateLimits', 'setUserRole', 'actors', 'uOwner')),
+  );
+});
+
+it('admin CANNOT read rate-limit counters', async () => {
+  await assertFails(
+    getDoc(doc(asRole(env, 'a', 'admin'), 'rateLimits', 'setUserRole', 'actors', 'uOwner')),
+  );
+});
+
+it('anon CANNOT read rate-limit counters', async () => {
+  await assertFails(
+    getDoc(doc(asAnon(env), 'rateLimits', 'setUserRole', 'actors', 'uOwner')),
+  );
+});
+
+it('no role can write rate-limit counters', async () => {
+  await assertFails(
+    setDoc(doc(asRole(env, 'o', 'owner'), 'rateLimits', 'setUserRole', 'actors', 'x'), { count: 1 }),
+  );
+  await assertFails(
+    setDoc(doc(asRole(env, 'a', 'admin'), 'rateLimits', 'setUserRole', 'actors', 'x'), { count: 1 }),
+  );
+  await assertFails(
+    setDoc(doc(asRole(env, 'u', 'user'), 'rateLimits', 'setUserRole', 'actors', 'x'), { count: 1 }),
+  );
+});

--- a/tests/rules/seasons.test.ts
+++ b/tests/rules/seasons.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Firestore rules: seasons/{year} and subcollections (teams, weeks, entries).
+ *
+ * Verifies the migration from `admin: true` to role-based access preserves
+ * existing semantics: public read on seasons/teams/weeks; owner+admin-only
+ * write across all four collections; entries are owner+admin-only end-to-end.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { assertFails, assertSucceeds, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { collection, doc, getDoc, getDocs, setDoc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { asAnon, asRole, seed, setupTestEnv } from './_helpers.js';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => { env = await setupTestEnv(); });
+beforeEach(async () => { await env.clearFirestore(); });
+afterAll(async () => { await env.cleanup(); });
+
+const YEAR = '2026';
+const TEAM_ID = 'team-1';
+const WEEK_NUM = 'week-1';
+const ENTRY_ID = 'entry-1';
+
+async function seedSeason(env: RulesTestEnvironment) {
+  await seed(env, async (db) => {
+    await setDoc(doc(db, 'seasons', YEAR), { year: YEAR });
+    await setDoc(doc(db, 'seasons', YEAR, 'teams', TEAM_ID), { name: 'Team 1' });
+    await setDoc(doc(db, 'seasons', YEAR, 'weeks', WEEK_NUM), { weekNumber: 1 });
+    await setDoc(doc(db, 'seasons', YEAR, 'entries', ENTRY_ID), { entryId: ENTRY_ID });
+  });
+}
+
+describe('seasons/{year} — public read, owner/admin write', () => {
+  beforeEach(async () => { await seedSeason(env); });
+
+  it('anon can read season + teams + weeks', async () => {
+    const db = asAnon(env);
+    await assertSucceeds(getDoc(doc(db, 'seasons', YEAR)));
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'teams')));
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'weeks')));
+  });
+
+  it('user role can read season + teams + weeks but NOT entries', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertSucceeds(getDoc(doc(db, 'seasons', YEAR)));
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'teams')));
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'weeks')));
+    await assertFails(getDocs(collection(db, 'seasons', YEAR, 'entries')));
+  });
+
+  it('owner can read everything including entries', async () => {
+    const db = asRole(env, 'o', 'owner');
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'entries')));
+  });
+
+  it('admin can read everything including entries', async () => {
+    const db = asRole(env, 'a', 'admin');
+    await assertSucceeds(getDocs(collection(db, 'seasons', YEAR, 'entries')));
+  });
+});
+
+describe('seasons writes — owner/admin only', () => {
+  beforeEach(async () => { await seedSeason(env); });
+
+  it('user CANNOT write season', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertFails(setDoc(doc(db, 'seasons', YEAR), { name: 'X' }));
+  });
+
+  it('user CANNOT delete a team', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertFails(deleteDoc(doc(db, 'seasons', YEAR, 'teams', TEAM_ID)));
+  });
+
+  it('admin can create + update + delete a team', async () => {
+    const db = asRole(env, 'a', 'admin');
+    // setDoc against a missing doc creates; against an existing doc updates;
+    // both gated by the same `create, update, delete` rule. Avoids flakiness
+    // from the rules-unit-testing seed-visibility quirk.
+    await assertSucceeds(setDoc(doc(db, 'seasons', YEAR, 'teams', 'new-team'), { name: 'New' }));
+    await assertSucceeds(setDoc(doc(db, 'seasons', YEAR, 'teams', 'new-team'), { name: 'Renamed' }));
+    await assertSucceeds(deleteDoc(doc(db, 'seasons', YEAR, 'teams', 'new-team')));
+  });
+
+  it('owner can write a week (publish)', async () => {
+    const db = asRole(env, 'o', 'owner');
+    await assertSucceeds(setDoc(doc(db, 'seasons', YEAR, 'weeks', 'new-week'), { status: 'published' }));
+  });
+
+  it('admin can create + update + delete an entry', async () => {
+    const db = asRole(env, 'a', 'admin');
+    await assertSucceeds(setDoc(doc(db, 'seasons', YEAR, 'entries', 'new-entry'), { e: 1 }));
+    // setDoc tests the same `create, update` rule as updateDoc.
+    await assertSucceeds(setDoc(doc(db, 'seasons', YEAR, 'entries', 'new-entry'), { e: 2 }));
+    await assertSucceeds(deleteDoc(doc(db, 'seasons', YEAR, 'entries', 'new-entry')));
+  });
+
+  it('user CANNOT write any season collection', async () => {
+    const db = asRole(env, 'u', 'user');
+    await assertFails(setDoc(doc(db, 'seasons', YEAR, 'teams', 'x'), {}));
+    await assertFails(setDoc(doc(db, 'seasons', YEAR, 'weeks', 'x'), {}));
+    await assertFails(setDoc(doc(db, 'seasons', YEAR, 'entries', 'x'), {}));
+  });
+});

--- a/tests/rules/users.test.ts
+++ b/tests/rules/users.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Firestore rules: users/{uid}
+ *
+ * Matrix: {owner, admin, user, anon} × {read self, read other, create
+ * self with/without role, update non-role, update role (must deny for
+ * every role since it would let clients self-promote), delete}.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertFails,
+  assertSucceeds,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+import { asAnon, asNoRole, asRole, seed, seedUser, setupTestEnv } from './_helpers.js';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => {
+  env = await setupTestEnv();
+});
+
+beforeEach(async () => {
+  await env.clearFirestore();
+});
+
+afterAll(async () => {
+  await env.cleanup();
+});
+
+const OWNER_UID = 'uOwner';
+const ADMIN_UID = 'uAdmin';
+const USER_UID = 'uUser';
+const OTHER_UID = 'uOther';
+
+describe('users/{uid} read', () => {
+  beforeEach(async () => {
+    await seedUser(env, OWNER_UID, 'owner');
+    await seedUser(env, ADMIN_UID, 'admin');
+    await seedUser(env, USER_UID, 'user');
+    await seedUser(env, OTHER_UID, 'user');
+  });
+
+  it('owner can read any user doc', async () => {
+    const db = asRole(env, OWNER_UID, 'owner');
+    await assertSucceeds(getDoc(doc(db, 'users', USER_UID)));
+    await assertSucceeds(getDoc(doc(db, 'users', OTHER_UID)));
+  });
+
+  it('admin can read any user doc', async () => {
+    const db = asRole(env, ADMIN_UID, 'admin');
+    await assertSucceeds(getDoc(doc(db, 'users', USER_UID)));
+    await assertSucceeds(getDoc(doc(db, 'users', OWNER_UID)));
+  });
+
+  it('user can read only their own doc', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertSucceeds(getDoc(doc(db, 'users', USER_UID)));
+    await assertFails(getDoc(doc(db, 'users', OTHER_UID)));
+  });
+
+  it('anon cannot read any user doc', async () => {
+    const db = asAnon(env);
+    await assertFails(getDoc(doc(db, 'users', USER_UID)));
+    await assertFails(getDoc(doc(db, 'users', OWNER_UID)));
+  });
+});
+
+describe('users/{uid} create (self-create defense)', () => {
+  it('user can create own doc without role field', async () => {
+    const db = asNoRole(env, USER_UID);
+    await assertSucceeds(
+      setDoc(doc(db, 'users', USER_UID), {
+        uid: USER_UID,
+        email: 'u@example.com',
+        displayName: 'U',
+        photoURL: null,
+        createdAt: serverTimestamp(),
+      }),
+    );
+  });
+
+  it('user CANNOT create own doc with role field — even role: user', async () => {
+    const db = asNoRole(env, USER_UID);
+    await assertFails(
+      setDoc(doc(db, 'users', USER_UID), {
+        uid: USER_UID,
+        role: 'user',
+      }),
+    );
+  });
+
+  it('user CANNOT create another user\'s doc', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertFails(
+      setDoc(doc(db, 'users', OTHER_UID), {
+        uid: OTHER_UID,
+      }),
+    );
+  });
+
+  it('anon cannot create any user doc', async () => {
+    const db = asAnon(env);
+    await assertFails(
+      setDoc(doc(db, 'users', USER_UID), { uid: USER_UID }),
+    );
+  });
+});
+
+describe('users/{uid} update — non-role fields', () => {
+  beforeEach(async () => {
+    await seedUser(env, USER_UID, 'user');
+    await seedUser(env, OTHER_UID, 'user');
+  });
+
+  it('user can update own non-role fields when preserving role', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertSucceeds(
+      updateDoc(doc(db, 'users', USER_UID), {
+        displayName: 'New Name',
+        // role unchanged in resource.data after update because client doesn\'t set it
+      }),
+    );
+  });
+
+  it('user CANNOT update another user\'s doc', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertFails(
+      updateDoc(doc(db, 'users', OTHER_UID), { displayName: 'Hacked' }),
+    );
+  });
+
+  it('admin CANNOT update another user\'s doc — even non-role fields', async () => {
+    // Rules say update requires isSelf(uid). Admin has read but not write
+    // on others (server-side mutations go through the callable, never the
+    // client SDK).
+    const db = asRole(env, ADMIN_UID, 'admin');
+    await assertFails(
+      updateDoc(doc(db, 'users', USER_UID), { displayName: 'AdminEdit' }),
+    );
+  });
+
+  it('owner CANNOT update another user\'s doc directly', async () => {
+    // Same reasoning: ownership of role writes belongs to the callable.
+    const db = asRole(env, OWNER_UID, 'owner');
+    await assertFails(
+      updateDoc(doc(db, 'users', USER_UID), { displayName: 'OwnerEdit' }),
+    );
+  });
+});
+
+describe('users/{uid} update — role field (the security boundary)', () => {
+  beforeEach(async () => {
+    await seedUser(env, OWNER_UID, 'owner');
+    await seedUser(env, ADMIN_UID, 'admin');
+    await seedUser(env, USER_UID, 'user');
+  });
+
+  it('user CANNOT change own role to admin', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertFails(
+      updateDoc(doc(db, 'users', USER_UID), { role: 'admin' }),
+    );
+  });
+
+  it('user CANNOT change own role to owner', async () => {
+    const db = asRole(env, USER_UID, 'user');
+    await assertFails(
+      updateDoc(doc(db, 'users', USER_UID), { role: 'owner' }),
+    );
+  });
+
+  it('admin CANNOT change own role to owner', async () => {
+    const db = asRole(env, ADMIN_UID, 'admin');
+    await assertFails(
+      updateDoc(doc(db, 'users', ADMIN_UID), { role: 'owner' }),
+    );
+  });
+
+  it('owner CANNOT change own role via direct write (must use callable)', async () => {
+    const db = asRole(env, OWNER_UID, 'owner');
+    await assertFails(
+      updateDoc(doc(db, 'users', OWNER_UID), { role: 'admin' }),
+    );
+  });
+
+  it('owner CANNOT change another user\'s role via direct write', async () => {
+    const db = asRole(env, OWNER_UID, 'owner');
+    await assertFails(
+      updateDoc(doc(db, 'users', USER_UID), { role: 'admin' }),
+    );
+  });
+});
+
+describe('users/{uid} delete', () => {
+  beforeEach(async () => {
+    await seedUser(env, USER_UID, 'user');
+  });
+
+  it('no role can delete a user doc', async () => {
+    await assertFails(deleteDoc(doc(asRole(env, OWNER_UID, 'owner'), 'users', USER_UID)));
+    await seed(env, async (db) => { await setDoc(doc(db, 'users', USER_UID), { role: 'user' }); });
+    await assertFails(deleteDoc(doc(asRole(env, ADMIN_UID, 'admin'), 'users', USER_UID)));
+    await seed(env, async (db) => { await setDoc(doc(db, 'users', USER_UID), { role: 'user' }); });
+    await assertFails(deleteDoc(doc(asRole(env, USER_UID, 'user'), 'users', USER_UID)));
+    await seed(env, async (db) => { await setDoc(doc(db, 'users', USER_UID), { role: 'user' }); });
+    await assertFails(deleteDoc(doc(asAnon(env), 'users', USER_UID)));
+  });
+});

--- a/tests/rules/vitest.config.ts
+++ b/tests/rules/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/rules/**/*.test.ts'],
+    root: repoRoot,
+    // Rules tests run sequentially in a shared emulator; isolate to avoid
+    // cross-test interference at the doc level.
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the legacy `admin: true` boolean Firebase Auth custom claim with a three-role RBAC system (`role: 'owner' | 'admin' | 'user'`). Owner-driven role management lives in the Admin Portal Users tab (callable Cloud Function with rate limit, last-owner guard, audit log); a CLI handles bootstrap + emergency recovery only. Advances Security from constitution Phase 1 → Phase 2 (App Check + custom-claim RBAC) and corrects the plan-tier drift Spark → Blaze.

Spec: `.specs/features/002-multi-user-rbac/spec.md` · ADR: `.prompts/meta/architectural-decision-log.md` ADR-009

## Changes

**Server (Cloud Functions)**
- `setUserRole` callable (2nd-gen, `firebase-functions/v2/https`) — owner-gated, App Check enforced in prod, zod-validated, runs inside one Firestore transaction with **claim-first ordering** (see spec §VI Design Decisions for the failure-mode rationale: fail-closed on revocation if the second-system write fails)
- `onUserCreate` 1st-gen auth trigger — idempotent seed of `users/{uid}` + `role: 'user'` claim
- `functions/src/lib/{validate,rateLimit,lastOwnerGuard}.ts` — defense-in-depth helpers

**Firestore rules**
- Full rewrite with role helpers (`isSignedIn` / `roleOf` / `isOwner` / `isAdmin` / `isOwnerOrAdmin` / `isSelf`); existing collections preserve their public-read + owner+admin-write semantics
- New `users/{uid}` (self+owner+admin read; never client-writable role), `audit/{id}` (owner-read only, no client write), `rateLimits/**` (Function-internal counter)

**Client**
- `<admin-users-panel>` Custom Element — paginated user table with owner-only role-change dropdown, confirm dialog, toast feedback mapped from callable error codes (`permission-denied` / `failed-precondition` / `resource-exhausted` / `invalid-argument`)
- `src/repositories/user-repository.ts` — paginated reads + observer (cursor pagination, never unbounded)
- `src/services/admin-user-service.ts` — wraps the callable + the repository
- `src/modules/role.ts` + `src/modules/auth.ts` — role-aware module with `users/{uid}.roleChangedAt` snapshot listener that forces ID-token refresh when the server bumps the timestamp
- `src/infrastructure/{functions,appcheck}.ts` — emulator-aware lazy-init wrappers
- `/admin` route guard, role-driven nav, lazy-mount of admin Custom Elements when viewer becomes elevated

**Refactor (cherry-picked from a parallel chip)**
- `admin-panel.ts` split from 1781 lines → 230-line shell + 6 per-tab modules under `src/components/admin-tabs/` (resolves a long-standing constitution §II.3 hard-limit violation)
- New "Users" tab in admin-panel hosts `<admin-users-panel>`

**CLI**
- `scripts/set-role.js` replaces `scripts/grant-admin.js` (kept as a deprecated shim for one release). Subcommands: `set <email> <role>`, `revoke <email>`, `list`. Enforces last-owner guard + audit entry (`actorUid: 'cli'`). Repositioned in `bootstrap.md` as bootstrap + emergency-recovery only — day-to-day role management goes through the in-app dropdown.
- `npm run set-role:emulator` convenience wrapper sets `FIREBASE_AUTH_EMULATOR_HOST` / `FIRESTORE_EMULATOR_HOST` / `GCLOUD_PROJECT` inline.

**Local dev — emulator-only by default**
- `npm run dev` flips to emulator-only — boots `auth+firestore+functions` with `--import=.emulator-data --export-on-exit=.emulator-data` and runs Vite with `VITE_USE_EMULATOR=true`. Eliminates the entire class of "accidental writes to prod from localhost" bugs. Opt-out via `npm run dev:prod`.

**Config**
- `firebase.json`: adds `functions` block (Node 22, us-central1), `emulators` block, expanded CSP for App Check (`https://www.google.com`) + Cloud Functions (`https://*.cloudfunctions.net`, `https://*.run.app`)
- `.env.example` documents `VITE_RECAPTCHA_ENTERPRISE_SITE_KEY` + `VITE_USE_EMULATOR` (matches salmoncow naming for cross-project consistency)

**Docs**
- `.specs/features/002-multi-user-rbac/{spec.md, tasks.md, bootstrap.md}` — full feature spec, including §VI Design Decisions documenting the claim-first ordering trade-off (portable to sibling projects)
- `.specs/technical/firebase-deployment.md` — new sections on Cloud Functions deployment, Browser API key posture, App Check configuration; cross-references the new global `firebase-deploy-runbook` skill rather than duplicating
- `.specs/constitution.md` v1.4.0 → v1.5.0 — §II.1 Security Phase 2 + Cost Blaze, §VI.1 rewritten with Spark-equivalent discipline framing + Functions limits + \$5/mo budget alert
- `.prompts/meta/architectural-decision-log.md` — ADR-009 documenting alternatives considered, trade-offs accepted, claim-first failure-mode analysis
- `.claude/agents/speckit.md` — Spark-only constraint replaced; new hard constraint requiring future Cloud-Functions-introducing specs to flag post-deploy operational steps

## Testing

- ✅ `npm run typecheck` clean
- ✅ `npm test` — 178/178 unit tests
- ✅ `npm run test:rules` — 44/44 rules tests across {owner, admin, user, anon} × users / seasons / content / audit / rateLimits
- ✅ `npm run test:functions` — 15/15 function tests (auth gate × 3, validation × 3, happy path × 2, last-owner × 2, rate limit × 2, not-found × 1, onUserCreate × 2)
- ✅ Emulator E2E walkthrough: promote/demote, last-owner guard, role-gated dropdown, route guard, direct devtools call rejected
- ✅ Real-Firebase preview-channel walkthrough on `citl-baed2`: owner bootstrapped via CLI, Admin UI loads, Users tab dropdown promotes/demotes, audit entries land in Firestore Console

## Constitutional Compliance

Audit against `.claude/agents/reviewer.md`'s 12-check list:

- ✅ #1 No `var` / #2 No inline event handlers / #3 No unfiltered Firestore reads (all queries use `limit()` + cursor) / #4 No leaked `onSnapshot` (auth.ts + admin-users-panel.ts both unsubscribe in teardown) / #6 No unsanitized innerHTML (escapeHtml on every user-supplied string) / #8 File size (admin-panel.ts now 230 lines; biggest tab module 583 / target 500 / hard 750) / #9 No circular imports / #11 Conventional commits / #12 Types in src/types/
- ⚠️ #5 — `scripts/set-role.js` hardcodes `PROJECT_ID = 'citl-baed2'` (acceptable for project-specific CLI; alternative would shift the hardcoding to an env var)
- ⚠️ #7 — `<admin-users-panel>` uses plain "Loading users…" text instead of `.skeleton` shimmer; matches the existing pattern in `roster-modal.ts` (cherry-picked, pre-existing). Future polish, not blocking.
- ⚠️ #10 — `admin-users-panel.ts` and `announcements-tab.ts` have **type-only** imports from `firebase/firestore` (`Timestamp`, `DocumentSnapshot`). Erased at compile time; arguably out of scope of the rule which targets runtime coupling.

**Phase transitions documented**:
- §II.1 Security: Phase 1 → Phase 2 (App Check + custom-claim RBAC) — ADR-009
- §II.1 Cost: Spark free tier → Blaze (drift correction; Blaze was already enabled)
- §III.1 Testing: critical-path RBAC code now has 100% coverage (rules + Functions); broader Phase 2 adoption stays pending its own trigger

**Forbidden patterns avoided** (§IV.2): all reads paginated, all listeners unsubscribed, no client-side filtering, no client writes to `role` field (rules deny + Admin SDK is the sole writer).

## Known follow-ups (not blocking merge)

- **Bundle size**: 540 kB (gzip 160 kB) — over §III.3 target of 250 kB pre-gzip. Adding the Firebase Functions + App Check + Firestore SDKs accounts for it. Consider code-splitting the admin route in a follow-up.
- **CSP cleanup**: `style-src` / `font-src` `cdnjs.cloudflare.com` allowances are stale per ADR-008; left intact in this PR for scope.
- **Admin-panel skeleton loading states**: noted above (#7).
- **App Check enforcement**: currently Unenforced on Firestore + Cloud Functions in prod. Flip to Enforced after a few days of clean metrics in the Firebase Console.
- **Legacy admin user migration**: their `admin: true` claim is no longer honored under the new rules. They sign in once via Google, then `npm run set-role -- set <email> admin` via the CLI's defensive seed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)