### PR TITLE
fix(scoring): single-source the blend rule; validate the Firestore boundary (WS-3)

### DIFF
--- a/src/repositories/score-repository.test.ts
+++ b/src/repositories/score-repository.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Boundary-validation guards (deep-review F-09).
+ *
+ * These guards are the only thing standing between a corrupt or hand-edited
+ * Firestore doc and silently wrong standings — a malformed doc must become a
+ * failure('MALFORMED_DOC') Result, never NaN math.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isValidWeekResult, isValidSeasonEntry } from './score-repository';
+
+const validTeamResult = {
+  teamId: 'hawks',
+  teamName: 'Hawks',
+  targets: 190,
+  rankPoints: 28,
+  bonusPoints: 5,
+  shooterScores: [{ name: 'A', score1: 20, score2: 21, total: 41 }],
+};
+
+describe('isValidWeekResult', () => {
+  it('accepts a well-formed week doc', () => {
+    expect(isValidWeekResult({ weekNumber: 3, publishedAt: 'x', teamResults: [validTeamResult] })).toBe(true);
+  });
+
+  it('accepts legacy variance: null targets/rankPoints/bonusPoints (forfeits, non-participants)', () => {
+    expect(isValidWeekResult({
+      weekNumber: 3,
+      teamResults: [{ ...validTeamResult, targets: null, rankPoints: null, bonusPoints: null }],
+    })).toBe(true);
+  });
+
+  it('rejects a string where a number belongs (targets: "42")', () => {
+    expect(isValidWeekResult({
+      weekNumber: 3,
+      teamResults: [{ ...validTeamResult, targets: '42' }],
+    })).toBe(false);
+  });
+
+  it('rejects a missing teamResults array', () => {
+    expect(isValidWeekResult({ weekNumber: 3 })).toBe(false);
+  });
+
+  it('rejects a non-numeric weekNumber', () => {
+    expect(isValidWeekResult({ weekNumber: 'three', teamResults: [] })).toBe(false);
+  });
+});
+
+describe('isValidSeasonEntry', () => {
+  const validEntry = {
+    year: 2026, weekNumber: 2, teamId: 'hawks', teamName: 'Hawks', savedAt: 'x',
+    shooters: [{ name: 'A', score1: 20, score2: 22, total: 42 }],
+  };
+
+  it('accepts a well-formed entry', () => {
+    expect(isValidSeasonEntry(validEntry)).toBe(true);
+  });
+
+  it('rejects a string total (total: "42") — entries feed publish math directly', () => {
+    expect(isValidSeasonEntry({
+      ...validEntry,
+      shooters: [{ name: 'A', score1: 20, score2: 22, total: '42' }],
+    })).toBe(false);
+  });
+
+  it('rejects a missing shooters array', () => {
+    const { shooters: _drop, ...noShooters } = validEntry;
+    expect(isValidSeasonEntry(noShooters)).toBe(false);
+  });
+
+  it('rejects an empty teamName', () => {
+    expect(isValidSeasonEntry({ ...validEntry, teamName: '' })).toBe(false);
+  });
+});

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -48,6 +48,65 @@ export function failure(error: string, code = 'UNKNOWN_ERROR'): Result<never> {
 }
 
 // ---------------------------------------------------------------------------
+// Boundary validation (deep-review F-09)
+//
+// Firestore document shapes are validated at the read boundary so a corrupt
+// or hand-edited doc surfaces as failure('MALFORMED_DOC') instead of flowing
+// silently into scoring math as NaN/undefined. Guards are deliberately
+// tolerant of known legacy variance (null targets/rankPoints/bonusPoints on
+// forfeit or non-participant rows in historical week docs — consumers apply
+// `?? 0`) and strict about genuine type corruption.
+// ---------------------------------------------------------------------------
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/** Finite number, or the null/undefined legacy variance consumers tolerate. */
+function isFiniteNumberOrNullish(v: unknown): boolean {
+  return v === null || v === undefined || isFiniteNumber(v);
+}
+
+export function isValidWeekResult(v: unknown): v is WeekResult {
+  if (typeof v !== 'object' || v === null) return false;
+  const w = v as Record<string, unknown>;
+  if (!isFiniteNumber(w['weekNumber'])) return false;
+  if (!Array.isArray(w['teamResults'])) return false;
+  return (w['teamResults'] as unknown[]).every((t) => {
+    if (typeof t !== 'object' || t === null) return false;
+    const tr = t as Record<string, unknown>;
+    return (
+      typeof tr['teamId'] === 'string' &&
+      typeof tr['teamName'] === 'string' &&
+      isFiniteNumberOrNullish(tr['targets']) &&
+      isFiniteNumberOrNullish(tr['rankPoints']) &&
+      isFiniteNumberOrNullish(tr['bonusPoints']) &&
+      (tr['shooterScores'] === undefined ||
+        (Array.isArray(tr['shooterScores']) &&
+          (tr['shooterScores'] as unknown[]).every((s) => {
+            if (typeof s !== 'object' || s === null) return false;
+            const sh = s as Record<string, unknown>;
+            return typeof sh['name'] === 'string' && isFiniteNumberOrNullish(sh['total']);
+          })))
+    );
+  });
+}
+
+export function isValidSeasonEntry(v: unknown): v is SeasonEntry {
+  if (typeof v !== 'object' || v === null) return false;
+  const e = v as Record<string, unknown>;
+  if (!isFiniteNumber(e['weekNumber'])) return false;
+  if (typeof e['teamName'] !== 'string' || e['teamName'].length === 0) return false;
+  if (!Array.isArray(e['shooters'])) return false;
+  // Entries feed publish math directly — totals must be real numbers.
+  return (e['shooters'] as unknown[]).every((s) => {
+    if (typeof s !== 'object' || s === null) return false;
+    const sh = s as Record<string, unknown>;
+    return typeof sh['name'] === 'string' && sh['name'].length > 0 && isFiniteNumber(sh['total']);
+  });
+}
+
+// ---------------------------------------------------------------------------
 // ScoreRepository
 // ---------------------------------------------------------------------------
 
@@ -128,7 +187,11 @@ export class ScoreRepository {
       const ref = doc(this.db, 'seasons', String(year), 'weeks', String(weekNumber));
       const snap = await getDoc(ref);
       if (!snap.exists()) return success(null);
-      return success({ id: snap.id, ...snap.data() } as unknown as WeekResult);
+      const wk: unknown = { id: snap.id, ...snap.data() };
+      if (!isValidWeekResult(wk)) {
+        return failure(`Malformed week doc seasons/${year}/weeks/${weekNumber}`, 'MALFORMED_DOC');
+      }
+      return success(wk);
     } catch (err) {
       return failure(
         `Failed to load week ${weekNumber} for ${year}: ${(err as Error).message}`,
@@ -145,7 +208,14 @@ export class ScoreRepository {
         limit(15),
       );
       const snap = await getDocs(q);
-      const weeks = snap.docs.map((d) => ({ id: d.id, ...d.data() } as unknown as WeekResult));
+      const weeks: WeekResult[] = [];
+      for (const d of snap.docs) {
+        const wk: unknown = { id: d.id, ...d.data() };
+        if (!isValidWeekResult(wk)) {
+          return failure(`Malformed week doc seasons/${year}/weeks/${d.id}`, 'MALFORMED_DOC');
+        }
+        weeks.push(wk);
+      }
       return success(weeks);
     } catch (err) {
       return failure(
@@ -165,7 +235,11 @@ export class ScoreRepository {
       const snap = await getDocs(q);
       if (snap.empty) return success(null);
       const d = snap.docs[0]!;
-      return success({ id: d.id, ...d.data() } as unknown as WeekResult);
+      const wk: unknown = { id: d.id, ...d.data() };
+      if (!isValidWeekResult(wk)) {
+        return failure(`Malformed week doc seasons/${year}/weeks/${d.id}`, 'MALFORMED_DOC');
+      }
+      return success(wk);
     } catch (err) {
       return failure(
         `Failed to load latest week for ${year}: ${(err as Error).message}`,
@@ -198,7 +272,11 @@ export class ScoreRepository {
       const ref = doc(this.db, 'seasons', String(year), 'entries', entryId);
       const snap = await getDoc(ref);
       if (!snap.exists()) return success(null);
-      return success({ id: snap.id, ...snap.data() } as unknown as SeasonEntry);
+      const entry: unknown = { id: snap.id, ...snap.data() };
+      if (!isValidSeasonEntry(entry)) {
+        return failure(`Malformed entry doc seasons/${year}/entries/${entryId}`, 'MALFORMED_DOC');
+      }
+      return success(entry);
     } catch (err) {
       return failure(`Failed to load entry: ${(err as Error).message}`, 'FIRESTORE_READ_ERROR');
     }
@@ -212,7 +290,14 @@ export class ScoreRepository {
         limit(maxWeekNumber * 10),
       );
       const snap = await getDocs(q);
-      const entries = snap.docs.map((d) => ({ id: d.id, ...d.data() } as unknown as SeasonEntry));
+      const entries: SeasonEntry[] = [];
+      for (const d of snap.docs) {
+        const entry: unknown = { id: d.id, ...d.data() };
+        if (!isValidSeasonEntry(entry)) {
+          return failure(`Malformed entry doc seasons/${year}/entries/${d.id}`, 'MALFORMED_DOC');
+        }
+        entries.push(entry);
+      }
       return success(entries);
     } catch (err) {
       return failure(`Failed to load entries: ${(err as Error).message}`, 'FIRESTORE_READ_ERROR');

--- a/src/services/score-service.test.ts
+++ b/src/services/score-service.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ScoreService, buildPriorAvgMap } from './score-service';
+import { ScoreService } from './score-service';
+import { buildPriorAvgMap, computeShooterAverage } from './scoring-engine';
 import { success } from '@/repositories/score-repository';
 import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Team, WeekResult, SeasonEntry } from '@/types/score';
@@ -143,6 +144,30 @@ describe('buildPriorAvgMap', () => {
     ];
     const map = buildPriorAvgMap(weeks, priorTeams);
     expect(map.get('carol')).toBeCloseTo(42, 5);
+  });
+
+  it('equivalence: single-team shooter output equals computeShooterAverage (F-02)', () => {
+    // Pins that the map and the engine share ONE blend implementation: for a
+    // shooter on a single team, the map value must equal computeShooterAverage
+    // over the same scores (rounded to the map's 1-decimal display convention).
+    const cases: { startingAvg: number; scores: number[] }[] = [
+      { startingAvg: 43, scores: [38] },           // <2 weeks: blend applies
+      { startingAvg: 35, scores: [40, 42] },       // exactly 2: blend phased out
+      { startingAvg: 30, scores: [40, 42, 47] },   // 3+: raw mean
+      { startingAvg: 41, scores: [25] },           // low single score
+    ];
+    for (const { startingAvg, scores } of cases) {
+      const priorTeams = [makeTeam('Team', [makeShooter('Eve', startingAvg)])];
+      const weeks = scores.map((total, i) => ({
+        ...makeWeekResult([{ name: 'Eve', total }]),
+        weekNumber: i + 1,
+      }));
+      const map = buildPriorAvgMap(weeks, priorTeams);
+      const expected = parseFloat(
+        computeShooterAverage(startingAvg, scores, scores.length - 1).toFixed(1),
+      );
+      expect(map.get('eve'), `startingAvg=${startingAvg} scores=[${scores}]`).toBe(expected);
+    }
   });
 
   it('startingAvg: 0 in priorTeams is treated as 35 for blending (corrupt/legacy data)', () => {
@@ -1073,6 +1098,18 @@ describe('publishWeek — standings computation', () => {
     // Correcting week 2 must not drop the season back to week 2.
     await svc.publishWeek(2026, 2);
     expect(capturedUpdate?.currentWeek).toBe(5);
+  });
+
+  it('never throws — a repository that throws yields a failure Result, not a wedged UI (F-09)', async () => {
+    // The class contract promises no throws across module boundaries; the
+    // admin UI relies on it to re-enable the Publishing… button.
+    const throwingRepo: Partial<ScoreRepository> = {
+      getSeason: async () => { throw new Error('boom'); },
+    };
+    const svc = new ScoreService(throwingRepo as unknown as ScoreRepository);
+    const result = await svc.publishWeek(2026, 3);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.code).toBe('INTERNAL_ERROR');
   });
 
   it('derives teamId from the team document id, not a re-slugified name (F-08)', async () => {

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { success, failure, type Result } from '@/repositories/score-repository';
-import { computeSeasonTotals, computeShooterAverage, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, mean, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst, computeAccolades, compareStandings } from '@/services/scoring-engine';
+import { buildPriorAvgMap, computeSeasonTotals, computeShooterAverage, computeShooterStartingAvg, isShooterRookie, computeDummyScore, isDummyName, mean, normalizeShooterName, getLastWord, sortShootersWithCaptainFirst, computeAccolades, compareStandings } from '@/services/scoring-engine';
 import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Season, SeasonStandings } from '@/types/season';
 import type { Team, WeekResult, SeasonEntry, ShooterScore } from '@/types/score';
@@ -192,7 +192,16 @@ export class ScoreService {
     if (!Number.isInteger(weekNumber) || weekNumber < 1 || weekNumber > 15) {
       return failure(`Invalid weekNumber: ${weekNumber}`, 'VALIDATION_ERROR');
     }
+    // The class contract promises no throws across module boundaries — an
+    // exception here would wedge the admin UI's Publishing… state (F-09).
+    try {
+      return await this._publishWeekInner(year, weekNumber);
+    } catch (err) {
+      return failure(`Publish failed unexpectedly: ${(err as Error).message}`, 'INTERNAL_ERROR');
+    }
+  }
 
+  private async _publishWeekInner(year: number, weekNumber: number): Promise<Result<unknown>> {
     // Determine the true max published week so republishing an earlier week
     // (a supported correction flow) never rewinds standings/currentWeek (F-05).
     const existingSeasonResult = await this.repository.getSeason(year);
@@ -979,54 +988,6 @@ function _buildScorecardTeamBlock(args: {
     bonusPoints,
   };
 }
-
-/**
- * Build a name→finalAvg map from published WeekResult documents, applying the
- * same business rule as computeShooterAverage: when a shooter has fewer than
- * 2 weeks of actual scores, the starting average is blended into the mean.
- * priorTeams is required for that startingAvg lookup.
- *
- * Exported so existing tests can exercise the helper directly.
- */
-export function buildPriorAvgMap(weekResults: WeekResult[], priorTeams: Team[]): Map<string, number> {
-  // Build startingAvg lookup keyed by lowercased name (first match wins)
-  const startingAvgMap = new Map<string, number>();
-  for (const team of priorTeams) {
-    for (const shooter of team.shooters) {
-      const key = normalizeShooterName(shooter.name);
-      if (!startingAvgMap.has(key)) {
-        startingAvgMap.set(key, shooter.startingAvg > 0 ? shooter.startingAvg : 35);
-      }
-    }
-  }
-
-  const acc = new Map<string, { total: number; weeks: number }>();
-  for (const wr of weekResults) {
-    for (const tr of wr.teamResults ?? []) {
-      for (const s of tr.shooterScores ?? []) {
-        if (typeof s.total !== 'number' || !isFinite(s.total)) continue;
-        const key = normalizeShooterName(s.name);
-        const cur = acc.get(key) ?? { total: 0, weeks: 0 };
-        acc.set(key, { total: cur.total + s.total, weeks: cur.weeks + 1 });
-      }
-    }
-  }
-
-  const result = new Map<string, number>();
-  for (const [key, { total, weeks }] of acc) {
-    let avg: number;
-    if (weeks < 2) {
-      // Mirror computeShooterAverage: blend startingAvg into mean until ≥ 2 weeks shot
-      const startingAvg = startingAvgMap.get(key) ?? 35;
-      avg = (startingAvg + total) / (weeks + 1);
-    } else {
-      avg = total / weeks;
-    }
-    result.set(key, parseFloat(avg.toFixed(1)));
-  }
-  return result;
-}
-
 
 /**
  * Recompute season standings by summing the stored per-week TeamResult values.

--- a/src/services/scoring-engine.ts
+++ b/src/services/scoring-engine.ts
@@ -11,7 +11,7 @@
 
 import type { ScorecardShooter, SeasonData } from '@/types/scorecard';
 import type { ComputedAwards } from '@/types/season';
-import type { Team, TeamResult } from '@/types/score';
+import type { Team, TeamResult, WeekResult } from '@/types/score';
 import type { Accolade } from '@/types/shooter';
 
 // ---------------------------------------------------------------------------
@@ -131,6 +131,57 @@ export function computeShooterAverage(startingAvg: number, scores: (number | nul
   if (weeksShot === 0) return startingAvg;
   if (weeksShot < 2) return mean([startingAvg, ...throughScores]);
   return mean(throughScores);
+}
+
+/**
+ * Build a name→finalAvg map from published WeekResult documents. The final
+ * number is delegated to computeShooterAverage so the <2-weeks starting-avg
+ * blend rule has exactly one implementation (deep-review F-02).
+ *
+ * Deliberate adaptations for the prior-season context (kept from the original
+ * score-service implementation so outputs are unchanged):
+ * - startingAvg <= 0 is treated as corrupt data and coerced to 35;
+ * - accumulation is keyed by normalized shooter NAME across teams (a shooter
+ *   who subbed on two teams gets one combined average);
+ * - shooters absent from priorTeams fall back to startingAvg 35;
+ * - dummy shooters are NOT filtered — dummy names are team-scoped
+ *   ("<team> DUMMY1") and only resolve against rosters that contain them,
+ *   matching the pre-refactor behavior;
+ * - the result is rounded to one decimal (display convention).
+ */
+export function buildPriorAvgMap(weekResults: WeekResult[], priorTeams: Team[]): Map<string, number> {
+  // startingAvg lookup keyed by normalized name (first match wins)
+  const startingAvgMap = new Map<string, number>();
+  for (const team of priorTeams) {
+    for (const shooter of team.shooters) {
+      const key = normalizeShooterName(shooter.name);
+      if (!startingAvgMap.has(key)) {
+        startingAvgMap.set(key, shooter.startingAvg > 0 ? shooter.startingAvg : 35);
+      }
+    }
+  }
+
+  // Collect each shooter's actual scores across all published weeks.
+  const scoresByShooter = new Map<string, number[]>();
+  for (const wr of weekResults) {
+    for (const tr of wr.teamResults ?? []) {
+      for (const s of tr.shooterScores ?? []) {
+        if (typeof s.total !== 'number' || !isFinite(s.total)) continue;
+        const key = normalizeShooterName(s.name);
+        const list = scoresByShooter.get(key) ?? [];
+        list.push(s.total);
+        scoresByShooter.set(key, list);
+      }
+    }
+  }
+
+  const result = new Map<string, number>();
+  for (const [key, scores] of scoresByShooter) {
+    const startingAvg = startingAvgMap.get(key) ?? 35;
+    const avg = computeShooterAverage(startingAvg, scores, scores.length - 1);
+    result.set(key, parseFloat(avg.toFixed(1)));
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Final two P1 correctness items from the [July 2026 deep review](.specs/reviews/2026-07-deep-review/report.md): **F-02** (the duplicated starting-average blend rule — the highest-rated drift risk in the repo) and **F-09** (the trusted-not-validated Firestore boundary).
- With this merged, **all 13 P1 findings are resolved**.

## Changes
- **F-02**: `buildPriorAvgMap` moved into `scoring-engine.ts` (it is pure) and now delegates its `<2-weeks` blend to `computeShooterAverage` — exactly one implementation of the rule remains. Behavior-preserving: the five deliberate prior-season adaptations are kept verbatim and documented; a new **equivalence test** pins map output == engine output so the paths can never silently drift again.
- **F-09**: the five `as unknown as` casts in `score-repository.ts` replaced with exported guards (`isValidWeekResult`, `isValidSeasonEntry`); malformed docs return `failure('MALFORMED_DOC')` naming the doc path. Guards tolerate known legacy variance (null targets/rankPoints/bonusPoints, absent shooterScores) and are strict on entries (they feed publish math).
- `publishWeek` wrapped in try/catch (`_publishWeekInner`, verbatim extraction) honoring the never-throws contract — the admin Publishing… button can no longer wedge on an unexpected exception.

## Behavior change to know about (deliberate)
List reads (`getAllWeekResults`, `getEntries`) now **fail the whole batch on one malformed doc** — loud failure with the offending doc path in the error, instead of partially rendering or silently computing wrong numbers. If a season page ever suddenly errors, the error message names the bad doc.

## Testing
- [x] `npm run typecheck` clean; `npm test` — **228 pass** (9 new guard tests, F-02 equivalence test, F-09 never-throws test)
- [x] All pre-existing `buildPriorAvgMap` regression tests pass against the moved implementation unchanged
- [x] Fresh-context `@reviewer` agent audit: no material findings; guard tolerance verified against the shapes written by `scripts/import-historical.js` (git history) and the admin entry flow — no legitimate production doc is rejected; blend delegation confirmed bit-identical (IEEE-754 summation order preserved)
- [ ] Post-preview-deploy: re-run the prod-vs-preview scorecards hash comparison (buildPriorAvgMap feeds the W0 column) — must remain byte-identical

## Constitutional Compliance
- §II.3: dependency direction preserved — guards live in the repository layer; the engine gained only a type-only import from `src/types/`
- §IV.2: no forbidden patterns; `score-service.ts` shrinks ~48 lines (grandfathered god file moving in the required direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)