### PR TITLE
ci: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -23,8 +23,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -35,8 +35,8 @@ jobs:
     name: Firestore Rules Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -51,8 +51,8 @@ jobs:
     name: Cloud Functions Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,8 +15,8 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build & Deploy (Production)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
## Summary

GitHub Actions is removing Node 20 from runners on **2026-09-16** (default-off **2026-06-02**), per the [Node 20 deprecation notice](https://github.blog/changelog/2025-09-17-actions-deprecating-node20-runtime/). The warning surfaced on [PR #177](https://github.com/salmoncow/citl/pull/177)'s preview-deploy run.

| Action | Old | New | Runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | Node 24 |
| `actions/setup-node` | `@v4` | `@v6` | Node 24 |
| `FirebaseExtended/action-hosting-deploy` | `@v0` | `@v0` (unchanged) | Node 20 — tracked in #179 |

### Why `FirebaseExtended/action-hosting-deploy` is unchanged

Node 24 was merged to upstream `main` on **2026-04-30** in [FirebaseExtended/action-hosting-deploy#450](https://github.com/FirebaseExtended/action-hosting-deploy/pull/450), but no release has been tagged yet — `v0.10.0` (and the `@v0` moving tag) both still declare `using: "node20"`. A release has been requested in [FirebaseExtended/action-hosting-deploy#457](https://github.com/FirebaseExtended/action-hosting-deploy/issues/457).

Bump tracked in #179, which must land before **2026-09-16**.

### Scope guardrails

This PR is purely a version pin bump. It does **not** touch:
- The App Check `VITE_APP_CHECK_DEBUG_TOKEN` env-var injection added in [#178](https://github.com/salmoncow/citl/pull/178)
- The production-vs-preview workflow split

## Files touched

- `.github/workflows/ci.yml` (4 × checkout/setup-node bumps across 4 jobs)
- `.github/workflows/deploy-preview.yml` (1 × checkout, 1 × setup-node)
- `.github/workflows/deploy-production.yml` (1 × checkout, 1 × setup-node)

## Test plan

- [x] CI (`typecheck`, `test`, `test-rules`, `test-functions`) passes on this PR
- [x] Preview-deploy workflow runs successfully and produces a working preview URL
- [x] No Node 20 deprecation warning in CI logs for `actions/checkout` or `actions/setup-node`
- [x] FirebaseExtended deprecation warning is still present (expected — tracked in #179)