### PR TITLE
chore(docs): make RBAC + deployment specs self-contained

### DIFF
--- a/.specs/features/002-multi-user-rbac/bootstrap.md
+++ b/.specs/features/002-multi-user-rbac/bootstrap.md
@@ -188,7 +188,3 @@ IAM permissions**, not to the in-app user.
   spec
 - [.specs/features/002-multi-user-rbac/tasks.md](./tasks.md) — task
   breakdown
-- Reference implementation:
-  [`~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/bootstrap.md`](~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/bootstrap.md)
-  (uses SA key download instead of gcloud ADC — citl uses the cleaner
-  ADC path)

--- a/.specs/features/002-multi-user-rbac/spec.md
+++ b/.specs/features/002-multi-user-rbac/spec.md
@@ -4,7 +4,6 @@
 **Created**: 2026-05-03
 **Status**: Approved — implementation in progress
 **Plan of record**: [/Users/ted/.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md](../../../../.claude/plans/i-recently-implemented-multi-user-partitioned-mochi.md)
-**Reference implementation**: [`~/Developer/salmoncow/.specs/archive/001-multi-user-rbac/`](~/Developer/salmoncow/.specs/archive/001-multi-user-rbac)
 
 ---
 
@@ -19,9 +18,7 @@ enforces rate limits, last-owner protection, and writes an append-only
 audit log. New users get auto-seeded on first sign-in via an
 `onUserCreate` auth trigger.
 
-This mirrors the implementation shipped in `~/Developer/salmoncow`,
-adapted to CITL's TypeScript/Vite stack and existing patterns. v1 ships
-a **Users tab** in the existing `<admin-panel>` Custom Element with:
+v1 ships a **Users tab** in the existing `<admin-panel>` Custom Element with:
 - a paginated user list visible to owner+admin (read-only fields);
 - an inline **role-change dropdown rendered only for owner**, which
   invokes the `setUserRole` callable.
@@ -228,8 +225,8 @@ sequencing" for the full file-by-file breakdown.
 ## VI. Design Decisions
 
 This section captures non-obvious implementation choices and the
-reasoning behind them. Self-contained so it can be ported to sibling
-projects (e.g. salmoncow) that share the same architecture.
+reasoning behind them. Written self-contained so it stands on its
+own without needing context from other projects or feature specs.
 
 ### VI.1 `setUserRole` write ordering — claim-first
 

--- a/.specs/technical/firebase-deployment.md
+++ b/.specs/technical/firebase-deployment.md
@@ -167,8 +167,7 @@ Artifact Registry cleanup policy).
 ## Browser API Key Restrictions
 
 citl-baed2's auto-created Browser API key has **HTTP referrer restrictions
-cleared** (`browserKeyRestrictions: {}`). This is intentional and matches the
-posture salmoncow has been running in production with no incidents.
+cleared** (`browserKeyRestrictions: {}`). This is intentional.
 
 ### Why cleared
 


### PR DESCRIPTION
## Summary

Removes references to an external sibling project from three spec files. The technical content was already self-contained — the references were just attribution that doesn't add value to a future reader of these specs.

## Changes

- `.specs/features/002-multi-user-rbac/spec.md` — drop the "Reference implementation" header link, the "this mirrors..." sentence in the Overview, and the parenthetical "(e.g. ...)" example in §VI Design Decisions
- `.specs/features/002-multi-user-rbac/bootstrap.md` — drop the trailing "Reference implementation" bullet from the Related section
- `.specs/technical/firebase-deployment.md` — drop the "matches the posture ... has been running in production" attribution from the Browser API key rationale

## Testing

No technical changes, no AC impact, no test changes. Verified zero remaining references via grep on `.prompts/`, `.specs/`, `.claude/`, `CLAUDE.md`, `src/`, `scripts/`, `functions/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)