### PR TITLE
chore(hooks): single-source the forbidden-pattern ruleset; make the hook bind (WS-2)

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -25,22 +25,33 @@ If on `main` with no branch, use `git diff HEAD~1` for the latest commit.
 
 ### Step 2: Audit against constitutional checks
 
-Check every changed file against this checklist:
+**Part A — run the machine-detectable rules.** Do not re-derive regexes here; run the
+single-source ruleset (the same one the commit-time hook uses) on each changed `.ts`/`.html`
+file:
 
-| # | Check | Constitution Ref | How to detect |
-|---|-------|-----------------|---------------|
-| 1 | No `var` declarations | §III.5, §IV.2 | grep `\bvar\b` in changed lines |
-| 2 | No inline event handlers | §III.5, §IV.2 | grep `onclick=\|onload=\|onerror=` |
-| 3 | No unfiltered Firestore reads | §IV.2 | `getDocs(collection(` without `where`/`limit` |
-| 4 | No leaked `onSnapshot` | §IV.2 | `onSnapshot(` without stored unsubscribe |
-| 5 | No hardcoded Firebase config | §IV.2 | Firebase API keys or project IDs in source |
-| 6 | No unsanitized innerHTML | §III.5, §IV.2 | `.innerHTML =` with non-static content |
-| 7 | No plain loading text | §III.3 | `Loading…` or `Loading...` in HTML strings |
-| 8 | File size within limits | §II.3 | >750 lines = violation; >500 = warning |
-| 9 | No circular imports | §II.3 | Check import chains in changed files |
-| 10 | No components importing firebase | §II.3 | `src/components/` importing from `firebase/` |
-| 11 | Conventional commit messages | §III.5 | All commits match `type(scope): description` |
-| 12 | Types in src/types/ | §III.5 | No `@typedef` JSDoc; interfaces in type files |
+```bash
+for f in $(git diff --name-only main...HEAD); do
+  case "$f" in *.ts|*.html)
+    printf '{"tool_input":{"file_path":"%s"}}' "$f" | bash scripts/check-constitution.sh ;;
+  esac
+done
+```
+
+Exit 2 = a `forbid` violation; stdout notes = warnings. Rules live in
+[`scripts/forbidden-patterns.json`](../../scripts/forbidden-patterns.json).
+
+**Part B — the review-only checks** (the ruleset marks these `enforcedBy: review`; a grep
+can't judge them, so this is your job):
+
+| # | Check | Ref | How to judge |
+|---|-------|-----|--------------|
+| 1 | Leaked `onSnapshot` | §IV.2 | every `onSnapshot(` stores its unsubscribe and calls it on teardown |
+| 2 | No circular imports | §II.3 | follow import chains in changed files |
+| 3 | Components don't import the firebase SDK for runtime use | §II.3 | `src/components/` — type-only imports OK, runtime SDK use not |
+| 4 | Client-side filtering | §IV.2 | Firestore data filtered via `where()`, not in-memory after a broad read |
+| 5 | Dependency direction | §II.3 | `components → modules → services → repositories`, never reversed |
+| 6 | Conventional commit messages | §III.5 | all commits match `type(scope): description` |
+| 7 | Types in `src/types/` | §III.5 | no `@typedef` JSDoc; interfaces in type files |
 
 ### Step 3: Review code quality
 Beyond the checklist, look for:

--- a/.claude/agents/speckit.md
+++ b/.claude/agents/speckit.md
@@ -85,11 +85,12 @@ Summarize the spec for the user. Highlight any decisions that need their input.
 
 These are non-negotiable for every feature:
 
-- **Forbidden patterns**: Never suggest anything listed in constitution §IV.2
-- **Firestore queries**: All reads must include `where()` + `limit()` — no full collection scans
-- **Loading states**: New async Web Components must use `.skeleton` shimmer classes (§III.3)
-- **File size**: Target <500 lines per file; hard limit 750 lines
+- **Forbidden patterns**: Never design anything that trips the ruleset in constitution §IV.2 /
+  [`scripts/forbidden-patterns.json`](../../scripts/forbidden-patterns.json) — that file (not a
+  copy here) is the source of truth for `var`, inline handlers, unfiltered `getDocs`,
+  unescaped `innerHTML`, God modules (>750 lines), loading text, etc.
 - **Dependency direction**: `components → modules → services → repositories` (never reverse)
+- **Loading states**: New async Web Components must use `.skeleton` shimmer classes (§III.3)
 - **Cost discipline**: Firebase Blaze plan (§VI.1); usage targets Spark-equivalent quotas. New Cloud Functions need a documented justification — they should solve a problem the client SDK + rules cannot.
 - **Cloud Functions deploy ops**: When a feature adds a new Cloud Function (especially a 2nd-gen callable), the spec **must** flag the post-deploy operational steps from the `firebase-deploy-runbook` global skill: lowercased Cloud Run service name, one-time `roles/run.invoker` binding for `allUsers` after first deploy, and (for a brand-new project) the GCF source bucket IAM fix. These add ~10 minutes to the first deploy and must be in the implementation plan, not discovered at deploy time.
 - **TypeScript strict**: No implicit `any`; explicit return types; `noUncheckedIndexedAccess: true`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/check-constitution.sh\"",
+            "statusMessage": "Checking constitutional compliance..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -10,23 +10,29 @@ Run a quick constitutional compliance check on the current working tree changes.
 ### 1. Identify changed files
 Run `git diff --name-only` and `git diff --cached --name-only` to find all modified files (staged and unstaged). If no changes exist, report "No changes to check" and stop.
 
-### 2. Check each changed `.ts` file for forbidden patterns (§IV.2)
-For each changed TypeScript file, check for:
+### 2. Check each changed `.ts`/`.html` file against the forbidden-pattern ruleset (§IV.2)
+Run the **single-source ruleset** on each changed file — the same one the PostToolUse hook
+uses, so `/check` and the hook can never disagree:
 
-| Pattern | Check | Fix |
-|---------|-------|-----|
-| `var ` declarations | grep for `\bvar\b` (excluding comments) | Use `const` or `let` |
-| Inline event handlers | grep for `onclick=\|onload=\|onerror=` | Attach listeners in JS |
-| Unfiltered Firestore reads | grep for `getDocs(collection(` without nearby `where`/`limit` | Add `where()` + `limit()` |
-| Unsanitized innerHTML | grep for `.innerHTML =` with non-static content | Use `textContent` or `escapeHtml()` |
-| Plain loading text | grep for `Loading…\|Loading...` in HTML strings | Use `.skeleton` shimmer classes (§III.3) |
-| File size | check line count | Target <500, hard limit 750 |
+```bash
+for f in $(git diff --name-only; git diff --cached --name-only | sort -u); do
+  case "$f" in *.ts|*.html)
+    printf '{"tool_input":{"file_path":"%s"}}' "$f" | bash scripts/check-constitution.sh ;;
+  esac
+done
+```
 
-### 3. Check dependency direction (§II.3)
-For changed files only:
-- Files in `src/repositories/` must NOT import from `src/services/` or `src/modules/` or `src/components/`
+A non-zero exit (2) means a **forbid** violation; stdout notes are advisory warnings. The
+rules live in [`scripts/forbidden-patterns.json`](../../../scripts/forbidden-patterns.json) —
+do not restate them here.
+
+### 3. Check dependency direction (§II.3) and the review-only rules
+The hook can't grep these — verify them by eye on the changed files (they are the
+`enforcedBy: review` rules in the ruleset):
+- Files in `src/repositories/` must NOT import from `src/services/`, `src/modules/`, or `src/components/`
 - Files in `src/services/` must NOT import from `src/modules/` or `src/components/`
-- Files in `src/components/` must NOT import directly from `firebase/`
+- Files in `src/components/` must NOT import the firebase SDK for runtime use (type-only imports are fine)
+- `onSnapshot()` listeners store and call their unsubscribe on teardown
 
 ### 4. Run typecheck
 Run `npm run typecheck` and report pass/fail.
@@ -39,7 +45,7 @@ Present results as a checklist:
 ```
 ✅ No var declarations
 ✅ No inline event handlers
-❌ File size: src/components/admin-panel.ts (1781 lines > 750 limit)
+❌ File size: src/services/some-service.ts (812 lines > 750 limit)
 ✅ Dependency direction OK
 ✅ Typecheck passed
 ✅ Tests passed

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,8 @@ dist/
 *~
 
 # Claude Code user settings (personal preferences)
-.claude/settings.json
+# NOTE: .claude/settings.json IS committed — it wires the shared constitutional-
+# compliance hook. Only the personal/local override files stay ignored.
 .claude/settings.local.json
 .claude/user-*
 .claude/.history

--- a/.specs/constitution.md
+++ b/.specs/constitution.md
@@ -113,7 +113,7 @@ Project-specific strategic frameworks remain in `.prompts/meta/`.
 4. **Module Size**: Target <500 lines per file; split at 750 lines hard limit
 
 **Anti-Patterns (Forbidden)**:
-- ❌ God modules (>500 lines, multiple responsibilities)
+- ❌ God modules (>750 lines hard limit; >500 is the target/warn threshold — multiple responsibilities)
 - ❌ Circular dependencies between modules
 - ❌ Components calling Firestore directly (must go through service layer)
 - ❌ Repositories importing from services
@@ -323,7 +323,7 @@ table (do not duplicate the figures here).
 ❌  var x = ...                              Use const / let
 ❌  onclick="myFunction()"                   Attach listeners in JS
 ❌  element.innerHTML = userInput            Use textContent or escapeHtml()
-❌  God modules > 500 lines                  Split by responsibility
+❌  God modules > 750 lines (target < 500)   Split by responsibility (§II.3)
 ❌  Circular imports between modules         Dependencies flow inward only
 ❌  Components importing from firebase/      Go through services → repositories
 ❌  <p>Loading…</p> in async components      Use .skeleton shimmer classes (§III.3)
@@ -336,6 +336,14 @@ table (do not duplicate the figures here).
 ❌  Force push to main                       Never
 ❌  Skipping security rules in Emulator      Test rules before deploying
 ```
+
+**Enforcement**: this list is the human-readable canon; the machine-readable, executable
+copy is [`scripts/forbidden-patterns.json`](../scripts/forbidden-patterns.json). The
+PostToolUse hook (`scripts/check-constitution.sh`) and the `/check` skill both run that
+ruleset — the hook **blocks** an edit on a hard (`forbid`) violation and warns on the rest.
+Rules it cannot detect by grep (leaked `onSnapshot`, client-side filtering, components
+importing the firebase SDK for runtime use, circular imports) are marked `enforcedBy: review`
+and are checked by `@reviewer`. Change a rule in the JSON, not in a doc copy.
 
 
 ### IV.3 Technology Evaluation Criteria

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ This project uses a spec-kit framework with Claude Code agents, skills, hooks, a
 
 | Hook | Trigger | Action |
 |------|---------|--------|
-| Constitutional check | After any file edit/write | Checks `.ts` files for `var`, inline handlers, unfiltered Firestore reads, file size >750 lines |
+| Constitutional check | After any `.ts`/`.html` edit/write | Runs `scripts/check-constitution.sh` against the ruleset in `scripts/forbidden-patterns.json`. **Blocks** the edit on a hard violation (`var`, inline handler, hardcoded config, file >750 lines); warns on the rest. Rules live in that one JSON file — see constitution §IV.2. |
 
 ### Feature Development Workflow
 

--- a/scripts/check-constitution.sh
+++ b/scripts/check-constitution.sh
@@ -1,51 +1,144 @@
 #!/bin/bash
-# Constitutional pattern checker for CITL
-# Used by Claude Code PostToolUse hook to catch forbidden patterns after file edits.
-# See .specs/constitution.md §IV.2 for the authoritative list.
+# Constitutional pattern checker for CITL.
+# PostToolUse hook (Edit|Write) — executes the single-source ruleset in
+# scripts/forbidden-patterns.json (constitution §IV.2 is the human canon).
 #
-# Input: JSON on stdin with tool_input.file_path
-# Exit 0: no violations found (or not a .ts file)
-# Stdout: JSON warnings for Claude to see
+# Contract:
+#   Input : JSON on stdin with .tool_input.file_path
+#   forbid violation  -> print reason to stderr, exit 2 (blocks; Claude sees it)
+#   warn  only        -> print notes to stdout, exit 0 (advisory)
+#   nothing / N/A file -> exit 0, silent
+#
+# Detects only what greps can detect reliably; rules with enforcedBy "review"
+# are documented in the ruleset for @reviewer, not enforced here.
 
-INPUT=$(cat)
-FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+set -u
+set -f  # no filename globbing — scope globs like *.ts are matched literally, not expanded against cwd
 
-# Only check TypeScript files
-if [[ -z "$FILE" ]] || [[ ! "$FILE" == *.ts ]] || [[ ! -f "$FILE" ]]; then
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULESET="$SCRIPT_DIR/forbidden-patterns.json"
+
+# Fail loud if jq is missing — do NOT silently pass (F-60).
+if ! command -v jq >/dev/null 2>&1; then
+  echo "check-constitution: jq not found — constitutional checks were SKIPPED. Install jq." >&2
   exit 0
 fi
+[[ -f "$RULESET" ]] || { echo "check-constitution: ruleset $RULESET missing — checks skipped." >&2; exit 0; }
 
-ISSUES=""
+INPUT=$(cat)
+FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-# Check for var declarations (excluding comments and strings)
-if grep -n '\bvar ' "$FILE" | grep -v '^\s*//' | grep -v '^\s*\*' | head -3 | grep -q .; then
-  MATCHES=$(grep -n '\bvar ' "$FILE" | grep -v '^\s*//' | grep -v '^\s*\*' | head -3)
-  ISSUES="${ISSUES}Forbidden pattern (§IV.2): 'var' declaration found. Use const/let.\n${MATCHES}\n\n"
+# Gate on scope: only .ts and .html files that exist (widened from .ts-only, F-60).
+[[ -n "$FILE" && -f "$FILE" ]] || exit 0
+case "$FILE" in
+  *.ts|*.html) ;;
+  *) exit 0 ;;
+esac
+BASE="$(basename "$FILE")"
+
+# Strip line comments once for comment-excluding rules (BSD-safe: [[:space:]] not \s, F-59).
+NOCOMMENT=$(grep -vE '^[[:space:]]*(//|\*|/\*)' "$FILE")
+
+BLOCKING=""
+WARNINGS=""
+
+rule_count=$(jq '.rules | length' "$RULESET")
+warn_limit=$(jq -r '.sizeLimits.warn' "$RULESET")
+forbid_limit=$(jq -r '.sizeLimits.forbid' "$RULESET")
+
+matches_scope() {
+  # $1 = file, remaining = scope globs (space-separated from jq)
+  local f="$1"; shift
+  local g
+  for g in "$@"; do
+    case "$g" in
+      "*.ts")            [[ "$f" == *.ts ]] && return 0 ;;
+      "*.html")          [[ "$f" == *.html ]] && return 0 ;;
+      "src/components/**") [[ "$f" == src/components/* ]] && return 0 ;;
+      *)                 [[ "$f" == $g ]] && return 0 ;;
+    esac
+  done
+  return 1
+}
+
+for i in $(seq 0 $((rule_count - 1))); do
+  kind=$(jq -r ".rules[$i].kind" "$RULESET")
+  enforced=$(jq -r ".rules[$i].enforcedBy" "$RULESET")
+  [[ "$enforced" == "hook" ]] || continue
+
+  scope=$(jq -r ".rules[$i].scope[]" "$RULESET")
+  matches_scope "$FILE" $scope || continue
+
+  id=$(jq -r ".rules[$i].id" "$RULESET")
+  ref=$(jq -r ".rules[$i].ref" "$RULESET")
+  sev=$(jq -r ".rules[$i].severity" "$RULESET")
+  msg=$(jq -r ".rules[$i].message" "$RULESET")
+
+  hits=""
+  case "$kind" in
+    regex)
+      pat=$(jq -r ".rules[$i].pattern" "$RULESET")
+      excl=$(jq -r ".rules[$i].excludeComments // false" "$RULESET")
+      if [[ "$excl" == "true" ]]; then
+        hits=$(printf '%s\n' "$NOCOMMENT" | grep -nE "$pat" | head -3)
+      else
+        hits=$(grep -nE "$pat" "$FILE" | head -3)
+      fi
+      ;;
+    getdocs-unbounded)
+      # Warn only if the file uses getDocs but has NO where()/limit() and no
+      # explicit `unbounded-ok` annotation anywhere in the file.
+      if grep -qE 'getDocs\(' "$FILE" \
+         && ! grep -qE 'where\(|limit\(' "$FILE" \
+         && ! grep -qi 'unbounded-ok' "$FILE"; then
+        hits=$(grep -nE 'getDocs\(' "$FILE" | head -3)
+      fi
+      ;;
+    *) continue ;;
+  esac
+
+  [[ -n "$hits" ]] || continue
+  entry="[$id $ref] $msg"$'\n'"$hits"$'\n'
+  if [[ "$sev" == "forbid" ]]; then
+    BLOCKING="${BLOCKING}${entry}"$'\n'
+  else
+    WARNINGS="${WARNINGS}${entry}"$'\n'
+  fi
+done
+
+# File-size rule (kind=filesize, handled specially with grandfathering).
+grandfathered=$(jq -r '.grandfathered["file-size"][]? ' "$RULESET")
+is_grandfathered=false
+while IFS= read -r gf; do
+  [[ -n "$gf" && "$FILE" == "$gf" ]] && is_grandfathered=true
+done <<< "$grandfathered"
+
+if [[ "$FILE" == *.ts ]]; then
+  LINES=$(wc -l < "$FILE" | tr -d ' ')
+  if [[ "$LINES" -gt "$forbid_limit" ]]; then
+    if $is_grandfathered; then
+      WARNINGS="${WARNINGS}[file-size §II.3] ${BASE} is ${LINES} lines (> ${forbid_limit} hard limit) — grandfathered; do not add to it, split it (WS-4)."$'\n\n'
+    else
+      BLOCKING="${BLOCKING}[file-size §II.3] ${BASE} is ${LINES} lines, over the ${forbid_limit}-line hard limit. Split by responsibility."$'\n\n'
+    fi
+  elif [[ "$LINES" -gt "$warn_limit" ]]; then
+    WARNINGS="${WARNINGS}[file-size §II.3] ${BASE} is ${LINES} lines (> ${warn_limit} target) — consider splitting."$'\n\n'
+  fi
 fi
 
-# Check for inline event handlers
-if grep -n 'onclick=\|onload=\|onerror=\|onsubmit=\|onchange=' "$FILE" | head -3 | grep -q .; then
-  MATCHES=$(grep -n 'onclick=\|onload=\|onerror=\|onsubmit=\|onchange=' "$FILE" | head -3)
-  ISSUES="${ISSUES}Forbidden pattern (§IV.2): Inline event handler found. Attach listeners in JS.\n${MATCHES}\n\n"
+if [[ -n "$BLOCKING" ]]; then
+  {
+    echo "Constitutional check BLOCKED the edit to ${BASE} (§IV.2 / scripts/forbidden-patterns.json):"
+    echo ""
+    printf '%b' "$BLOCKING"
+    [[ -n "$WARNINGS" ]] && { echo "Also (non-blocking):"; printf '%b' "$WARNINGS"; }
+    echo "Fix the forbidden pattern(s) above, then re-apply the edit."
+  } >&2
+  exit 2
 fi
 
-# Check for unfiltered Firestore reads
-if grep -n 'getDocs(collection(' "$FILE" | head -3 | grep -q .; then
-  MATCHES=$(grep -n 'getDocs(collection(' "$FILE" | head -3)
-  ISSUES="${ISSUES}Warning (§IV.2): getDocs(collection(...)) found — verify where() + limit() are present.\n${MATCHES}\n\n"
+if [[ -n "$WARNINGS" ]]; then
+  echo "Constitutional check for ${BASE} (advisory):"
+  printf '%b' "$WARNINGS"
 fi
-
-# Check file size
-LINES=$(wc -l < "$FILE")
-if [[ "$LINES" -gt 750 ]]; then
-  ISSUES="${ISSUES}Forbidden (§II.3): File exceeds 750-line hard limit (${LINES} lines). Split by responsibility.\n\n"
-elif [[ "$LINES" -gt 500 ]]; then
-  ISSUES="${ISSUES}Warning (§II.3): File exceeds 500-line target (${LINES} lines). Consider splitting.\n\n"
-fi
-
-if [[ -n "$ISSUES" ]]; then
-  # Output as a message Claude will see
-  echo -e "Constitutional check for $(basename "$FILE"):\n${ISSUES}"
-fi
-
 exit 0

--- a/scripts/forbidden-patterns.json
+++ b/scripts/forbidden-patterns.json
@@ -1,0 +1,98 @@
+{
+  "$comment": "Single source of truth for CITL forbidden/quality patterns. Constitution §IV.2 is the human-readable canon; this file is what scripts/check-constitution.sh (the PostToolUse hook) and the /check skill execute. Docs (reviewer.md, speckit.md, check/SKILL.md, CLAUDE.md) point here instead of restating rules. To change a rule, edit it HERE.",
+  "version": 1,
+  "sizeLimits": { "warn": 500, "forbid": 750 },
+  "grandfathered": {
+    "$comment": "Pre-existing violators the hook must not block. Remove entries as the underlying debt is fixed (e.g. score-service.ts split in WS-4).",
+    "file-size": ["src/services/score-service.ts"]
+  },
+  "rules": [
+    {
+      "id": "no-var",
+      "ref": "§III.5 / §IV.2",
+      "severity": "forbid",
+      "kind": "regex",
+      "pattern": "(^[[:space:]]*|[;{}][[:space:]]*)var[[:space:]]+[A-Za-z_$]",
+      "scope": ["*.ts"],
+      "excludeComments": true,
+      "enforcedBy": "hook",
+      "message": "'var' declaration — use const/let."
+    },
+    {
+      "id": "inline-handler",
+      "ref": "§III.5 / §IV.2",
+      "severity": "forbid",
+      "kind": "regex",
+      "pattern": "on(click|load|error|submit|change)[[:space:]]*=[[:space:]]*[\"']",
+      "scope": ["*.ts", "*.html"],
+      "enforcedBy": "hook",
+      "message": "Inline HTML event handler (onX=\"...\") — attach listeners in JS. (JS listener assignment el.onclick = fn is fine.)"
+    },
+    {
+      "id": "hardcoded-firebase-config",
+      "ref": "§IV.2",
+      "severity": "forbid",
+      "kind": "regex",
+      "pattern": "apiKey[[:space:]]*:[[:space:]]*[\"']AIza",
+      "scope": ["*.ts"],
+      "enforcedBy": "hook",
+      "message": "Hardcoded Firebase API key — use import.meta.env.VITE_*."
+    },
+    {
+      "id": "loading-text",
+      "ref": "§III.3",
+      "severity": "warn",
+      "kind": "regex",
+      "pattern": ">[[:space:]]*Loading(\\.\\.\\.|…)",
+      "scope": ["*.ts"],
+      "enforcedBy": "hook",
+      "message": "Plain 'Loading…' text in markup — use .skeleton shimmer classes (§III.3)."
+    },
+    {
+      "id": "innerhtml-interpolation",
+      "ref": "§III.5 / §IV.2",
+      "severity": "warn",
+      "kind": "regex",
+      "pattern": "innerHTML[[:space:]]*=.*\\$\\{",
+      "scope": ["*.ts"],
+      "enforcedBy": "hook",
+      "message": "innerHTML assignment with ${...} interpolation — escape Firestore/user values with escapeHtml() or build via textContent (§IV.2, F-07)."
+    },
+    {
+      "id": "unbounded-getdocs",
+      "ref": "§IV.2",
+      "severity": "warn",
+      "kind": "getdocs-unbounded",
+      "scope": ["*.ts"],
+      "enforcedBy": "hook",
+      "message": "getDocs() with no where()/limit() in the file — add a filter/limit, or annotate a deliberate bounded scan with an inline `// unbounded-ok: <reason>` comment."
+    },
+    {
+      "id": "leaked-onsnapshot",
+      "ref": "§IV.2",
+      "severity": "warn",
+      "kind": "manual",
+      "scope": ["*.ts"],
+      "enforcedBy": "review",
+      "message": "onSnapshot() — ensure the returned unsubscribe is stored and called on teardown (not auto-detectable; reviewer/@reviewer checks this)."
+    },
+    {
+      "id": "components-import-firebase",
+      "ref": "§II.3",
+      "severity": "forbid",
+      "kind": "manual",
+      "scope": ["src/components/**"],
+      "enforcedBy": "review",
+      "message": "Component importing the firebase SDK for runtime use — go through services → repositories (type-only imports are fine). Not auto-detected to avoid flagging `import type`."
+    },
+    {
+      "id": "client-side-filtering",
+      "ref": "§IV.2",
+      "severity": "warn",
+      "kind": "manual",
+      "scope": ["*.ts"],
+      "enforcedBy": "review",
+      "message": "Client-side filtering of Firestore data — use where() queries (not auto-detectable)."
+    }
+  ]
+}

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -354,6 +354,7 @@ export class ScoreRepository {
 
       // Step 2: cascade-remove team from published week results + season standings
       const [weeksSnap, seasonSnap] = await Promise.all([
+        // unbounded-ok: weeks collection is bounded to <=15 docs per season by league schedule
         getDocs(collection(this.db, 'seasons', String(year), 'weeks')),
         getDoc(doc(this.db, 'seasons', String(year))),
       ]);


### PR DESCRIPTION
## Summary
- **WS-2 (part 2 of 2)** of the [July 2026 deep review](.specs/reviews/2026-07-deep-review/report.md): the constitutional-compliance hook enforced nothing and the forbidden-pattern ruleset was hand-duplicated across six locations (already drifted). This makes the hook actually bind and collapses the six copies to one machine-readable source.
- Per your call, the hook **blocks** hard violations (grandfathering existing ones).

## Changes
- **`scripts/forbidden-patterns.json`** (new) — the single ruleset: each rule has an id, §-ref, severity (`forbid`/`warn`), detector kind, scope glob, and `enforcedBy` (`hook` vs `review`). Change a rule here; nowhere else restates it.
- **`scripts/check-constitution.sh`** (rewritten) — executes the ruleset and **binds**: a `forbid` violation prints to stderr and exits 2 (blocks the edit); warnings go to stdout. Fixes from the review: BSD-safe `[[:space:]]`, `var` anchored to declaration position (no more false positives on `variant`/strings/comments), inline-handler scoped to `onX="` so `el.onclick = fn` is fine, `getDocs` flagged only when the file has no `where()`/`limit()` and no `// unbounded-ok:` note, **fails loud** if `jq` is missing, checks `.ts` **and** `.html`, and grandfathers `score-service.ts` until WS-4 splits it (F-19, F-20, F-59, F-60).
- **`.claude/settings.json`** — un-ignored and committed (it was gitignored, so the hook had never run — F-39); command anchored to `$CLAUDE_PROJECT_DIR`.
- **Docs → pointers** — reviewer.md, speckit.md, check/SKILL.md, and CLAUDE.md no longer restate rule regexes; they run/point at the ruleset. Reconciled the §IV.2 vs §II.3 size canon to **750-hard / 500-warn** and added an Enforcement note to §IV.2 (F-40).
- Annotated the intentional bounded weeks-scan in `score-repository.ts`.

## Testing
- [x] Hook self-tests: blocks bare `var` (exit 2) and `onclick="…"` in `.html`; stays silent on `var` in comments/strings and on `el.onclick = fn`; warns on unbounded `getDocs`; grandfathers `score-service.ts` (warn, not block)
- [x] `/check` and `@reviewer` now execute the same ruleset the hook does — they cannot disagree
- [x] `grep` confirms no rule regexes remain in the agent/skill docs
- [x] `npm run typecheck` clean; `npm test` 215 pass; `bash -n` on the hook clean

## Behavioral note
Once merged, the hook is active for everyone working in the repo: an edit that introduces a hard violation will be **rejected** at write time until fixed. Existing oversized files are grandfathered so only *new* violations block. If it ever proves too aggressive, flipping a rule's `severity` from `forbid` to `warn` in the JSON is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)