### PR TITLE
feat(admin): default Score Entry week to current shoot week

### DIFF
--- a/src/components/admin-tabs/score-entry-tab.ts
+++ b/src/components/admin-tabs/score-entry-tab.ts
@@ -9,7 +9,7 @@
 
 import { ScoreService } from '@/services/score-service';
 import { showToast } from '@/modules/ui';
-import { computeSchedule } from '@/utils/schedule';
+import { computeSchedule, currentShootWeek } from '@/utils/schedule';
 import {
   LOCK_SVG,
   PENCIL_SVG,
@@ -43,10 +43,12 @@ export class ScoreEntryTab implements AdminTab {
     this._host = host;
     this._ctx = ctx;
 
+    const defaultWeek = currentShootWeek(ctx.getYear());
+
     host.innerHTML = `
       <div class="admin-form-row">
         <label for="ap-week">Week</label>
-        <select id="ap-week">${buildOptions(1, MAX_WEEKS, 'Week', 1)}</select>
+        <select id="ap-week">${buildOptions(1, MAX_WEEKS, 'Week', defaultWeek)}</select>
         <label for="ap-team">Team</label>
         <select id="ap-team">
           <option value="">-- Select team --</option>
@@ -107,6 +109,10 @@ export class ScoreEntryTab implements AdminTab {
   onYearChange(): void {
     this._dateEditMode = false;
     this._weekHasScores = false;
+    const weekSelect = this._host?.querySelector<HTMLSelectElement>('#ap-week');
+    if (weekSelect && this._ctx) {
+      weekSelect.value = String(currentShootWeek(this._ctx.getYear()));
+    }
     void this._loadSavedEntries();
   }
 

--- a/src/utils/schedule.test.ts
+++ b/src/utils/schedule.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { nthTuesdayOfMonth, computeSchedule } from './schedule';
+import { nthTuesdayOfMonth, computeSchedule, currentShootWeek } from './schedule';
 
 // ─── nthTuesdayOfMonth ──────────────────────────────────────────────────────
 
@@ -189,5 +189,59 @@ describe('computeSchedule — no July 4 skip (2026: July 4 = Saturday)', () => {
         (1000 * 60 * 60 * 24);
       expect(diff).toBe(7);
     }
+  });
+});
+
+// ─── currentShootWeek ───────────────────────────────────────────────────────
+
+describe('currentShootWeek — defaults the Score Entry week dropdown', () => {
+  // 2025 reference (Week 1 = Apr 15, Week 3 = Apr 29, Week 4 = May 6;
+  // July 1 skipped → Week 11 = Jun 24, Week 12 = Jul 8)
+
+  it('returns 1 when today is well before Week 1 of the year', () => {
+    expect(currentShootWeek(2025, new Date(2025, 0, 15))).toBe(1);
+  });
+
+  it('returns 1 when today is the day before Week 1', () => {
+    expect(currentShootWeek(2025, new Date(2025, 3, 14))).toBe(1);
+  });
+
+  it('returns 1 on the exact day of Week 1', () => {
+    expect(currentShootWeek(2025, new Date(2025, 3, 15))).toBe(1);
+  });
+
+  it('returns the current week on the exact shoot day (Week 3, Apr 29 2025)', () => {
+    expect(currentShootWeek(2025, new Date(2025, 3, 29))).toBe(3);
+  });
+
+  it('returns the most recent shoot week on a non-Tuesday between shoots', () => {
+    // Thu May 1 2025 falls between Week 3 (Apr 29) and Week 4 (May 6)
+    expect(currentShootWeek(2025, new Date(2025, 4, 1))).toBe(3);
+  });
+
+  it('advances to the next week on its shoot day', () => {
+    expect(currentShootWeek(2025, new Date(2025, 4, 6))).toBe(4);
+  });
+
+  it('handles the July 4 skip correctly (Wed Jul 2 2025 → Week 11)', () => {
+    // 2025: Week 11 is Jun 24; the would-be Week 12 Tuesday (Jul 1) is skipped.
+    // On Jul 2 the most recent shoot is still Jun 24.
+    expect(currentShootWeek(2025, new Date(2025, 6, 2))).toBe(11);
+  });
+
+  it('returns 15 when today is well after Week 15 of the year', () => {
+    expect(currentShootWeek(2025, new Date(2025, 8, 1))).toBe(15);
+  });
+
+  it('returns 15 when the selected year is entirely in the past', () => {
+    expect(currentShootWeek(2024, new Date(2026, 4, 5))).toBe(15);
+  });
+
+  it('returns 1 when the selected year is entirely in the future', () => {
+    expect(currentShootWeek(2027, new Date(2026, 4, 5))).toBe(1);
+  });
+
+  it('ignores time of day (late evening on Week 3 still resolves to Week 3)', () => {
+    expect(currentShootWeek(2025, new Date(2025, 3, 29, 23, 59))).toBe(3);
   });
 });

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -72,3 +72,27 @@ export function computeSchedule(year: number): ScheduleEvent[] {
 
   return events;
 }
+
+/**
+ * Returns the appropriate default shoot-week number for the given year,
+ * based on today's date. Used to default the Score Entry "Week" dropdown.
+ *
+ *  - Before Week 1 of the year → 1
+ *  - On/after Week 15 of the year → 15
+ *  - Otherwise → the week of the most recent shoot event whose date ≤ today
+ *
+ * Date-only comparison (time of day is ignored).
+ */
+export function currentShootWeek(year: number, today: Date = new Date()): number {
+  const shootEvents = computeSchedule(year).filter(e => e.type === 'shoot');
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+
+  let result = 1;
+  for (const e of shootEvents) {
+    const eventStart = new Date(e.date.getFullYear(), e.date.getMonth(), e.date.getDate()).getTime();
+    if (eventStart <= todayStart && e.week !== undefined) {
+      result = e.week;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds `currentShootWeek(year, today?)` to `src/utils/schedule.ts` — returns 1 before the season, 15 after Week 15, otherwise the most recent shoot week whose date ≤ today (date-only, honors the existing July 4 Tuesday skip).
- Score Entry tab uses it at mount and re-applies it in `onYearChange()`, so opening the tab on May 5 (Week 3 of 2026) lands on Week 3 instead of always Week 1.
- 11 new unit tests cover pre-season, exact-day, mid-week, post-skip, post-season, and past/future year selections.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 189/189 pass
- [x] Local: open Admin Portal → Score Entry as an admin; confirm the Week dropdown defaults to the current shoot week of the selected year
- [x] Local: change the Year selector to a past year → Week defaults to 15; change to a future year → Week defaults to 1
- [x] Local: manually pick a different week → saved entries load for that week (no regression in existing flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)