### PR TITLE
chore(scripts): add emulator seed script for fresh-checkout dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,18 @@ Start with these documents in order:
 ```bash
 nvm use 24                           # Node 24 required (.nvmrc)
 npm install                          # Install deps
-npm run dev                          # Dev server → http://localhost:3000
+npm run dev                          # Dev server → http://localhost:3000 (reuses existing .emulator-data)
+npm run dev:seeded                   # Same, but seeds the emulator first (fresh-checkout flow)
+npm run seed:emulator                # Seed running emulators (also: -- clear | -- status)
 npm run build                        # Production build → dist/
 npm run preview                      # Serve dist/ locally
 npm run deploy                       # build + firebase deploy --only hosting
 npm run deploy:preview               # build + Firebase preview channel (7-day URL)
 ```
+
+> **Fresh checkout?** `.emulator-data/` is git-ignored, so `npm run dev` starts an empty
+> Firestore. Use `npm run dev:seeded` once to populate it. See
+> [CONTRIBUTING.md](CONTRIBUTING.md#seeding-the-emulator) for details.
 
 ### Key Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,56 @@
 
 ```bash
 npm install
-npm run dev       # localhost:3000
+npm run dev       # localhost:3000 (uses existing .emulator-data)
 npm test          # Vitest unit suite
 npm run typecheck # tsc --noEmit (must be 0 errors)
 npm run build     # production build
 ```
+
+## Seeding the emulator
+
+A fresh checkout has no `.emulator-data/` (it's git-ignored), so `npm run dev` will
+start an empty Firestore — every view that reads scorecards, standings, or
+announcements will render blank.
+
+To get a realistic dataset (2024 season in progress + 2025 season complete, four
+teams, three test accounts) running on the local emulator:
+
+```bash
+npm run dev:seeded        # one-shot: boot emulators, seed, start Vite
+```
+
+Or, if you prefer running emulators in their own terminal:
+
+```bash
+npm run emulators         # terminal 1 — keep alive
+npm run seed:emulator     # terminal 2 — populates and exits
+npm run dev               # terminal 3 — Vite against the seeded emulators
+```
+
+The seed script is idempotent — re-running it clears the seeded collections
+(`users`, `audit`, `announcements`, `config`, `seasons`) plus the three
+`seed-*@citl.test` auth users, then rewrites them. Other emulator state (e.g.
+docs you've created by hand while clicking around) is left alone but will get
+swept by `--export-on-exit` if you let the emulator persist on shutdown.
+
+Test sign-in (emulator accepts any password):
+
+| Role  | Email              |
+| ----- | ------------------ |
+| owner | owner@citl.test    |
+| admin | admin@citl.test    |
+| user  | user@citl.test     |
+
+Other subcommands:
+
+```bash
+npm run seed:emulator -- clear    # wipe seeded collections only
+npm run seed:emulator -- status   # print doc counts
+```
+
+The script refuses to run without `FIREBASE_*_EMULATOR_HOST` set — it cannot
+touch production data.
 
 ## Contribution Guidelines
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "deploy:preview": "npm run build && firebase hosting:channel:deploy preview",
     "deploy:rules:dryrun": "firebase deploy --only firestore:rules --dry-run",
     "emulators": "firebase emulators:start --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data",
+    "dev:seeded": "firebase emulators:exec --only auth,firestore,functions --import=.emulator-data --export-on-exit=.emulator-data 'npm run seed:emulator && VITE_USE_EMULATOR=true vite'",
+    "seed:emulator": "FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=citl-baed2 node scripts/seed-emulator.js",
     "set-role": "node scripts/set-role.js",
     "set-role:emulator": "FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=citl-baed2 node scripts/set-role.js",
     "grant-admin": "node scripts/grant-admin.js",

--- a/scripts/fixtures/seed-data.js
+++ b/scripts/fixtures/seed-data.js
@@ -1,0 +1,277 @@
+/**
+ * seed-data.js — Deterministic fixture builders for the emulator seed.
+ *
+ * No randomness, no timestamps from the clock — every run produces identical
+ * documents so tests, screenshots, and bug repros remain reproducible.
+ *
+ * Schema references (keep in sync if these change):
+ *   src/types/season.ts        Season, SeasonStandings, SeasonAwards
+ *   src/types/score.ts         Team, TeamTotals, WeekResult, TeamResult,
+ *                              ShooterScore, SeasonEntry
+ *   src/types/shooter.ts       Shooter, Accolade
+ *   src/types/announcement.ts  Announcement
+ *   src/types/user.ts          UserDoc, Role
+ */
+
+export const ACTIVE_YEAR = 2024;
+export const COMPLETE_YEAR = 2025;
+export const WEEKS_PER_SEASON = 15;
+export const ACTIVE_WEEKS_PUBLISHED = 5; // week 6 carries draft entries
+
+const TEAMS = [
+  { id: 'eagles', name: 'Eagles', captain: 'Greg Litchfield' },
+  { id: 'falcons', name: 'Falcons', captain: 'Mike Hardy' },
+  { id: 'hawks', name: 'Hawks', captain: 'Dave Brennan' },
+  { id: 'kestrels', name: 'Kestrels', captain: 'Tom Schroeder' },
+];
+
+const SHOOTERS_BY_TEAM = {
+  eagles: ['Greg Litchfield', 'Aaron Klein', 'Pete Sandoval', 'Rick Mancuso'],
+  falcons: ['Mike Hardy', 'Carl Webb', 'Steve Aldrich', 'Doug Reilly'],
+  hawks: ['Dave Brennan', 'Frank Holt', 'Larry Pence', 'Joe Vance'],
+  kestrels: ['Tom Schroeder', 'Bill Frey', 'Hank Olson', 'Norm Brady'],
+};
+
+// ── Deterministic round-score generator ────────────────────────────────────
+
+function roundScore(seed, base) {
+  const h = (seed * 9301 + 49297) % 233280;
+  const v = base + ((h % 9) - 4);
+  return Math.max(0, Math.min(25, v));
+}
+
+function makeRounds(teamIdx, shooterIdx, weekIdx) {
+  const base = 18 + ((teamIdx + shooterIdx) % 5); // 18–22 base avg per round
+  const seed = teamIdx * 100 + shooterIdx * 17 + weekIdx * 3 + 1;
+  const score1 = roundScore(seed, base);
+  const score2 = roundScore(seed + 11, base);
+  return { score1, score2, total: score1 + score2 };
+}
+
+// ── Shooter / Team builders ────────────────────────────────────────────────
+
+function buildShooter(teamIdx, shooterIdx, name, weeksPlayed) {
+  const scores = Array.from({ length: WEEKS_PER_SEASON }, (_, w) => {
+    if (w >= weeksPlayed) return null;
+    return makeRounds(teamIdx, shooterIdx, w).total;
+  });
+  const played = scores.filter((s) => s !== null);
+  const startingAvg = 38 + ((teamIdx + shooterIdx) % 8);
+  const finalAvg = played.length
+    ? Math.round((played.reduce((a, b) => a + b, 0) / played.length) * 100) / 100
+    : null;
+  return {
+    id: `${name.toLowerCase().replace(/\s+/g, '-')}-t${teamIdx}-s${shooterIdx}`,
+    name,
+    rookie: shooterIdx === 3, // every team's 4th shooter is a rookie
+    startingAvg,
+    finalAvg,
+    weeksShot: played.length || null,
+    scores,
+  };
+}
+
+export function buildTeam(teamIdx, weeksPlayed) {
+  const team = TEAMS[teamIdx];
+  const shooters = SHOOTERS_BY_TEAM[team.id].map((name, shooterIdx) =>
+    buildShooter(teamIdx, shooterIdx, name, weeksPlayed),
+  );
+  const targets = Array.from({ length: WEEKS_PER_SEASON }, (_, w) => {
+    if (w >= weeksPlayed) return null;
+    return shooters.reduce((sum, s) => sum + (s.scores[w] ?? 0), 0);
+  });
+  return {
+    id: team.id,
+    name: team.name,
+    captain: team.captain,
+    shooters,
+    totals: {
+      targets,
+      rankPoints: Array.from({ length: WEEKS_PER_SEASON }, () => null),
+      bonusPoints: Array.from({ length: WEEKS_PER_SEASON }, () => null),
+    },
+  };
+}
+
+// ── Weekly results ──────────────────────────────────────────────────────────
+
+function rankWeek(weekIdx, teams) {
+  const rows = teams.map((t) => ({
+    teamId: t.id,
+    teamName: t.name,
+    targets: t.totals.targets[weekIdx] ?? 0,
+  }));
+  rows.sort((a, b) => b.targets - a.targets);
+  return rows.map((r, i) => ({
+    ...r,
+    rankPoints: teams.length - i,
+    bonusPoints: 1,
+  }));
+}
+
+export function buildWeekResult(weekIdx, teams) {
+  const ranked = rankWeek(weekIdx, teams);
+  const teamResults = teams.map((team) => {
+    const r = ranked.find((x) => x.teamId === team.id);
+    const teamIdx = TEAMS.findIndex((t) => t.id === team.id);
+    const shooterScores = team.shooters.map((s, shooterIdx) => {
+      const rounds = makeRounds(teamIdx, shooterIdx, weekIdx);
+      return { name: s.name, ...rounds };
+    });
+    return {
+      teamId: team.id,
+      teamName: team.name,
+      targets: r.targets,
+      rankPoints: r.rankPoints,
+      bonusPoints: r.bonusPoints,
+      shooterScores,
+    };
+  });
+  // Backfill rank/bonus on the parent team totals so SeasonStandings can sum them.
+  for (const team of teams) {
+    const r = ranked.find((x) => x.teamId === team.id);
+    team.totals.rankPoints[weekIdx] = r.rankPoints;
+    team.totals.bonusPoints[weekIdx] = r.bonusPoints;
+  }
+  const accolades = [];
+  for (const tr of teamResults) {
+    for (const ss of tr.shooterScores) {
+      if (ss.score1 === 25 || ss.score2 === 25) {
+        accolades.push({ shooterName: ss.name, teamName: tr.teamName, streak: 25 });
+      }
+    }
+  }
+  // Deterministic publish stamp: Tuesday evenings starting early March.
+  const publishedAt = new Date(Date.UTC(2024, 2, 5 + weekIdx * 7, 2, 30)).toISOString();
+  return {
+    weekNumber: weekIdx + 1,
+    publishedAt,
+    teamResults,
+    accolades,
+  };
+}
+
+export function buildEntry(year, weekIdx, team) {
+  const teamIdx = TEAMS.findIndex((t) => t.id === team.id);
+  const shooters = team.shooters.map((s, shooterIdx) => {
+    const rounds = makeRounds(teamIdx, shooterIdx, weekIdx);
+    return { name: s.name, ...rounds };
+  });
+  // Saved-at: noon UTC on the Tuesday of that week.
+  const savedAt = new Date(Date.UTC(year, 2, 5 + weekIdx * 7, 17, 0)).toISOString();
+  return {
+    year,
+    weekNumber: weekIdx + 1,
+    teamId: team.id,
+    teamName: team.name,
+    savedAt,
+    shooters,
+  };
+}
+
+// ── Season aggregates ──────────────────────────────────────────────────────
+
+function buildStandings(teams, throughWeekIdx) {
+  const rows = teams.map((team) => {
+    let totalRankPoints = 0;
+    let totalBonusPoints = 0;
+    let totalTargets = 0;
+    for (let w = 0; w <= throughWeekIdx; w++) {
+      totalRankPoints += team.totals.rankPoints[w] ?? 0;
+      totalBonusPoints += team.totals.bonusPoints[w] ?? 0;
+      totalTargets += team.totals.targets[w] ?? 0;
+    }
+    return {
+      rank: 0,
+      teamId: team.id,
+      teamName: team.name,
+      totalRankPoints,
+      totalBonusPoints,
+      totalTargets,
+    };
+  });
+  rows.sort((a, b) => {
+    if (b.totalRankPoints !== a.totalRankPoints) return b.totalRankPoints - a.totalRankPoints;
+    if (b.totalBonusPoints !== a.totalBonusPoints) return b.totalBonusPoints - a.totalBonusPoints;
+    return b.totalTargets - a.totalTargets;
+  });
+  rows.forEach((r, i) => {
+    r.rank = i + 1;
+  });
+  return rows;
+}
+
+export function buildAwards(teams) {
+  let top = { shooterName: '', teamName: '', avg: -1 };
+  let rookie = { shooterName: '', teamName: '', avg: -1 };
+  for (const team of teams) {
+    for (const s of team.shooters) {
+      if (s.finalAvg !== null && s.finalAvg > top.avg) {
+        top = { shooterName: s.name, teamName: team.name, avg: s.finalAvg };
+      }
+      if (s.rookie && s.finalAvg !== null && s.finalAvg > rookie.avg) {
+        rookie = { shooterName: s.name, teamName: team.name, avg: s.finalAvg };
+      }
+    }
+  }
+  return {
+    highestAvg: top,
+    rookieOfYear: rookie.avg >= 0 ? rookie : null,
+    mostImproved: null,
+  };
+}
+
+export function buildSeason(year, status, currentWeek, teams, awards) {
+  const throughWeekIdx =
+    status === 'complete' ? WEEKS_PER_SEASON - 1 : currentWeek - 2;
+  const standings =
+    throughWeekIdx >= 0
+      ? buildStandings(teams, throughWeekIdx)
+      : teams.map((t, i) => ({
+          rank: i + 1,
+          teamId: t.id,
+          teamName: t.name,
+          totalRankPoints: 0,
+          totalBonusPoints: 0,
+          totalTargets: 0,
+        }));
+  return {
+    id: String(year),
+    year,
+    status,
+    currentWeek,
+    standings,
+    awards,
+  };
+}
+
+// ── Users, announcements, config ────────────────────────────────────────────
+
+export const TEST_USERS = [
+  { uid: 'seed-owner', email: 'owner@citl.test', displayName: 'Seed Owner', role: 'owner' },
+  { uid: 'seed-admin', email: 'admin@citl.test', displayName: 'Seed Admin', role: 'admin' },
+  { uid: 'seed-user', email: 'user@citl.test', displayName: 'Seed User', role: 'user' },
+];
+
+export const ANNOUNCEMENTS = [
+  {
+    year: ACTIVE_YEAR,
+    title: 'Season opener postponed one week',
+    body: 'Forecast freezing rain — Week 1 moves from March 5 to March 12. Same lineup; see you Tuesday at 6pm.',
+    postedAtMs: Date.UTC(2024, 1, 28, 14, 0),
+  },
+  {
+    year: ACTIVE_YEAR,
+    title: 'Banquet date confirmed',
+    body: 'End-of-season banquet is **September 14** at Roma\'s. RSVPs by Sept 7.',
+    postedAtMs: Date.UTC(2024, 6, 15, 18, 0),
+  },
+  {
+    year: COMPLETE_YEAR,
+    title: 'Congratulations to the 2025 champions',
+    body: 'A great season — full standings and awards are now posted under Past Seasons.',
+    postedAtMs: Date.UTC(2025, 7, 20, 12, 0),
+  },
+];
+
+export const BANNER_MESSAGE = 'Local dev seed loaded — see CONTRIBUTING.md#seeding-the-emulator';

--- a/scripts/seed-emulator.js
+++ b/scripts/seed-emulator.js
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * seed-emulator.js — Populate the local Firebase emulator with realistic
+ * scorecard / standings / announcement data for SPA development.
+ *
+ * Refuses to run unless FIREBASE_AUTH_EMULATOR_HOST and FIRESTORE_EMULATOR_HOST
+ * are set — this script must never touch production. Use the npm wrappers
+ * (`npm run seed:emulator`) which set those env vars for you.
+ *
+ * Auth: gcloud Application Default Credentials. No service-account key.
+ *   One-time setup: gcloud auth application-default login
+ *
+ * Usage:
+ *   node scripts/seed-emulator.js seed       Clear + write fresh seed (default)
+ *   node scripts/seed-emulator.js clear      Wipe seeded collections only
+ *   node scripts/seed-emulator.js status     Print doc counts per collection
+ */
+
+import { initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, Timestamp, FieldValue } from 'firebase-admin/firestore';
+
+import {
+  ACTIVE_YEAR,
+  COMPLETE_YEAR,
+  WEEKS_PER_SEASON,
+  ACTIVE_WEEKS_PUBLISHED,
+  TEST_USERS,
+  ANNOUNCEMENTS,
+  BANNER_MESSAGE,
+  buildTeam,
+  buildWeekResult,
+  buildEntry,
+  buildSeason,
+  buildAwards,
+} from './fixtures/seed-data.js';
+
+const PROJECT_ID = 'citl-baed2';
+
+const AUTH_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+const FS_HOST = process.env.FIRESTORE_EMULATOR_HOST;
+if (!AUTH_HOST || !FS_HOST) {
+  console.error('Refusing to run: FIREBASE_AUTH_EMULATOR_HOST and FIRESTORE_EMULATOR_HOST must be set.');
+  console.error('Use `npm run seed:emulator` (the npm wrapper sets these for you).');
+  process.exit(1);
+}
+
+initializeApp({ projectId: PROJECT_ID });
+const auth = getAuth();
+const db = getFirestore();
+
+const SEEDED_COLLECTIONS = ['users', 'audit', 'announcements', 'config', 'seasons'];
+
+function usage(message) {
+  if (message) console.error(`Error: ${message}\n`);
+  console.error(`Usage:
+  node scripts/seed-emulator.js seed     Clear + write fresh seed (default)
+  node scripts/seed-emulator.js clear    Wipe seeded collections only
+  node scripts/seed-emulator.js status   Print doc counts per collection
+
+Env (set automatically by \`npm run seed:emulator\`):
+  FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+  FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
+  GCLOUD_PROJECT=citl-baed2
+
+One-time setup: gcloud auth application-default login`);
+  process.exit(1);
+}
+
+function header(title) {
+  console.log(`─── seed-emulator: ${title} ${'─'.repeat(Math.max(0, 32 - title.length))}`);
+  console.log(`project   : ${PROJECT_ID} (emulator)`);
+  console.log(`auth host : ${AUTH_HOST}`);
+  console.log(`fs host   : ${FS_HOST}`);
+  console.log('───────────────────────────────────────────────────');
+}
+
+// ── Clear ───────────────────────────────────────────────────────────────────
+
+async function clearSeededFirestore() {
+  for (const col of SEEDED_COLLECTIONS) {
+    await db.recursiveDelete(db.collection(col));
+  }
+}
+
+async function clearSeededAuthUsers() {
+  for (const u of TEST_USERS) {
+    try {
+      await auth.deleteUser(u.uid);
+    } catch (e) {
+      if (e.code !== 'auth/user-not-found') throw e;
+    }
+  }
+}
+
+async function clearCommand({ quiet = false } = {}) {
+  if (!quiet) header('clear');
+  await clearSeededFirestore();
+  await clearSeededAuthUsers();
+  if (!quiet) {
+    console.log(`✓ cleared ${SEEDED_COLLECTIONS.map((c) => `${c}/`).join(', ')}`);
+    console.log(`✓ cleared seeded Auth users (${TEST_USERS.length})`);
+  }
+}
+
+// ── Seed: users ─────────────────────────────────────────────────────────────
+
+async function seedUser(u) {
+  // Pre-write the mirror so onUserCreate's `if (existing.exists) return;`
+  // guard short-circuits — eliminates the race between trigger and seed.
+  await db.doc(`users/${u.uid}`).set({
+    uid: u.uid,
+    email: u.email,
+    displayName: u.displayName,
+    photoURL: null,
+    role: u.role,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    lastSignInAt: null,
+    roleChangedAt: FieldValue.serverTimestamp(),
+  });
+
+  try {
+    await auth.getUser(u.uid);
+    await auth.updateUser(u.uid, { email: u.email, displayName: u.displayName });
+  } catch (e) {
+    if (e.code !== 'auth/user-not-found') throw e;
+    await auth.createUser({
+      uid: u.uid,
+      email: u.email,
+      emailVerified: true,
+      displayName: u.displayName,
+      password: 'devpass-not-used-in-emulator',
+    });
+  }
+
+  // Trigger no-ops its own setCustomUserClaims when the mirror exists, so
+  // we own claim assignment here.
+  await auth.setCustomUserClaims(u.uid, { role: u.role });
+}
+
+// ── Seed: announcements + banner ───────────────────────────────────────────
+
+async function seedAnnouncements() {
+  for (const a of ANNOUNCEMENTS) {
+    await db.collection('announcements').add({
+      year: a.year,
+      title: a.title,
+      body: a.body,
+      postedAt: Timestamp.fromMillis(a.postedAtMs),
+      lastEditedAt: null,
+    });
+  }
+}
+
+async function seedConfig() {
+  await db.doc('config/banner').set({ message: BANNER_MESSAGE });
+}
+
+// ── Seed: a single season ──────────────────────────────────────────────────
+
+async function seedSeason(year, { status, currentWeek, publishedWeekCount, draftWeek }) {
+  const teams = [0, 1, 2, 3].map((idx) => buildTeam(idx, publishedWeekCount));
+
+  const weeks = [];
+  for (let w = 0; w < publishedWeekCount; w++) {
+    weeks.push(buildWeekResult(w, teams));
+  }
+
+  const awards = status === 'complete' ? buildAwards(teams) : null;
+  const season = buildSeason(year, status, currentWeek, teams, awards);
+
+  const seasonRef = db.doc(`seasons/${year}`);
+  await seasonRef.set(season);
+
+  for (const team of teams) {
+    await seasonRef.collection('teams').doc(team.id).set(team);
+  }
+  for (const week of weeks) {
+    await seasonRef.collection('weeks').doc(String(week.weekNumber)).set(week);
+  }
+  if (draftWeek != null) {
+    for (const team of teams) {
+      const entry = buildEntry(year, draftWeek - 1, team);
+      await seasonRef.collection('entries').doc(`${draftWeek}_${team.id}`).set(entry);
+    }
+  }
+}
+
+// ── Seed: top-level orchestrator ───────────────────────────────────────────
+
+async function seedCommand() {
+  header('seed');
+  await clearCommand({ quiet: true });
+  console.log('✓ wiped seeded collections + test auth users');
+
+  for (const u of TEST_USERS) await seedUser(u);
+  console.log(`✓ seeded ${TEST_USERS.length} test users (owner, admin, user)`);
+
+  await seedConfig();
+  console.log('✓ seeded config/banner');
+
+  await seedAnnouncements();
+  console.log(`✓ seeded ${ANNOUNCEMENTS.length} announcements`);
+
+  await seedSeason(ACTIVE_YEAR, {
+    status: 'active',
+    currentWeek: ACTIVE_WEEKS_PUBLISHED + 1,
+    publishedWeekCount: ACTIVE_WEEKS_PUBLISHED,
+    draftWeek: ACTIVE_WEEKS_PUBLISHED + 1,
+  });
+  console.log(`✓ seeded ${ACTIVE_YEAR} (active, ${ACTIVE_WEEKS_PUBLISHED} weeks + 1 draft)`);
+
+  await seedSeason(COMPLETE_YEAR, {
+    status: 'complete',
+    currentWeek: WEEKS_PER_SEASON,
+    publishedWeekCount: WEEKS_PER_SEASON,
+    draftWeek: null,
+  });
+  console.log(`✓ seeded ${COMPLETE_YEAR} (complete, ${WEEKS_PER_SEASON} weeks + awards)`);
+
+  console.log('───────────────────────────────────────────────────');
+  console.log('Test sign-in (any password works on the auth emulator):');
+  for (const u of TEST_USERS) {
+    console.log(`  ${u.role.padEnd(5)} → ${u.email}`);
+  }
+}
+
+// ── Status ──────────────────────────────────────────────────────────────────
+
+async function statusCommand() {
+  header('status');
+  for (const col of ['users', 'audit', 'announcements', 'config']) {
+    const snap = await db.collection(col).count().get();
+    console.log(`${col.padEnd(15)} ${snap.data().count}`);
+  }
+  const seasonsSnap = await db.collection('seasons').get();
+  console.log(`seasons/        ${seasonsSnap.size}`);
+  for (const seasonDoc of seasonsSnap.docs) {
+    const [teamsSnap, weeksSnap, entriesSnap] = await Promise.all([
+      seasonDoc.ref.collection('teams').count().get(),
+      seasonDoc.ref.collection('weeks').count().get(),
+      seasonDoc.ref.collection('entries').count().get(),
+    ]);
+    console.log(
+      `  ${seasonDoc.id}: ${teamsSnap.data().count} teams, ${weeksSnap.data().count} weeks, ${entriesSnap.data().count} entries`,
+    );
+  }
+  const authUsers = await auth.listUsers();
+  console.log(`auth users      ${authUsers.users.length}`);
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+async function main() {
+  const [, , subcommand = 'seed'] = process.argv;
+  switch (subcommand) {
+    case 'seed':
+      return seedCommand();
+    case 'clear':
+      return clearCommand();
+    case 'status':
+      return statusCommand();
+    default:
+      usage(`unknown subcommand "${subcommand}"`);
+  }
+}
+
+try {
+  await main();
+} catch (e) {
+  console.error(`\nError: ${e.message ?? e}`);
+  if (e.stack) console.error(e.stack);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- New `scripts/seed-emulator.js` + `scripts/fixtures/seed-data.js` populate the local emulator with realistic data so a fresh worktree can `npm run dev:seeded` and immediately see scorecards, standings, announcements, and the admin panel.
- Covers every collection in `firestore.rules`: 3 test users (owner/admin/user with matching custom claims), `config/banner`, 3 announcements, 2024 active with weeks 1–5 published + week 6 draft entries, 2025 complete with all 15 weeks and awards.
- Mirrors the existing `set-role.js` pattern (ADC auth, hardcoded `PROJECT_ID`, env-var emulator hosts, ✓ logging) and refuses to run without `FIREBASE_*_EMULATOR_HOST` set — cannot touch production.

## Notes

- `npm run dev` is unchanged; `dev:seeded` and `seed:emulator` are additive.
- Deterministic fixtures (no clock, no RNG) — identical output every run for reproducible bug repros and screenshots.
- `seed:emulator` also accepts `-- clear` and `-- status` subcommands.
- Pre-writes the `users/{uid}` mirror before `auth.createUser` so the `onUserCreate` trigger's `if (existing.exists) return;` short-circuits — eliminates the race that would otherwise let the trigger clobber the seeded role and claim. Verified both mirror and custom claim land correctly for all three roles.
- Constitutional check hook is a no-op on `.js` (only checks `.ts`); both new files stay well under the 500-line target.

## Test plan

- [x] `npm run seed:emulator` — produces expected ✓ output (3 users, 3 announcements, 1 config, 2 seasons)
- [x] `npm run seed:emulator -- status` — shows correct doc counts
- [x] `npm run typecheck` — clean
- [x] `npm test` — 200/200 pass
- [x] Verified document shapes via emulator REST against `src/types/season.ts`, `src/types/score.ts`
- [x] Verified mirror role + custom claim match for owner / admin / user after the race fix
- [ ] Reviewer: `npm run dev:seeded` from a worktree with empty `.emulator-data/` and click through home / scorecards / past seasons / admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)