### PR TITLE
feat(admin): users tab fixes — styling, year selector, last sign-in

### DIFF
--- a/src/components/admin-panel.ts
+++ b/src/components/admin-panel.ts
@@ -60,7 +60,7 @@ class AdminPanel extends HTMLElement {
           <button class="admin-tab-btn" data-tab="users">Users</button>
         </div>
 
-        <div class="admin-form-row">
+        <div id="ap-year-row" class="admin-form-row">
           <label for="ap-year">Year</label>
           <select id="ap-year">${buildOptions(2019, 2030, '', CURRENT_YEAR)}</select>
         </div>
@@ -111,6 +111,9 @@ class AdminPanel extends HTMLElement {
       const el = this.querySelector(`#${id}`);
       if (el) el.classList.toggle('admin-tab-panel--hidden', name !== tab);
     }
+
+    const yearRow = this.querySelector<HTMLElement>('#ap-year-row');
+    if (yearRow) yearRow.classList.toggle('admin-form-row--hidden', tab === 'users');
 
     if (tab === 'score-entry') this._scoreEntryTab.onActivate?.();
     else if (tab === 'announcements') this._announcementsTab.onActivate?.();

--- a/src/components/admin-users-panel.ts
+++ b/src/components/admin-users-panel.ts
@@ -50,18 +50,20 @@ class AdminUsersPanel extends HTMLElement {
       <section class="users-panel">
         <h2>Users</h2>
         <div class="users-panel__status" aria-live="polite"></div>
-        <table class="users-table" hidden>
-          <thead>
-            <tr>
-              <th scope="col">Display name</th>
-              <th scope="col">Email</th>
-              <th scope="col">Role</th>
-              <th scope="col">Last sign-in</th>
-              <th scope="col">Created</th>
-            </tr>
-          </thead>
-          <tbody class="users-table__body"></tbody>
-        </table>
+        <div class="admin-table-wrapper users-table-wrapper" hidden>
+          <table class="users-table">
+            <thead>
+              <tr>
+                <th scope="col">Display name</th>
+                <th scope="col">Email</th>
+                <th scope="col">Role</th>
+                <th scope="col">Last sign-in</th>
+                <th scope="col">Created</th>
+              </tr>
+            </thead>
+            <tbody class="users-table__body"></tbody>
+          </table>
+        </div>
         <div class="users-panel__empty" hidden>No users yet.</div>
         <div class="users-panel__error" hidden role="alert"></div>
         <button type="button" class="users-panel__load-more btn-secondary" hidden>Load more</button>
@@ -126,19 +128,19 @@ class AdminUsersPanel extends HTMLElement {
 
   private _renderRows(): void {
     const tbody = this.querySelector<HTMLTableSectionElement>('.users-table__body');
-    const table = this.querySelector<HTMLTableElement>('.users-table');
+    const wrapper = this.querySelector<HTMLElement>('.users-table-wrapper');
     const empty = this.querySelector<HTMLElement>('.users-panel__empty');
     const loadMore = this.querySelector<HTMLButtonElement>('.users-panel__load-more');
-    if (!tbody || !table || !empty || !loadMore) return;
+    if (!tbody || !wrapper || !empty || !loadMore) return;
 
     if (this._users.length === 0) {
-      table.hidden = true;
+      wrapper.hidden = true;
       empty.hidden = false;
       loadMore.hidden = true;
       return;
     }
 
-    table.hidden = false;
+    wrapper.hidden = false;
     empty.hidden = true;
     loadMore.hidden = this._nextCursor === null;
 

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -32,22 +32,31 @@ import {
 } from 'firebase/auth';
 import { doc, onSnapshot, type Unsubscribe } from 'firebase/firestore';
 import { type Result, success, failure } from '@/repositories/score-repository';
+import { createRepositoryFactory } from '@/repositories/repository-factory';
+import type { UserRepository } from '@/repositories/user-repository';
 import { getRole, refreshRole } from '@/modules/role';
 import type { Role } from '@/types/user';
 
 export class AuthModule {
   private readonly _provider = new GoogleAuthProvider();
+  private readonly _userRepo: UserRepository;
   private _snapshotUnsub: Unsubscribe | null = null;
   private _lastRoleChangedAtMs: number | null = null;
   private _internalAuthUnsub: () => void;
 
   constructor() {
+    this._userRepo = createRepositoryFactory({ db }).getUserRepository();
+
     // Internal: keep the role-change snapshot listener in sync with
-    // sign-in/sign-out lifecycle. Exposed onAuthStateChanged is for
+    // sign-in/sign-out lifecycle, and refresh lastSignInAt on every
+    // authenticated session start. Exposed onAuthStateChanged is for
     // consumers; this internal subscription is independent of it.
     this._internalAuthUnsub = firebaseOnAuthStateChanged(auth, (user) => {
       this._teardownSnapshot();
-      if (user) this._setupSnapshot(user.uid);
+      if (user) {
+        this._setupSnapshot(user.uid);
+        void this._userRepo.touchLastSignIn(user.uid);
+      }
     });
   }
 

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -7,10 +7,12 @@
  *     (per constitution §III.3 / §IV.2 — never unbounded reads)
  *   - observeSelf: real-time listener on the current user's doc, used
  *     to detect roleChangedAt bumps and force token refresh
+ *   - touchLastSignIn: self-update of lastSignInAt on each session
+ *     start (skipped on first sign-in to let onUserCreate seed the doc
+ *     with role + custom claims).
  *
  * Never writes the `role` field. Self-update of non-role fields is
- * permitted by rules but currently unused — clients should not write
- * the mirror outside the server-managed flow.
+ * permitted by Firestore rules.
  */
 
 import {
@@ -22,7 +24,9 @@ import {
   onSnapshot,
   orderBy,
   query,
+  serverTimestamp,
   startAfter,
+  updateDoc,
   type DocumentSnapshot,
   type Firestore,
   type Unsubscribe,
@@ -64,5 +68,28 @@ export class UserRepository {
     return onSnapshot(doc(this.db, 'users', uid), (snap) => {
       cb(snap.exists() ? (snap.data() as UserDoc) : null);
     });
+  }
+
+  /**
+   * Update lastSignInAt on the user's mirror doc. Skipped if the doc
+   * doesn't exist yet — onUserCreate races with this on first sign-in
+   * and is idempotent (no-ops if the doc already exists), so beating
+   * it would cause role + custom claims to never be written.
+   *
+   * Errors are swallowed: sign-in must never fail because of a mirror
+   * update.
+   */
+  async touchLastSignIn(uid: string): Promise<void> {
+    try {
+      const ref = doc(this.db, 'users', uid);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return;
+      await updateDoc(ref, {
+        lastSignInAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+    } catch (e) {
+      console.warn('[user-repository] touchLastSignIn failed:', e);
+    }
   }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1451,6 +1451,70 @@ input[type=number] { -moz-appearance: textfield; }
 .admin-roster-table tr:last-child td { border-bottom: none; }
 
 /* ============================================================
+   Users Table (admin Users tab)
+   ============================================================ */
+
+.users-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: var(--text-sm);
+}
+
+.users-table th {
+  background: var(--c-table-header-bg);
+  color: var(--c-text-inverse);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+}
+
+.users-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--c-table-border);
+  vertical-align: middle;
+}
+
+.users-table tr:last-child td { border-bottom: none; }
+
+.users-table td:nth-child(4),
+.users-table td:nth-child(5) {
+  font-variant-numeric: tabular-nums;
+  color: var(--c-text-muted);
+  white-space: nowrap;
+}
+
+.users-table__role-select {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-sm);
+  background: var(--c-bg);
+  color: var(--c-text);
+  font-size: var(--text-sm);
+}
+
+.users-table__role-select:focus {
+  outline: none;
+  border-color: var(--c-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--c-accent) 15%, transparent);
+}
+
+.users-panel__status,
+.users-panel__empty,
+.users-panel__error {
+  padding: var(--space-3) 0;
+  color: var(--c-text-muted);
+  font-size: var(--text-sm);
+}
+
+.users-panel__load-more {
+  margin-top: var(--space-3);
+}
+
+/* ============================================================
    Text Inputs (name fields, etc.)
    ============================================================ */
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1421,6 +1421,8 @@ input[type=number] { -moz-appearance: textfield; }
 
 .admin-tab-panel--hidden { display: none; }
 
+.admin-form-row--hidden { display: none; }
+
 /* ============================================================
    Roster Table
    ============================================================ */

--- a/tests/rules/users.test.ts
+++ b/tests/rules/users.test.ts
@@ -124,6 +124,18 @@ describe('users/{uid} update — non-role fields', () => {
     );
   });
 
+  it('user can self-update lastSignInAt + updatedAt (touchLastSignIn path)', async () => {
+    // Exercises the rules path that AuthModule.touchLastSignIn relies on:
+    // self-update of timestamp fields with no role field present.
+    const db = asRole(env, USER_UID, 'user');
+    await assertSucceeds(
+      updateDoc(doc(db, 'users', USER_UID), {
+        lastSignInAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      }),
+    );
+  });
+
   it('user CANNOT update another user\'s doc', async () => {
     const db = asRole(env, USER_UID, 'user');
     await assertFails(


### PR DESCRIPTION
## Summary
- The Users tab (recently shipped) had three issues worth a single grouped fix: a stray Year dropdown that doesn't apply to user records, a Last sign-in column that always rendered an em-dash, and a table rendering with browser defaults instead of the admin-table chrome.
- Bringing it up to the visual + functional standard set by the rest of the admin UI without enlarging the change beyond what's needed.

## Changes
- **style(admin):** wrap the users table in `.admin-table-wrapper` and add `.users-table*` rules mirroring `.admin-shooters-table` (header bar, row dividers, tabular-nums for the timestamp columns, focus-ring on the role select). Harmonize spacing for the panel's empty / error / status / load-more states. → `src/components/admin-users-panel.ts`, `src/styles/main.css`
- **fix(admin):** give the year row an id and toggle `.admin-form-row--hidden` from `_switchTab` so the selector hides on the Users tab and shows on the others. → `src/components/admin-panel.ts`, `src/styles/main.css`
- **feat(auth):** add `UserRepository.touchLastSignIn` (self-update of `lastSignInAt` + `updatedAt` via the existing rules path) and call it from `AuthModule` on every authenticated session start. Gates the write on `getDoc.exists()` so it never beats `onUserCreate` on a brand-new user (the trigger is idempotent and would otherwise no-op, leaving role + custom claims unset). Errors are swallowed with `console.warn` — sign-in must not fail because of a mirror-doc update. Includes a positive Firestore-rules test covering the new path. → `src/modules/auth.ts`, `src/repositories/user-repository.ts`, `tests/rules/users.test.ts`

## Testing
- [x] `npm run typecheck` — clean
- [x] `npm test` — 178/178 pass
- [ ] `npm run test:rules` — please run; my local port 8080 was occupied by an existing emulator so I couldn't run it here. The new positive test for `lastSignInAt` self-update is in `tests/rules/users.test.ts`.
- [ ] Manual: Year row hides on Users tab, reappears when switching to Team Mgmt / Score Entry / Announcements
- [ ] Manual: Users table renders with the same chrome as Team / Roster tables (rounded wrapper, header bar, row dividers, monospaced timestamps)
- [ ] Manual: Sign out + back in → `users/{uid}.lastSignInAt` advances. Reload the page while signed in → advances again.
- [ ] Manual: Sign in as a brand-new test account → `onUserCreate` still seeds the doc with `role: 'user'` and a custom claim is set (race-avoidance verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)