### PR TITLE
refactor(scorecards): route season-scorecards through ScoreService

### DIFF
--- a/src/components/season-scorecards.ts
+++ b/src/components/season-scorecards.ts
@@ -1,49 +1,30 @@
 /**
  * season-scorecards — Custom Element
  *
- * Displays a year dropdown and per-team collapsible scorecard tables driven from Firestore.
+ * Displays a year dropdown and per-team collapsible scorecard tables driven
+ * from Firestore. Pure rendering: all data assembly happens in ScoreService.
  * No shadow DOM; uses global CSS classes.
  */
 
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
-import { ScoreService, buildPriorAvgMap } from '@/services/score-service';
-import { computeShooterAverage, computeShooterStartingAvg, isShooterRookie, mean, isDummyName, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst } from '@/services/scoring-engine';
+import { ScoreService } from '@/services/score-service';
 import type { Season } from '@/types/season';
-import type { Team, WeekResult } from '@/types/score';
+import type { ScorecardRowShooter, ScorecardTeamBlock } from '@/types/scorecard';
 
 const factory = createRepositoryFactory({ db });
 const scoreService = new ScoreService(factory.getScoreRepository());
 
 const WEEK_HEADERS = ['W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7', 'W8', 'W9', 'W10', 'W11', 'W12', 'W13', 'W14', 'W15'];
 
-/** Runtime state for a shooter during display rendering */
-interface ShooterState {
-  name: string;
-  rookie: boolean;
-  isDummy: boolean;
-  startingAvg: number | '-';
-  scores: (number | null)[];
-  w0Display?: number;
-  weeksShot?: number | null;
-  finalAvg?: number | string;
-}
-
 function fmt(val: number | null | undefined | '-' | string): string {
   return val === null || val === undefined || val === '-' ? '-' : String(val);
 }
 
-
-
 class SeasonScorecards extends HTMLElement {
   private _seasons: Season[] = [];
   private _selectedYear: number | null = null;
-  private _teams: Team[] = [];
-  private _allWeekResults: WeekResult[] = [];
-  private _prior1Teams: Team[] = [];
-  private _prior2Teams: Team[] = [];
-  private _prior1AvgMap: Map<string, number> = new Map();
-  private _prior2AvgMap: Map<string, number> = new Map();
+  private _teamBlocks: ScorecardTeamBlock[] = [];
 
   connectedCallback(): void {
     this.innerHTML = `
@@ -61,7 +42,6 @@ class SeasonScorecards extends HTMLElement {
       void this._loadYear(year);
     });
 
-    // Event delegation for collapsible buttons
     this.querySelector('#sc-content')!.addEventListener('click', (e) => {
       const btn = (e.target as HTMLElement).closest('button.collapsible') as HTMLElement | null;
       if (!btn) return;
@@ -114,188 +94,46 @@ class SeasonScorecards extends HTMLElement {
   private async _loadYear(year: number): Promise<void> {
     this.querySelector('#sc-content')!.innerHTML = SeasonScorecards._scorecardsSkeletonHTML();
 
-    const [teamsResult, weeksResult, prior1TeamsResult, prior2TeamsResult, prior1WeeksResult, prior2WeeksResult] = await Promise.all([
-      scoreService.getTeams(year),
-      scoreService.getAllWeekResults(year),
-      scoreService.getTeams(year - 1),
-      scoreService.getTeams(year - 2),
-      scoreService.getAllWeekResults(year - 1),
-      scoreService.getAllWeekResults(year - 2),
-    ]);
-
-    this._teams = teamsResult.success ? (teamsResult.data ?? []) : [];
-    this._allWeekResults = weeksResult.success ? (weeksResult.data ?? []) : [];
-    this._prior1Teams = prior1TeamsResult.success ? prior1TeamsResult.data : [];
-    this._prior2Teams = prior2TeamsResult.success ? prior2TeamsResult.data : [];
-    const prior1Weeks = prior1WeeksResult.success ? prior1WeeksResult.data : [];
-    const prior2Weeks = prior2WeeksResult.success ? prior2WeeksResult.data : [];
-    this._prior1AvgMap = buildPriorAvgMap(prior1Weeks, this._prior1Teams);
-    this._prior2AvgMap = buildPriorAvgMap(prior2Weeks, this._prior2Teams);
-
-    if (!weeksResult.success && !teamsResult.success) {
+    const result = await scoreService.buildScorecardData(year);
+    if (!result.success) {
       this.querySelector('#sc-content')!.innerHTML = `<p>Error loading scorecard data for ${year}.</p>`;
       return;
     }
 
+    this._teamBlocks = result.data.teams;
     this._renderScorecards();
   }
 
   private _renderScorecards(): void {
     const content = this.querySelector('#sc-content')!;
-
-    const teamDocMap = new Map<string, Team>();
-    for (const team of this._teams) {
-      teamDocMap.set(team.name, team);
-    }
-
-    const teamNamesFromWeeks = new Set<string>();
-    for (const wr of this._allWeekResults) {
-      for (const tr of wr.teamResults ?? []) {
-        teamNamesFromWeeks.add(tr.teamName);
-      }
-    }
-
-    const allTeamNames: string[] = [];
-    for (const team of this._teams) {
-      allTeamNames.push(team.name);
-      teamNamesFromWeeks.delete(team.name);
-    }
-    for (const name of teamNamesFromWeeks) {
-      allTeamNames.push(name);
-    }
-
-    if (allTeamNames.length === 0) {
+    if (this._teamBlocks.length === 0) {
       content.innerHTML = `<p>No scorecard data available for ${this._selectedYear}.</p>`;
       return;
     }
-
-    const blocks = allTeamNames.map((teamName) => this._buildTeamBlock(teamName, teamDocMap.get(teamName)));
-    content.innerHTML = blocks.join('\n');
+    content.innerHTML = this._teamBlocks.map(SeasonScorecards._renderTeamBlock).join('\n');
   }
 
-  private _buildTeamBlock(teamName: string, teamDoc: Team | undefined): string {
-    const shooterMap = new Map<string, ShooterState>();
-
-    if (teamDoc?.shooters?.length) {
-      for (const s of teamDoc.shooters) {
-        const key = normalizeShooterName(s.name);
-        const computedAvg = this._prior1AvgMap.get(key)
-          ?? this._prior2AvgMap.get(key)
-          ?? computeShooterStartingAvg(s.name, [...this._prior1Teams, ...this._prior2Teams]);
-        const computedRookie = isShooterRookie(s.name, this._prior1Teams, this._prior2Teams, this._prior1AvgMap, this._prior2AvgMap);
-        shooterMap.set(s.name, {
-          name: s.name,
-          rookie: computedRookie,
-          isDummy: isDummyName(s.name),
-          startingAvg: computedAvg,
-          scores: new Array<number | null>(15).fill(null),
-        });
-      }
-    }
-
-    const targets: (number | null)[] = new Array(15).fill(null);
-    const rankPoints: (number | null)[] = new Array(15).fill(null);
-    const bonusPoints: (number | null)[] = new Array(15).fill(null);
-
-    for (const wr of this._allWeekResults) {
-      const wi = wr.weekNumber - 1;
-      if (wi < 0 || wi >= 15) continue;
-
-      const teamResult = (wr.teamResults ?? []).find((tr) => tr.teamName === teamName);
-      if (!teamResult) continue;
-
-      targets[wi] = teamResult.targets ?? null;
-      rankPoints[wi] = teamResult.rankPoints ?? null;
-      bonusPoints[wi] = teamResult.bonusPoints ?? null;
-
-      for (const ss of teamResult.shooterScores ?? []) {
-        if (!shooterMap.has(ss.name)) {
-          // Only add shooters not already on the current roster if they are dummies.
-          // Real shooters removed from the roster must not reappear via published data.
-          if (!isDummyName(ss.name)) continue;
-          shooterMap.set(ss.name, {
-            name: ss.name,
-            rookie: false,
-            isDummy: true,
-            startingAvg: '-',
-            scores: new Array<number | null>(15).fill(null),
-          });
-        }
-        shooterMap.get(ss.name)!.scores[wi] = ss.total ?? null;
-      }
-    }
-
-    // Pad to 2 DUMMY placeholder rows per team
-    const existingDummies = [...shooterMap.values()].filter((s) => s.isDummy);
-    if (existingDummies.length < 2) {
-      const prefix = getLastWord(teamName);
-      for (let n = existingDummies.length + 1; n <= 2; n++) {
-        const dName = `${prefix} DUMMY${n}`;
-        if (!shooterMap.has(dName)) {
-          shooterMap.set(dName, {
-            name: dName,
-            rookie: false,
-            isDummy: true,
-            startingAvg: '-',
-            scores: new Array<number | null>(15).fill(null),
-          });
-        }
-      }
-    }
-
-    // DUMMY W0 display = mean of real teammates' actual W1 scores
-    const realW1Scores = [...shooterMap.values()]
-      .filter((s) => !s.isDummy && s.scores[0] !== null)
-      .map((s) => s.scores[0] as number);
-    if (realW1Scores.length > 0) {
-      const dummyW0Display = Math.round(mean(realW1Scores) * 10) / 10;
-      for (const s of shooterMap.values()) {
-        if (s.isDummy) s.w0Display = dummyW0Display;
-      }
-    }
-
-    // Compute weeksShot and finalAvg per shooter
-    const shooters: ShooterState[] = [...shooterMap.values()].map((s) => {
-      const nonNull = s.scores.filter((v): v is number => v !== null);
-      const weeksShot = nonNull.length > 0 ? nonNull.length : null;
-      const w0 = s.isDummy
-        ? (nonNull.length > 0 ? (s.w0Display ?? null) : null)
-        : (typeof s.startingAvg === 'number' ? s.startingAvg : null);
-      const finalAvg = w0 !== null
-        ? Math.round(computeShooterAverage(w0, s.scores, 14) * 10) / 10
-        : nonNull.length > 0
-          ? Math.round(mean(nonNull) * 10) / 10
-          : (s.w0Display ?? s.startingAvg);
-      return { ...s, weeksShot, finalAvg };
-    });
-
-    // Sort: captain first (among real shooters), dummies last
-    const withCaptainFirst = sortShootersWithCaptainFirst(shooters, teamDoc?.captain ?? '');
-    withCaptainFirst.sort((a, b) => {
-      if (a.isDummy === b.isDummy) return 0;
-      return a.isDummy ? 1 : -1;
-    });
-
+  private static _renderTeamBlock(block: ScorecardTeamBlock): string {
     const headerCells = WEEK_HEADERS.map((w) => `<th>${w}</th>`).join('');
 
-    const shooterRows = withCaptainFirst
-      .map((s) => {
+    const shooterRows = block.shooters
+      .map((s: ScorecardRowShooter) => {
         const rookieMark = s.rookie ? 'R' : '';
         const scoreCells = s.scores.map((v) => `<td>${fmt(v)}</td>`).join('');
         const weeks = s.weeksShot !== null ? s.weeksShot : '-';
         const rowClass = s.isDummy ? ' class="dummy-row"' : '';
-        return `<tr${rowClass}><td>${s.name}</td><td>${rookieMark}</td><td>${fmt(s.w0Display ?? s.startingAvg)}</td>${scoreCells}<td>${weeks}</td><td>${fmt(s.finalAvg)}</td></tr>`;
+        return `<tr${rowClass}><td>${s.name}</td><td>${rookieMark}</td><td>${fmt(s.w0Display)}</td>${scoreCells}<td>${weeks}</td><td>${fmt(s.finalAvg)}</td></tr>`;
       })
       .join('\n        ');
 
-    const targetCells = targets.map((v) => `<td>${fmt(v)}</td>`).join('');
-    const rpCells = rankPoints.map((v) => `<td>${fmt(v)}</td>`).join('');
-    const bpCells = bonusPoints.map((v) => `<td>${fmt(v)}</td>`).join('');
+    const targetCells = block.targets.map((v) => `<td>${fmt(v)}</td>`).join('');
+    const rpCells = block.rankPoints.map((v) => `<td>${fmt(v)}</td>`).join('');
+    const bpCells = block.bonusPoints.map((v) => `<td>${fmt(v)}</td>`).join('');
 
     const chevronSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 320 512" class="collapsible__chevron" aria-hidden="true" focusable="false"><path fill="currentColor" d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8H32c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/></svg>`;
 
     return `
-    <button class="collapsible"><span class="collapsible__label">${teamName}</span>${chevronSvg}</button>
+    <button class="collapsible"><span class="collapsible__label">${block.teamName}</span>${chevronSvg}</button>
     <div class="scorecard">
       <table class="scorecard-tables">
         <tr><th></th><th>R</th>${headerCells}<th>Weeks Shot</th><th>Avg</th></tr>

--- a/src/services/score-service.test.ts
+++ b/src/services/score-service.test.ts
@@ -437,6 +437,290 @@ describe('computeRosterDefaults', () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildScorecardData — service-layer data assembly for season-scorecards
+// ---------------------------------------------------------------------------
+
+/**
+ * Repository stub that dispatches by year. `currentYear` resolves the
+ * current season's teams + weeks; the prior 1 and prior 2 years resolve from
+ * their own slots. Anything else returns empty.
+ */
+function makeScorecardRepo(opts: {
+  currentYear: number;
+  currentTeams?: Team[];
+  currentWeeks?: WeekResult[];
+  prior1Teams?: Team[];
+  prior2Teams?: Team[];
+  prior1Weeks?: WeekResult[];
+  prior2Weeks?: WeekResult[];
+}): ScoreRepository {
+  const y = opts.currentYear;
+  const stub: Partial<ScoreRepository> = {
+    getTeams: async (year) => {
+      if (year === y) return success(opts.currentTeams ?? []);
+      if (year === y - 1) return success(opts.prior1Teams ?? []);
+      if (year === y - 2) return success(opts.prior2Teams ?? []);
+      return success([]);
+    },
+    getAllWeekResults: async (year) => {
+      if (year === y) return success(opts.currentWeeks ?? []);
+      if (year === y - 1) return success(opts.prior1Weeks ?? []);
+      if (year === y - 2) return success(opts.prior2Weeks ?? []);
+      return success([]);
+    },
+  };
+  return stub as unknown as ScoreRepository;
+}
+
+function makeFullWeekResult(opts: {
+  weekNumber: number;
+  teamName: string;
+  teamId?: string;
+  targets?: number;
+  rankPoints?: number;
+  bonusPoints?: number;
+  shooterScores: { name: string; total: number }[];
+}): WeekResult {
+  return {
+    weekNumber: opts.weekNumber,
+    publishedAt: '',
+    teamResults: [
+      {
+        teamId: opts.teamId ?? opts.teamName.toLowerCase(),
+        teamName: opts.teamName,
+        targets: opts.targets ?? 0,
+        rankPoints: opts.rankPoints ?? 0,
+        bonusPoints: opts.bonusPoints ?? 0,
+        shooterScores: opts.shooterScores.map((s) => ({
+          name: s.name,
+          score1: null,
+          score2: null,
+          total: s.total,
+        })),
+      },
+    ],
+  };
+}
+
+describe('buildScorecardData', () => {
+  it('returns VALIDATION_ERROR for out-of-range year', async () => {
+    const svc = new ScoreService(makeScorecardRepo({ currentYear: 2026 }));
+    const result = await svc.buildScorecardData(2000);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns an empty teams array when no data exists for the year', async () => {
+    const svc = new ScoreService(makeScorecardRepo({ currentYear: 2026 }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.teams).toEqual([]);
+  });
+
+  it('builds one block per rostered team, in roster order', async () => {
+    const teamA = makeTeam('Alpha', [makeRosterShooter('A1'), makeRosterShooter('A2')]);
+    const teamB = makeTeam('Bravo', [makeRosterShooter('B1'), makeRosterShooter('B2')]);
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [teamA, teamB],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.teams.map((b) => b.teamName)).toEqual(['Alpha', 'Bravo']);
+    }
+  });
+
+  it('appends teams that appear only in week results (no current roster doc)', async () => {
+    const teamA = makeTeam('Alpha', [makeRosterShooter('A1')]);
+    const orphanWeek = makeFullWeekResult({
+      weekNumber: 1, teamName: 'Ghost', shooterScores: [{ name: 'G1', total: 40 }],
+    });
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [teamA],
+      currentWeeks: [orphanWeek],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const names = result.data.teams.map((b) => b.teamName);
+      expect(names).toEqual(['Alpha', 'Ghost']);
+    }
+  });
+
+  it('regression #141 — applies prior2AvgMap fallback to scorecard rows (matches computeRosterDefaults)', async () => {
+    // Eve was on the roster both N-1 and N-2, did not shoot in N-1, but shot
+    // twice in N-2 averaging (40+42)/2 = 41. The scorecard view must show 41,
+    // not the new-shooter default of 35.
+    const team = makeTeam('Team', [makeRosterShooter('Eve')]);
+    const prior1Team = makeTeam('Team', [makeShooter('Eve', 35)]);
+    const prior2Team = makeTeam('Team', [makeShooter('Eve', 35)]);
+    const prior2Weeks: WeekResult[] = [
+      makeWeekResult([{ name: 'Eve', total: 40 }]),
+      { ...makeWeekResult([{ name: 'Eve', total: 42 }]), weekNumber: 2 },
+    ];
+
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+      prior1Teams: [prior1Team],
+      prior1Weeks: [],
+      prior2Teams: [prior2Team],
+      prior2Weeks,
+    }));
+
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const eveRow = result.data.teams[0]!.shooters.find((s) => s.name === 'Eve');
+      expect(eveRow?.w0Display).toBe(41);
+      expect(eveRow?.rookie).toBe(false);
+    }
+  });
+
+  it('regression #141 — flags roster-only shooter as rookie when never shot in prior years', async () => {
+    // Frank on roster both prior years but published no scores → rookie.
+    const team = makeTeam('Team', [makeRosterShooter('Frank')]);
+    const prior1Team = makeTeam('Team', [makeShooter('Frank', 35)]);
+    const prior2Team = makeTeam('Team', [makeShooter('Frank', 35)]);
+
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+      prior1Teams: [prior1Team],
+      prior2Teams: [prior2Team],
+    }));
+
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const frankRow = result.data.teams[0]!.shooters.find((s) => s.name === 'Frank');
+      expect(frankRow?.rookie).toBe(true);
+    }
+  });
+
+  it('pads each team to 2 DUMMY rows when fewer dummies exist on the roster', async () => {
+    const team = makeTeam('Hawks', [
+      makeRosterShooter('A'),
+      makeRosterShooter('B'),
+      makeRosterShooter('C'),
+    ]);
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const dummies = result.data.teams[0]!.shooters.filter((s) => s.isDummy);
+      expect(dummies.map((d) => d.name)).toEqual(['Hawks DUMMY1', 'Hawks DUMMY2']);
+    }
+  });
+
+  it('sorts captain first among real shooters and pushes dummies last', async () => {
+    const team: Team = {
+      id: 'team',
+      name: 'Team',
+      captain: 'Bob',
+      shooters: [
+        makeRosterShooter('Alice'),
+        makeRosterShooter('Bob'),
+        makeRosterShooter('Carol'),
+        makeRosterShooter('Team DUMMY1'),
+        makeRosterShooter('Team DUMMY2'),
+      ],
+      totals: { targets: [], rankPoints: [], bonusPoints: [] },
+    };
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const order = result.data.teams[0]!.shooters.map((s) => s.name);
+      expect(order[0]).toBe('Bob');
+      expect(order.slice(-2).every((n) => n.includes('DUMMY'))).toBe(true);
+    }
+  });
+
+  it('computes dummy W0 display = mean of real teammates W1 scores', async () => {
+    // Real W1 scores: 40 and 50 → dummy W0 display = 45
+    const team = makeTeam('Team', [
+      makeRosterShooter('A'),
+      makeRosterShooter('B'),
+      makeRosterShooter('Team DUMMY1'),
+    ]);
+    const week = makeFullWeekResult({
+      weekNumber: 1, teamName: 'Team',
+      targets: 130, rankPoints: 30, bonusPoints: 5,
+      shooterScores: [
+        { name: 'A', total: 40 },
+        { name: 'B', total: 50 },
+        { name: 'Team DUMMY1', total: 40 },
+      ],
+    });
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+      currentWeeks: [week],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const dummy = result.data.teams[0]!.shooters.find((s) => s.name === 'Team DUMMY1');
+      expect(dummy?.w0Display).toBe(45);
+    }
+  });
+
+  it('carries through targets, rankPoints, and bonusPoints from week results', async () => {
+    const team = makeTeam('Team', [makeRosterShooter('A')]);
+    const week = makeFullWeekResult({
+      weekNumber: 1, teamName: 'Team',
+      targets: 200, rankPoints: 28, bonusPoints: 3,
+      shooterScores: [{ name: 'A', total: 40 }],
+    });
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+      currentWeeks: [week],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const block = result.data.teams[0]!;
+      expect(block.targets[0]).toBe(200);
+      expect(block.rankPoints[0]).toBe(28);
+      expect(block.bonusPoints[0]).toBe(3);
+    }
+  });
+
+  it('does not re-add non-dummy shooters removed from the roster but still in week results', async () => {
+    // Charlie was on a published week but is no longer on the roster — must be dropped.
+    const team = makeTeam('Team', [makeRosterShooter('A')]);
+    const week = makeFullWeekResult({
+      weekNumber: 1, teamName: 'Team',
+      shooterScores: [
+        { name: 'A', total: 40 },
+        { name: 'Charlie', total: 38 },
+      ],
+    });
+    const svc = new ScoreService(makeScorecardRepo({
+      currentYear: 2026,
+      currentTeams: [team],
+      currentWeeks: [week],
+    }));
+    const result = await svc.buildScorecardData(2026);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const names = result.data.teams[0]!.shooters.map((s) => s.name);
+      expect(names).not.toContain('Charlie');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // saveTeamRoster — minimum shooter count
 // ---------------------------------------------------------------------------
 

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -8,11 +8,11 @@
  */
 
 import { success, failure, type Result } from '@/repositories/score-repository';
-import { computeSeasonTotals, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, normalizeShooterName, getLastWord, computeAccolades } from '@/services/scoring-engine';
+import { computeSeasonTotals, computeShooterAverage, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, mean, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst, computeAccolades } from '@/services/scoring-engine';
 import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Season, SeasonStandings } from '@/types/season';
 import type { Team, WeekResult, SeasonEntry, ShooterScore } from '@/types/score';
-import type { SeasonData, ScorecardShooter } from '@/types/scorecard';
+import type { SeasonData, ScorecardShooter, ScorecardRowShooter, ScorecardTeamBlock, ScorecardViewData } from '@/types/scorecard';
 import type { Announcement } from '@/types/announcement';
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -412,6 +412,76 @@ export class ScoreService {
     });
   }
 
+  /**
+   * Build the full per-team display data for the season-scorecards view.
+   * Returns one ScorecardTeamBlock per team (rostered teams first, in roster
+   * order; then any teams that appear in published week results but not on
+   * the current roster). Each shooter row carries fully computed display
+   * fields: prior-blended starting/W0 value, rookie flag, scores, weeksShot,
+   * and final average. Shooters are pre-sorted (captain first among real
+   * shooters; dummies last).
+   *
+   * Failures fetching current-year data return an empty `teams` array with
+   * `success: true` so the caller can render a "no data" placeholder.
+   */
+  async buildScorecardData(year: number): Promise<Result<ScorecardViewData>> {
+    if (!Number.isInteger(year) || year < 2019 || year > 2100) {
+      return failure(`Invalid year: ${year}`, 'VALIDATION_ERROR');
+    }
+
+    const [teamsResult, weeksResult, prior1TeamsResult, prior2TeamsResult, prior1WeeksResult, prior2WeeksResult] = await Promise.all([
+      this.getTeams(year),
+      this.getAllWeekResults(year),
+      this.getTeams(year - 1),
+      this.getTeams(year - 2),
+      this.getAllWeekResults(year - 1),
+      this.getAllWeekResults(year - 2),
+    ]);
+
+    if (!teamsResult.success && !weeksResult.success) {
+      return failure(`Unable to load scorecard data for ${year}`, 'NO_DATA');
+    }
+
+    const teams: Team[] = teamsResult.success ? (teamsResult.data ?? []) : [];
+    const weekResults: WeekResult[] = weeksResult.success ? (weeksResult.data ?? []) : [];
+    const prior1Teams: Team[] = prior1TeamsResult.success ? prior1TeamsResult.data : [];
+    const prior2Teams: Team[] = prior2TeamsResult.success ? prior2TeamsResult.data : [];
+    const prior1Weeks: WeekResult[] = prior1WeeksResult.success ? prior1WeeksResult.data : [];
+    const prior2Weeks: WeekResult[] = prior2WeeksResult.success ? prior2WeeksResult.data : [];
+
+    const prior1AvgMap = buildPriorAvgMap(prior1Weeks, prior1Teams);
+    const prior2AvgMap = buildPriorAvgMap(prior2Weeks, prior2Teams);
+
+    const teamDocMap = new Map<string, Team>();
+    for (const team of teams) teamDocMap.set(team.name, team);
+
+    const teamNamesFromWeeks = new Set<string>();
+    for (const wr of weekResults) {
+      for (const tr of wr.teamResults ?? []) teamNamesFromWeeks.add(tr.teamName);
+    }
+
+    const orderedTeamNames: string[] = [];
+    for (const team of teams) {
+      orderedTeamNames.push(team.name);
+      teamNamesFromWeeks.delete(team.name);
+    }
+    for (const name of teamNamesFromWeeks) orderedTeamNames.push(name);
+
+    const blocks = orderedTeamNames.map((teamName) =>
+      _buildScorecardTeamBlock({
+        teamName,
+        teamDoc: teamDocMap.get(teamName),
+        weekResults,
+        prior1Teams,
+        prior2Teams,
+        prior1AvgMap,
+        prior2AvgMap,
+      }),
+    );
+
+    return success({ year, teams: blocks });
+  }
+
   async deleteTeam(year: number, teamId: string): Promise<Result<void>> {
     if (!Number.isInteger(year) || year < 2019 || year > 2100) {
       return failure(`Invalid year: ${year}`, 'VALIDATION_ERROR');
@@ -753,12 +823,156 @@ function _buildSeasonData(
 }
 
 /**
+ * Build one team block for the season-scorecards view. Pure given its inputs
+ * (no I/O), so it can be unit-tested without a repository stub.
+ */
+function _buildScorecardTeamBlock(args: {
+  teamName: string;
+  teamDoc: Team | undefined;
+  weekResults: WeekResult[];
+  prior1Teams: Team[];
+  prior2Teams: Team[];
+  prior1AvgMap: Map<string, number>;
+  prior2AvgMap: Map<string, number>;
+}): ScorecardTeamBlock {
+  const { teamName, teamDoc, weekResults, prior1Teams, prior2Teams, prior1AvgMap, prior2AvgMap } = args;
+  const WEEK_COUNT = 15;
+
+  interface ShooterState {
+    name: string;
+    rookie: boolean;
+    isDummy: boolean;
+    startingAvg: number | '-';
+    scores: (number | null)[];
+    w0Display?: number;
+  }
+
+  const shooterMap = new Map<string, ShooterState>();
+
+  if (teamDoc?.shooters?.length) {
+    for (const s of teamDoc.shooters) {
+      const key = normalizeShooterName(s.name);
+      const computedAvg = prior1AvgMap.get(key)
+        ?? prior2AvgMap.get(key)
+        ?? computeShooterStartingAvg(s.name, [...prior1Teams, ...prior2Teams]);
+      const computedRookie = isShooterRookie(s.name, prior1Teams, prior2Teams, prior1AvgMap, prior2AvgMap);
+      shooterMap.set(s.name, {
+        name: s.name,
+        rookie: computedRookie,
+        isDummy: isDummyName(s.name),
+        startingAvg: computedAvg,
+        scores: new Array<number | null>(WEEK_COUNT).fill(null),
+      });
+    }
+  }
+
+  const targets: (number | null)[] = new Array(WEEK_COUNT).fill(null);
+  const rankPoints: (number | null)[] = new Array(WEEK_COUNT).fill(null);
+  const bonusPoints: (number | null)[] = new Array(WEEK_COUNT).fill(null);
+
+  for (const wr of weekResults) {
+    const wi = wr.weekNumber - 1;
+    if (wi < 0 || wi >= WEEK_COUNT) continue;
+
+    const teamResult = (wr.teamResults ?? []).find((tr) => tr.teamName === teamName);
+    if (!teamResult) continue;
+
+    targets[wi] = teamResult.targets ?? null;
+    rankPoints[wi] = teamResult.rankPoints ?? null;
+    bonusPoints[wi] = teamResult.bonusPoints ?? null;
+
+    for (const ss of teamResult.shooterScores ?? []) {
+      if (!shooterMap.has(ss.name)) {
+        // Only re-add shooters not on the current roster if they are dummies.
+        // Real shooters removed from the roster must not reappear via published data.
+        if (!isDummyName(ss.name)) continue;
+        shooterMap.set(ss.name, {
+          name: ss.name,
+          rookie: false,
+          isDummy: true,
+          startingAvg: '-',
+          scores: new Array<number | null>(WEEK_COUNT).fill(null),
+        });
+      }
+      shooterMap.get(ss.name)!.scores[wi] = ss.total ?? null;
+    }
+  }
+
+  // Pad to 2 DUMMY placeholder rows per team
+  const existingDummies = [...shooterMap.values()].filter((s) => s.isDummy);
+  if (existingDummies.length < 2) {
+    const prefix = getLastWord(teamName);
+    for (let n = existingDummies.length + 1; n <= 2; n++) {
+      const dName = `${prefix} DUMMY${n}`;
+      if (!shooterMap.has(dName)) {
+        shooterMap.set(dName, {
+          name: dName,
+          rookie: false,
+          isDummy: true,
+          startingAvg: '-',
+          scores: new Array<number | null>(WEEK_COUNT).fill(null),
+        });
+      }
+    }
+  }
+
+  // DUMMY W0 display = mean of real teammates' actual W1 scores
+  const realW1Scores = [...shooterMap.values()]
+    .filter((s) => !s.isDummy && s.scores[0] !== null)
+    .map((s) => s.scores[0] as number);
+  if (realW1Scores.length > 0) {
+    const dummyW0Display = Math.round(mean(realW1Scores) * 10) / 10;
+    for (const s of shooterMap.values()) {
+      if (s.isDummy) s.w0Display = dummyW0Display;
+    }
+  }
+
+  // Compute weeksShot, finalAvg, and final w0Display per shooter
+  const rows: ScorecardRowShooter[] = [...shooterMap.values()].map((s) => {
+    const nonNull = s.scores.filter((v): v is number => v !== null);
+    const weeksShot = nonNull.length > 0 ? nonNull.length : null;
+    const w0Num = s.isDummy
+      ? (nonNull.length > 0 ? (s.w0Display ?? null) : null)
+      : (typeof s.startingAvg === 'number' ? s.startingAvg : null);
+    const finalAvg = w0Num !== null
+      ? Math.round(computeShooterAverage(w0Num, s.scores, WEEK_COUNT - 1) * 10) / 10
+      : nonNull.length > 0
+        ? Math.round(mean(nonNull) * 10) / 10
+        : (s.w0Display ?? s.startingAvg);
+    const w0Display: number | '-' = s.w0Display ?? s.startingAvg;
+    return {
+      name: s.name,
+      rookie: s.rookie,
+      isDummy: s.isDummy,
+      w0Display,
+      scores: s.scores,
+      weeksShot,
+      finalAvg,
+    };
+  });
+
+  const withCaptainFirst = sortShootersWithCaptainFirst(rows, teamDoc?.captain ?? '');
+  withCaptainFirst.sort((a, b) => {
+    if (a.isDummy === b.isDummy) return 0;
+    return a.isDummy ? 1 : -1;
+  });
+
+  return {
+    teamName,
+    shooters: withCaptainFirst,
+    targets,
+    rankPoints,
+    bonusPoints,
+  };
+}
+
+/**
  * Build a name→finalAvg map from published WeekResult documents, applying the
  * same business rule as computeShooterAverage: when a shooter has fewer than
  * 2 weeks of actual scores, the starting average is blended into the mean.
  * priorTeams is required for that startingAvg lookup.
  *
- * Exported so the scorecard component can reuse this logic without duplicating it.
+ * Exported so existing tests can exercise the helper directly.
  */
 export function buildPriorAvgMap(weekResults: WeekResult[], priorTeams: Team[]): Map<string, number> {
   // Build startingAvg lookup keyed by lowercased name (first match wins)

--- a/src/types/scorecard.ts
+++ b/src/types/scorecard.ts
@@ -50,3 +50,41 @@ export interface SeasonData {
   season: number;
   teams: Team[];
 }
+
+/**
+ * A single shooter row, fully computed and ready to render in the
+ * season-scorecards view. Built by ScoreService.buildScorecardData.
+ */
+export interface ScorecardRowShooter {
+  name: string;
+  rookie: boolean;
+  isDummy: boolean;
+  /** Display value for the W0 column: prior avg, dummy display, or '-' when unknown. */
+  w0Display: number | '-';
+  /** 15 weekly scores (W1–W15); null = did not shoot. */
+  scores: (number | null)[];
+  /** Number of weeks actually shot; null when zero. */
+  weeksShot: number | null;
+  /** Display value for the season-average column. */
+  finalAvg: number | string;
+}
+
+/**
+ * A team block ready to render. Shooters are pre-sorted: captain first
+ * among real shooters, dummies last.
+ */
+export interface ScorecardTeamBlock {
+  teamName: string;
+  shooters: ScorecardRowShooter[];
+  targets: (number | null)[];
+  rankPoints: (number | null)[];
+  bonusPoints: (number | null)[];
+}
+
+/**
+ * Aggregate scorecard view data for one season.
+ */
+export interface ScorecardViewData {
+  year: number;
+  teams: ScorecardTeamBlock[];
+}


### PR DESCRIPTION
## Summary
- `season-scorecards.ts` was bypassing the service layer — pulling 7 helpers from `scoring-engine.ts` plus `buildPriorAvgMap` from `score-service.ts` and running its own data pipeline in violation of the `components → services → repositories` rule
- This had already caused a real defect: the #139/#140 fixes to prior-year avg blending and rookie detection had to be patched into the component separately because the parallel implementation didn't pick them up
- Move all data assembly into a new `ScoreService.buildScorecardData(year)` so both the admin (roster defaults) and public (scorecards) views share one source of truth

## Changes
- `src/types/scorecard.ts` — add `ScorecardRowShooter`, `ScorecardTeamBlock`, `ScorecardViewData` describing the fully-rendered shape the component receives
- `src/services/score-service.ts` — add `buildScorecardData(year)` that fetches current + prior-1 + prior-2 teams/weeks in parallel, builds `prior1AvgMap` / `prior2AvgMap`, computes per-shooter starting avg + rookie status, pads dummies, computes W0 display + final avg, and sorts captain-first / dummies-last
- `src/components/season-scorecards.ts` — drops 159 lines (311 → 152); no imports from `scoring-engine`; one service call followed by pure rendering
- `src/services/score-service.test.ts` — add 11 tests for `buildScorecardData` including explicit regression coverage for #139 (`prior2AvgMap` fallback) and #140 (roster-only rookie flagging) routed through the scorecard path

## Testing
- [x] `vitest run` — 200/200 pass (11 new)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Manual smoke test: scorecards page renders identically for an active and an archived season on a preview channel

Closes #141