### PR TITLE
fix(ci): restore sequential test execution under Vitest 4

### DIFF
--- a/tests/functions/vitest.config.ts
+++ b/tests/functions/vitest.config.ts
@@ -8,8 +8,12 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/functions/**/*.test.ts'],
     root: repoRoot,
-    pool: 'forks',
-    poolOptions: { forks: { singleFork: true } },
+    // Run all test files sequentially in a single worker process so they
+    // share — and don't race on — the emulator state started by
+    // `firebase emulators:exec`. Vitest 4 dropped poolOptions.forks.singleFork;
+    // `maxWorkers: 1, isolate: false` is the documented replacement.
+    maxWorkers: 1,
+    isolate: false,
     testTimeout: 30_000,
     hookTimeout: 30_000,
     setupFiles: ['tests/functions/_setup.ts'],

--- a/tests/rules/vitest.config.ts
+++ b/tests/rules/vitest.config.ts
@@ -9,9 +9,11 @@ export default defineConfig({
     include: ['tests/rules/**/*.test.ts'],
     root: repoRoot,
     // Rules tests run sequentially in a shared emulator; isolate to avoid
-    // cross-test interference at the doc level.
-    pool: 'forks',
-    poolOptions: { forks: { singleFork: true } },
+    // cross-test interference at the doc level. Vitest 4 dropped
+    // poolOptions.forks.singleFork; `maxWorkers: 1, isolate: false` is the
+    // documented replacement.
+    maxWorkers: 1,
+    isolate: false,
     testTimeout: 15_000,
     hookTimeout: 15_000,
   },


### PR DESCRIPTION
## Summary

- Migrate `tests/functions/vitest.config.ts` and `tests/rules/vitest.config.ts` from the Vitest 3 `poolOptions.forks.singleFork: true` syntax (silently ignored in Vitest 4) to the documented Vitest 4 equivalent: `maxWorkers: 1, isolate: false`.
- Restores sequential test-file execution against the shared `firebase emulators:exec` instance, eliminating the cross-file race that's been intermittently failing the Cloud Functions Tests CI job.

## Why

CI run [25469811845](https://github.com/salmoncow/citl/actions/runs/25469811845) (and several others since `c5bb405`) failed with:

- `tests/functions/onUserCreate.test.ts > is idempotent — does not overwrite an existing users/{uid} doc` → `FirebaseAuthError: There is no user record corresponding to the provided identifier.`
- `tests/functions/onUserCreate.test.ts > handles missing email/displayName/photoURL gracefully` → `expected undefined to be 'user'`

The CI log emits `DEPRECATED test.poolOptions was removed in Vitest 4` immediately before the failures. Without `singleFork: true` being honored, both function test files run in parallel forks. `setUserRole.test.ts`'s `beforeEach` calls `clearAuth()` + `clearFirestore()` — wiping all emulator state — and was racing `onUserCreate.test.ts`, deleting the user/doc it had just written. That fully explains both failure modes:

- Test 1: pre-seeded doc gets wiped → `existing.exists` returns false → handler proceeds to `setCustomUserClaims` → Auth user is also wiped → `no user record`.
- Test 2: handler-written doc gets wiped before the test reads it back → `role` is `undefined`.

The rules config had the same deprecated syntax; fixing it now while we're here, before a second rules test file gets added.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (178 tests)
- [x] `npx vitest list --config tests/functions/vitest.config.ts` — no `DEPRECATED` warning
- [x] `npx vitest list --config tests/rules/vitest.config.ts` — no `DEPRECATED` warning
- [ ] Cloud Functions Tests CI job passes on this branch
- [ ] Re-run Cloud Functions Tests a few times to confirm flake rate drops to zero (pre-fix was ~1 in 3)
- [ ] Firestore Rules Tests CI job still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)