### PR TITLE
feat(appcheck): support debug tokens for preview channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,22 @@ NODE_ENV=development
 # when VITE_USE_EMULATOR=true.
 VITE_RECAPTCHA_ENTERPRISE_SITE_KEY=
 
+# App Check debug token (preview channels and occasional local-against-
+# prod testing only). When set, the App Check SDK bypasses reCAPTCHA
+# and uses this token to obtain a real App Check token from Firebase's
+# service. The token must first be registered under Firebase Console →
+# App Check → Apps → Manage debug tokens for the citl web app.
+#
+# Required for Firebase Hosting preview channels: their URLs
+# (citl-baed2--*.web.app) can't be added to the reCAPTCHA Enterprise
+# allowed-domains list (no mid-label wildcards supported) and they're
+# siblings of citl-baed2.web.app, not subdomains, so real reCAPTCHA
+# tokens can't be minted from those origins.
+#
+# CI injection: .github/workflows/deploy-preview.yml only.
+# NEVER set this on production builds.
+VITE_APP_CHECK_DEBUG_TOKEN=
+
 # Local emulator suite
 # `npm run dev` sets this automatically; do not set it for production builds.
 # When true, Auth, Firestore, and Functions SDKs connect to:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,6 +33,13 @@ jobs:
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
           VITE_RECAPTCHA_ENTERPRISE_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_ENTERPRISE_SITE_KEY }}
+          # Preview-only: App Check debug token. Bypasses reCAPTCHA on
+          # preview channel origins, which can't be added to the
+          # reCAPTCHA Enterprise allowed-domains list. The token value
+          # must be registered in Firebase Console → App Check → Apps →
+          # Manage debug tokens for the citl web app. Do NOT add this
+          # env var to deploy-production.yml.
+          VITE_APP_CHECK_DEBUG_TOKEN: ${{ secrets.VITE_APP_CHECK_DEBUG_TOKEN }}
 
       - name: Deploy to Firebase Hosting (preview channel)
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/src/infrastructure/appcheck.ts
+++ b/src/infrastructure/appcheck.ts
@@ -10,11 +10,31 @@
  * it, App Check init is skipped and a console warning is emitted —
  * the deployed Cloud Function will reject calls without an App Check
  * token, so the warning is operational, not silent.
+ *
+ * For Firebase Hosting preview channels: reCAPTCHA Enterprise doesn't
+ * support mid-label wildcards (citl-baed2--*.web.app is invalid) and
+ * preview URLs are siblings of citl-baed2.web.app, not subdomains —
+ * so real reCAPTCHA tokens can't be minted from preview origins.
+ * Set VITE_APP_CHECK_DEBUG_TOKEN in preview-channel deploys (CI
+ * injects from a secret) and register the same token under Firebase
+ * Console → App Check → Apps → Manage debug tokens. The SDK then
+ * exchanges the debug token for a real App Check token from Firebase's
+ * service, bypassing reCAPTCHA on the client.
+ *
+ * Production builds MUST NOT set VITE_APP_CHECK_DEBUG_TOKEN — only the
+ * preview-channel deploy workflow injects it.
  */
 
 import { getApp } from 'firebase/app';
 import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
 import { useEmulator } from '@/firebase-config';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    FIREBASE_APPCHECK_DEBUG_TOKEN?: string | boolean;
+  }
+}
 
 let initialized = false;
 
@@ -35,6 +55,22 @@ export function initAppCheck(): void {
     );
     initialized = true;
     return;
+  }
+
+  // Debug token for non-production builds (Firebase Hosting preview
+  // channels, occasional local-against-prod testing). MUST be set
+  // BEFORE initializeAppCheck() so the SDK picks it up. The token must
+  // also be registered in Firebase Console → App Check → Apps →
+  // Manage debug tokens for the citl web app. Production deploys never
+  // inject this env var; see deploy-production.yml vs deploy-preview.yml.
+  const debugToken = import.meta.env['VITE_APP_CHECK_DEBUG_TOKEN'];
+  if (debugToken) {
+    window.FIREBASE_APPCHECK_DEBUG_TOKEN = debugToken;
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[appcheck] DEBUG TOKEN MODE — reCAPTCHA bypassed. ' +
+        'Production builds must NEVER set VITE_APP_CHECK_DEBUG_TOKEN.',
+    );
   }
 
   initializeAppCheck(getApp(), {


### PR DESCRIPTION
## Summary
- Unblock Firebase Hosting preview channels from App Check enforcement on Firestore
- Preview URLs (`citl-baed2--<channel>-<hash>.web.app`) can't be added to reCAPTCHA Enterprise's allowed-domains list (siblings of `citl-baed2.web.app`, no mid-label wildcard support), so reCAPTCHA refuses to mint tokens → SDK aborts the Firestore request → browser shows `ERR_BLOCKED_BY_CLIENT`
- Implements Firebase's canonical pattern: a build-time env var that, when present, switches App Check to debug-token mode where Firebase's service issues a real App Check token in exchange for a pre-registered debug token, bypassing client-side reCAPTCHA entirely

## Changes
- **`src/infrastructure/appcheck.ts`** — when `import.meta.env.VITE_APP_CHECK_DEBUG_TOKEN` is set, write it to `window.FIREBASE_APPCHECK_DEBUG_TOKEN` immediately before `initializeAppCheck()`. Loud `console.warn` so debug mode is never silent. Module docstring rewritten to explain the preview-channel constraint and the production-build prohibition.
- **`.github/workflows/deploy-preview.yml`** — inject `VITE_APP_CHECK_DEBUG_TOKEN: ${{ secrets.VITE_APP_CHECK_DEBUG_TOKEN }}` into the build env. Inline comment warns against copying to production workflow.
- **`.github/workflows/deploy-production.yml`** — **deliberately untouched**. Production builds never receive the debug token, preserving full reCAPTCHA enforcement on the live site.
- **`.env.example`** — document the variable, when to use it, where to register the token in Firebase Console, and the production prohibition.

## What this does NOT fix
The parallel Firebase Auth gap on preview channels: `signInWithPopup` raises `auth/unauthorized-domain` because preview URLs aren't in the Firebase Auth authorized-domains list and that list doesn't accept wildcards. Out of scope for this PR — recommendation is to skip auth testing on preview channels and validate auth via the production smoke pass after merge. Documented in the commit body.

## Pre-merge setup (manual, one-time)
1. **Firebase Console** → App Check → Apps → `citl` web app → Manage debug tokens → Add debug token → save the generated value
2. **GitHub repo** → Settings → Secrets and variables → Actions → New repository secret → name `VITE_APP_CHECK_DEBUG_TOKEN`, value = the token from step 1
3. **Trigger** a preview deploy on this PR (push any commit, or close/reopen) to verify the build picks up the secret

## Testing
- [ ] Confirm `npx tsc --noEmit` passes (verified locally: exit 0)
- [ ] Confirm `npx vitest run` passes (verified locally: 189/189)
- [ ] After Firebase Console + GitHub secret are set up, trigger a preview deploy
- [ ] Open the preview URL in a browser and confirm scorecards data loads (no `ERR_BLOCKED_BY_CLIENT`, no App Check errors in console)
- [ ] Confirm the browser console shows the `[appcheck] DEBUG TOKEN MODE` warning on preview (and does NOT show it on production)
- [ ] Verify production (`citl.club`) still loads normally — debug token env var is absent from `deploy-production.yml`, so behavior is unchanged
- [ ] Verify the App Check metrics for Firestore continue to show 100% Verified post-merge (preview-channel debug tokens count as verified via the debug exchange path)

## Context
Discovered during PR 177 (refactor/scorecards-via-service) testing when scorecards data failed to load on the preview channel after App Check enforcement was enabled on Firestore last week. The enforcement work itself was correct; this PR closes the preview-channel access gap that surfaced as a consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)