### PR TITLE
ci: add build job and gate production deploy on CI success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,20 @@ jobs:
       - run: npm ci
       - run: npm ci --prefix functions
       - run: npm run test:functions
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm ci --prefix functions
+      # Exercises the production rollup/terser path (which vitest's dev
+      # transform never runs) and the Functions tsc build. No VITE_
+      # secrets needed — the build succeeds with the env vars undefined.
+      - run: npm run build
+      - run: npm --prefix functions run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,16 +1,35 @@
 name: Deploy to Firebase Hosting (Production)
 
+# Deploy is gated on CI: it runs only after the CI workflow completes
+# successfully on main (or via manual dispatch). This prevents a
+# test- or build-failing commit — including a dependabot major that
+# breaks the production build — from shipping to production.
 on:
-  push:
+  workflow_run:
+    workflows: ['CI']
     branches: [main]
+    types: [completed]
   workflow_dispatch:
+
+# Never run two production deploys at once; cancel an in-flight deploy
+# if a newer commit's CI passes first.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     name: Build & Deploy (Production)
     runs-on: ubuntu-latest
+    # Manual dispatch always deploys; the CI-triggered path deploys only
+    # on success.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      # Deploy the exact commit that passed CI. On manual dispatch this
+      # is empty and checkout falls back to the default branch HEAD.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
## Summary
- Second PR from the July 2026 deep review (finding F-03)
- Closes the pre-merge build gap and stops the production deploy from running independently of CI

## The problem
- `ci.yml` had no build job: the production vite build (rollup/terser) and the Functions `tsc` build never ran before merge. A dependabot major that breaks the build (e.g. the vite 7→8 bump that already merged unverified) would compile for the first time *during* the deploy job, blocking hosting, rules, and functions from shipping.
- `deploy-production.yml` triggered on `push: main` with no dependency on CI, so a test-failing commit on main still deployed to production.

## Changes
- **`ci.yml`**: new `build` job runs `npm run build` + `npm --prefix functions run build`. Verified locally that the vite build succeeds with no `VITE_` secrets present.
- **`deploy-production.yml`**: switched trigger from `push` to `workflow_run` on CI completion, gated on `workflow_run.conclusion == 'success'`; `workflow_dispatch` still deploys unconditionally. Checks out the exact `head_sha` that passed CI. Added a `deploy-production` concurrency group.

## Follow-up (not in this PR — needs a repo-admin decision)
Branch protection on `main` currently requires **zero** status checks (ruleset `13744523`), so CI is not required to pass before a PR merges. Gating the deploy on CI closes the production-safety hole, but to also keep `main` itself green you'd add the four CI jobs + `build` as required checks. I can provide the exact `gh api` command if you want that — left out here because it's a GitHub settings change, not a code change.

## Testing
- [x] Both workflow files parse as valid YAML
- [x] `npm run build` succeeds locally without `VITE_` secrets
- [x] `npm --prefix functions run build` (tsc) succeeds
- [ ] Post-merge: confirm this merge's CI run triggers exactly one production deploy via `workflow_run`, and that it deploys the merged commit

## Note on the merge sequence
Because `workflow_run` uses the default-branch copy of the workflow, the new gated behavior takes effect starting with *this* PR's merge — the merge's own CI run will be the first to trigger the gated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)