### PR TITLE
fix(scoring): break standings point ties by total targets

### DIFF
--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -8,6 +8,7 @@
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
+import { compareStandings } from '@/services/scoring-engine';
 import type { Team, WeekResult } from '@/types/score';
 import type { Season } from '@/types/season';
 import type { Accolade } from '@/types/shooter';
@@ -197,7 +198,12 @@ class HomeStandings extends HTMLElement {
         };
       });
 
-      rows.sort((a, b) => (b.total as number) - (a.total as number));
+      rows.sort((a, b) =>
+        compareStandings(
+          { points: a.total as number, targets: a.totalTargets as number },
+          { points: b.total as number, targets: b.totalTargets as number },
+        ),
+      );
       rows = rows.map((r, i) => ({ ...r, place: i + 1 }));
       subtitle = `Week ${weekNum} results \u00b7 Total reflects season-to-date`;
       accolades = weekResult.accolades ?? [];

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { success, failure, type Result } from '@/repositories/score-repository';
-import { computeSeasonTotals, computeShooterAverage, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, mean, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst, computeAccolades } from '@/services/scoring-engine';
+import { computeSeasonTotals, computeShooterAverage, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, mean, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst, computeAccolades, compareStandings } from '@/services/scoring-engine';
 import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Season, SeasonStandings } from '@/types/season';
 import type { Team, WeekResult, SeasonEntry, ShooterScore } from '@/types/score';
@@ -1031,8 +1031,11 @@ function _recomputeStandingsFromWeeks(weekResults: WeekResult[]): SeasonStanding
       });
     }
   }
-  const rows = [...acc.values()].sort(
-    (a, b) => (b.rankPoints + b.bonusPoints) - (a.rankPoints + a.bonusPoints),
+  const rows = [...acc.values()].sort((a, b) =>
+    compareStandings(
+      { points: a.rankPoints + a.bonusPoints, targets: a.targets },
+      { points: b.rankPoints + b.bonusPoints, targets: b.targets },
+    ),
   );
   return rows.map((row, i) => ({
     rank: i + 1,
@@ -1065,7 +1068,12 @@ function _computeStandings(computed: SeasonData, throughWeek: number): SeasonSta
     };
   });
 
-  rows.sort((a, b) => (b.totalRankPoints + b.totalBonusPoints) - (a.totalRankPoints + a.totalBonusPoints));
+  rows.sort((a, b) =>
+    compareStandings(
+      { points: a.totalRankPoints + a.totalBonusPoints, targets: a.totalTargets },
+      { points: b.totalRankPoints + b.totalBonusPoints, targets: b.totalTargets },
+    ),
+  );
 
   return rows.map((row, i) => ({ rank: i + 1, ...row }));
 }

--- a/src/services/scoring-engine.test.ts
+++ b/src/services/scoring-engine.test.ts
@@ -20,6 +20,7 @@ import {
   computeTargetBonus,
   computeRookieBonus,
   computeRankPoints,
+  compareStandings,
   computeShooterStartingAvg,
   isShooterRookie,
   computeMostImprovedScore,
@@ -459,6 +460,41 @@ describe('computeRankPoints', () => {
 
   it('treats forfeit (0 targets) as last place', () => {
     expect(computeRankPoints([200, 0])).toEqual([30, 28]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block 7b: compareStandings
+// ---------------------------------------------------------------------------
+
+describe('compareStandings', () => {
+  it('orders by total points descending when points differ', () => {
+    // Higher points wins regardless of targets.
+    expect(
+      compareStandings({ points: 150, targets: 100 }, { points: 174, targets: 9999 }),
+    ).toBeGreaterThan(0);
+    expect(
+      compareStandings({ points: 174, targets: 100 }, { points: 150, targets: 9999 }),
+    ).toBeLessThan(0);
+  });
+
+  it('breaks a points tie in favor of more targets', () => {
+    // The reported week-6 case: both 174 points, Powder Burners broke more targets.
+    const fullChoke = { points: 174, targets: 1143 };
+    const powderBurners = { points: 174, targets: 1162 };
+    expect(compareStandings(powderBurners, fullChoke)).toBeLessThan(0); // PB sorts first
+    expect([fullChoke, powderBurners].sort(compareStandings)).toEqual([
+      powderBurners,
+      fullChoke,
+    ]);
+  });
+
+  it('returns 0 (stable order) when points and targets both tie', () => {
+    const a = { points: 174, targets: 1150 };
+    const b = { points: 174, targets: 1150 };
+    expect(compareStandings(a, b)).toBe(0);
+    // Array.sort is stable, so the original order is preserved.
+    expect([a, b].sort(compareStandings)).toEqual([a, b]);
   });
 });
 

--- a/src/services/scoring-engine.ts
+++ b/src/services/scoring-engine.ts
@@ -264,6 +264,24 @@ export function computeRankPoints(allTeamTargets: (number | null)[]): (number | 
 }
 
 // ---------------------------------------------------------------------------
+// Standings ordering
+// ---------------------------------------------------------------------------
+
+/**
+ * Standings sort comparator: total points (rankPoints + bonusPoints) descending,
+ * then total targets descending as the tie-breaker — a points tie is broken in
+ * favor of the team that broke more targets. Equal on both points and targets
+ * returns 0; Array.prototype.sort is stable, so the existing order is preserved.
+ */
+export function compareStandings(
+  a: { points: number; targets: number },
+  b: { points: number; targets: number },
+): number {
+  if (b.points !== a.points) return b.points - a.points;
+  return b.targets - a.targets;
+}
+
+// ---------------------------------------------------------------------------
 // Full season pass
 // ---------------------------------------------------------------------------
 

--- a/src/views/rules.ts
+++ b/src/views/rules.ts
@@ -76,6 +76,8 @@ export function rulesView(): string {
       considered Rookies</li>
       <li>Each week the highest scoring team is awarded 30 points; next highest gets 28, and so
       on. Points will be split for ties</li>
+      <li>In the season standings, a tie on total points is broken in favor of the team that has
+      broken more total targets</li>
       <li>Any team that scores higher than its going-in average receives 5 bonus points</li>
       <li>A team will receive 1 bonus point for each qualifying rookie shooting that week up to
       a maximum of 2 rookie bonus points</li>


### PR DESCRIPTION
## What

Adds a total-targets tie-breaker to season-standings ordering. A points tie is now broken in favor of the team that broke more total targets; if points **and** targets are equal, existing order is preserved (stable sort).

## Why

A participant who independently tracks scores reported that the 2026 cumulative standings ranked **Full Choke Artists above Powder Burners** while both were tied at **174 points**.

Verified read-only against production — the tie is the cumulative standing through **week 6** (the report said "week 5"; the weekly table shows season-to-date totals):

| Through Wk 6 | Total Points | Total Targets |
|---|---|---|
| Full Choke Artists | 174 | 1,143 |
| Powder Burners | 174 | **1,162** |

Powder Burners broke more targets, so it should rank higher. This is **not a data-entry issue** — per-week targets are distinct and correct. Root cause: all three standings comparators sorted on `rankPoints + bonusPoints` only and never used the already-stored `totalTargets`.

## Changes

- **`scoring-engine.ts`** — new shared pure comparator `compareStandings({points, targets})` (points desc, then targets desc; returns 0 on a full tie).
- **`score-service.ts`** — `_recomputeStandingsFromWeeks` and `_computeStandings` now use it.
- **`home-standings.ts`** — live weekly-view sort now uses it.
- **`rules.ts`** — documents the tie-breaker in Section 5 (Scoring & Yardage).
- **`scoring-engine.test.ts`** — unit tests: points-difference, the 174/174 → more-targets-wins case, and full-tie → stable order.

## Verification

- `npm run typecheck` clean
- `npm run build` succeeds
- `npm test` — 203 tests pass (107 in scoring-engine)

## Reviewer notes / follow-up

- The **live weekly view** self-corrects on deploy (it sorts on the fly).
- The **season tab** reads the precomputed `standings` array on `seasons/2026`. After deploy, an admin should **re-publish week 8** so `publishWeek()` re-derives standings from the source-of-truth entries with the fixed sort. This is a recompute of a derived projection, **not** an edit of entered scores. (Through week 8 the two teams are no longer tied — 231 vs 220 — so the season-tab order is already correct; the re-publish just bakes in the fix.)
- No historical season (2019–2025) is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)