### PR TITLE
ci: deploy Cloud Functions + indexes; run rules + function tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,36 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run test
+
+  test-rules:
+    name: Firestore Rules Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - run: npm ci
+      - run: npm run test:rules
+
+  test-functions:
+    name: Cloud Functions Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - run: npm ci
+      - run: npm ci --prefix functions
+      - run: npm run test:functions

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,6 +32,7 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          VITE_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_ENTERPRISE_SITE_KEY }}
 
       - name: Deploy to Firebase Hosting (preview channel)
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,6 +16,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+      - run: npm ci --prefix functions
 
       - name: Build
         run: npm run build
@@ -27,12 +28,13 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          VITE_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_ENTERPRISE_SITE_KEY }}
 
       - name: Write service account credentials
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > /tmp/sa.json
 
-      - name: Deploy Firestore security rules
-        run: npx firebase deploy --only firestore:rules --project citl-baed2
+      - name: Deploy Firestore rules + indexes and Cloud Functions
+        run: npx firebase deploy --only firestore:rules,firestore:indexes,functions --project citl-baed2 --force
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/sa.json
 


### PR DESCRIPTION
## Summary

Closes the CI gap from #157. After RBAC merged, push-to-main only deploys hosting + Firestore rules — Cloud Functions, Firestore indexes, and the App Check site-key build dependency had to be deployed manually via `npm run deploy`. This brings CI back to "push to main = full production deploy" parity, and adds the rules + function test suites to the PR-merge gate.

## Changes

**`deploy-production.yml`** (push to main):
- `npm ci --prefix functions` to install function deps (the `firebase.json` predeploy hook builds with `tsc`)
- Add `VITE_RECAPTCHA_ENTERPRISE_SITE_KEY` to the build env. Without it, the deployed bundle prints `[appcheck] not set; init skipped` — currently OK because App Check is Unenforced, but flipping to Enforced would reject every legitimate caller until the env var is wired.
- Expand the deploy command from `firestore:rules` only → `firestore:rules,firestore:indexes,functions` and add `--force` so the Artifact Registry cleanup-policy prompt doesn't hang non-interactive CI.

**`deploy-preview.yml`** (PR open/sync):
- Add the same `VITE_RECAPTCHA_ENTERPRISE_SITE_KEY`. Preview channels are hosting-only (Firestore + Functions are correctly shared with prod), so no functions/indexes deploy here.

**`ci.yml`** (push + PR):
- New `test-rules` job: Java 21 + `npm ci` + `npm run test:rules` (44 rules-unit-testing cases — full {owner, admin, user, anon} matrix on users / seasons / content / audit / rateLimits)
- New `test-functions` job: Java 21 + root deps + functions deps + `npm run test:functions` (15 cases covering setUserRole and onUserCreate)
- Both gate PR merges per constitution §III.1 (auth/authorization critical-path = 100% coverage required)

## Prerequisite — IAM roles on the github-actions-deploy SA

The current SA (`github-actions-deploy@citl-baed2.iam.gserviceaccount.com`) has the roles needed for hosting + rules deploy, but not for Cloud Functions deploy:

**Currently has:**
- `roles/firebasehosting.admin` ✓
- `roles/firebaserules.admin` ✓
- `roles/iam.serviceAccountUser` ✓
- `roles/serviceusage.apiKeysViewer` ✓
- `roles/serviceusage.serviceUsageConsumer` ✓

**Needs to add (one-time, before this PR is merged or the first CI deploy after merge):**

```bash
PROJECT=citl-baed2
SA=github-actions-deploy@citl-baed2.iam.gserviceaccount.com

gcloud projects add-iam-policy-binding $PROJECT \
  --member="serviceAccount:$SA" --role="roles/datastore.indexAdmin"
gcloud projects add-iam-policy-binding $PROJECT \
  --member="serviceAccount:$SA" --role="roles/cloudfunctions.developer"
gcloud projects add-iam-policy-binding $PROJECT \
  --member="serviceAccount:$SA" --role="roles/run.developer"
gcloud projects add-iam-policy-binding $PROJECT \
  --member="serviceAccount:$SA" --role="roles/artifactregistry.writer"
```

Without these, the first CI deploy after merging this PR will fail with a `PERMISSION_DENIED` from `cloudfunctions.googleapis.com` or `artifactregistry.googleapis.com`.

(The `590948706466-compute@developer.gserviceaccount.com` Compute SA already has `roles/storage.objectViewer` from the manual first-deploy fix — that's the SA Cloud Build *runs as*, distinct from the SA that *triggers* the deploy.)

## Testing

Static-validated:
- All three YAML files parse cleanly (`js-yaml`)
- `firebase deploy --only firestore:rules,firestore:indexes,functions` syntax matches what worked manually for #157
- Java 21 setup matches the Firestore emulator requirement (`firebase-tools` 15.x dropped Java <21)

End-to-end will be verified on the first push-to-main after merge.

## Constitutional Compliance

- §III.1 Testing: critical-path RBAC code (rules + Functions) now gates PR merges in CI, completing the "100% coverage at unit layer" requirement
- §V.1 Workflow: PR description follows the standard structure
- §IV.2 Forbidden patterns: none introduced
- §II.3 Modularity: workflow files are independent jobs; no coupling

🤖 Generated with [Claude Code](https://claude.com/claude-code)