### PR TITLE
fix(security): escape Firestore names in public views; guard async re-renders (WS-3)

### DIFF
--- a/src/components/admin-tabs/score-entry-tab.ts
+++ b/src/components/admin-tabs/score-entry-tab.ts
@@ -34,6 +34,8 @@ export class ScoreEntryTab implements AdminTab {
   private _dateEditMode = false;
   /** Whether any entries have been saved for the currently selected week. */
   private _weekHasScores = false;
+  /** Re-entrancy guard: only the latest _populateShooterRows call may render (F-23). */
+  private _loadGen = 0;
 
   constructor(scoreService: ScoreService) {
     this._scoreService = scoreService;
@@ -155,6 +157,7 @@ export class ScoreEntryTab implements AdminTab {
   // ── Shooter rows ────────────────────────────────────────────────────────
 
   private async _populateShooterRows(): Promise<void> {
+    const gen = ++this._loadGen;
     const host = this._host;
     if (!host) return;
     const year = this._ctx?.getYear() ?? 0;
@@ -168,6 +171,7 @@ export class ScoreEntryTab implements AdminTab {
     // 1. Try to load existing saved entry first
     if (teamId) {
       const entryResult = await this._scoreService.getEntry(year, weekNumber, teamId);
+      if (gen !== this._loadGen) return; // superseded — a newer week/team selection owns the tbody
       if (entryResult.success && entryResult.data !== null) {
         const team = this._ctx?.getTeamsData()?.find((t) => t.id === teamId);
         const rosterNames = team ? new Set(team.shooters.map((s) => s.name)) : null;

--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -9,6 +9,7 @@ import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
 import { compareStandings } from '@/services/scoring-engine';
+import { escapeHtml } from '@/modules/ui';
 import type { Team, WeekResult } from '@/types/score';
 import type { Season } from '@/types/season';
 import type { Accolade } from '@/types/shooter';
@@ -22,6 +23,8 @@ class HomeStandings extends HTMLElement {
   private _season: Season | null = null;
   private _allWeekResults: WeekResult[] = [];
   private _teams: Team[] = [];
+  /** Re-entrancy guard: only the latest _loadYear call may render (F-23). */
+  private _loadGen = 0;
 
   connectedCallback(): void {
     this.innerHTML = `
@@ -76,6 +79,7 @@ class HomeStandings extends HTMLElement {
   }
 
   private async _loadYear(year: number): Promise<void> {
+    const gen = ++this._loadGen;
     this.querySelector('#hs-table')!.innerHTML = HomeStandings._standingsSkeleton();
 
     const [weeksResult, seasonResult, teamsResult] = await Promise.all([
@@ -83,6 +87,7 @@ class HomeStandings extends HTMLElement {
       scoreService.getSeason(year),
       scoreService.getTeams(year),
     ]);
+    if (gen !== this._loadGen) return; // superseded by a newer selection
 
     if (!seasonResult.success || !seasonResult.data) {
       this.querySelector('#hs-table')!.innerHTML = `<p>Error loading standings for ${year}.</p>`;
@@ -225,8 +230,8 @@ class HomeStandings extends HTMLElement {
       return `
       <li class="accolades-item">
         <span class="accolades-badge ${badgeClass}">${label}</span>
-        <span class="accolades-item__name">${a.shooterName}</span>
-        <span class="accolades-item__team">${a.teamName}</span>
+        <span class="accolades-item__name">${escapeHtml(a.shooterName)}</span>
+        <span class="accolades-item__team">${escapeHtml(a.teamName)}</span>
       </li>`;
     }).join('');
 
@@ -274,8 +279,8 @@ class HomeStandings extends HTMLElement {
         (r) => `
         <tr>
           <td>${r.place}</td>
-          <td>${r.teamName}</td>
-          <td>${r.captain}</td>
+          <td>${escapeHtml(r.teamName)}</td>
+          <td>${escapeHtml(r.captain)}</td>
           <td>${r.targets}</td>
           <td>${r.totalTargets}</td>
           <td>${r.rankPoints}</td>

--- a/src/components/scoresheet-generator.ts
+++ b/src/components/scoresheet-generator.ts
@@ -10,6 +10,7 @@ import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
 import { computeGoingInAverage, getLastWord, isDummyName, normalizeShooterName, sortShootersWithCaptainFirst } from '@/services/scoring-engine';
 import { computeSchedule } from '@/utils/schedule';
+import { escapeHtml } from '@/modules/ui';
 import type { Season } from '@/types/season';
 import type { Team, WeekResult } from '@/types/score';
 
@@ -25,6 +26,8 @@ class ScoresheetGenerator extends HTMLElement {
   private _weekResults: WeekResult[] = [];
   /** week number → Date (computed/postponed) or null (cancelled) */
   private _dateMap = new Map<number, Date | null>();
+  /** Re-entrancy guard: only the latest _changeYear call may render (F-23). */
+  private _loadGen = 0;
 
   connectedCallback(): void {
     this.innerHTML = ScoresheetGenerator._fullSkeleton();
@@ -63,6 +66,7 @@ class ScoresheetGenerator extends HTMLElement {
   }
 
   private async _changeYear(year: number): Promise<void> {
+    const gen = ++this._loadGen;
     this._year = year;
     const season = this._seasons.find((s) => s.year === year);
     this._maxWeek = Math.min(15, (season?.currentWeek ?? 0) + 1);
@@ -73,6 +77,7 @@ class ScoresheetGenerator extends HTMLElement {
     if (container) container.innerHTML = ScoresheetGenerator._cardsSkeleton();
 
     await this._fetchYearData();
+    if (gen !== this._loadGen) return; // superseded by a newer selection
 
     const weekSelect = this.querySelector<HTMLSelectElement>('#sg-week');
     if (weekSelect) weekSelect.innerHTML = this._weekOptions();
@@ -168,7 +173,7 @@ class ScoresheetGenerator extends HTMLElement {
         const avg = computeGoingInAverage(shooter.startingAvg, scores, this._selectedWeek - 1);
         return `
           <tr>
-            <td>${shooter.name}</td>
+            <td>${escapeHtml(shooter.name)}</td>
             <td>${avg.toFixed(1)}</td>
             <td class="fill"></td>
             <td class="fill"></td>
@@ -187,7 +192,7 @@ class ScoresheetGenerator extends HTMLElement {
           </tr>`;
 
     const dummyNote = 'Starting Dummy Score = Avg. of shooters going-in for that day<br>Ending Dummy Score is automatically calculated via the tool';
-    const prefix = getLastWord(team.name);
+    const prefix = escapeHtml(getLastWord(team.name));
     const dummyRows = `
           <tr>
             <td>${prefix} DUMMY1</td>
@@ -215,7 +220,7 @@ class ScoresheetGenerator extends HTMLElement {
           ${dateLine}
         </div>
 
-        <h3 class="scoresheet-team-name">${team.name}</h3>
+        <h3 class="scoresheet-team-name">${escapeHtml(team.name)}</h3>
         <table class="scoresheet-table">
           <thead>
             <tr>

--- a/src/components/season-scorecards.ts
+++ b/src/components/season-scorecards.ts
@@ -9,6 +9,7 @@
 import { db } from '@/firebase-config';
 import { createRepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
+import { escapeHtml } from '@/modules/ui';
 import type { Season } from '@/types/season';
 import type { ScorecardRowShooter, ScorecardTeamBlock } from '@/types/scorecard';
 
@@ -25,6 +26,8 @@ class SeasonScorecards extends HTMLElement {
   private _seasons: Season[] = [];
   private _selectedYear: number | null = null;
   private _teamBlocks: ScorecardTeamBlock[] = [];
+  /** Re-entrancy guard: only the latest _loadYear call may render (F-23). */
+  private _loadGen = 0;
 
   connectedCallback(): void {
     this.innerHTML = `
@@ -92,9 +95,11 @@ class SeasonScorecards extends HTMLElement {
   }
 
   private async _loadYear(year: number): Promise<void> {
+    const gen = ++this._loadGen;
     this.querySelector('#sc-content')!.innerHTML = SeasonScorecards._scorecardsSkeletonHTML();
 
     const result = await scoreService.buildScorecardData(year);
+    if (gen !== this._loadGen) return; // superseded by a newer selection
     if (!result.success) {
       this.querySelector('#sc-content')!.innerHTML = `<p>Error loading scorecard data for ${year}.</p>`;
       return;
@@ -122,7 +127,7 @@ class SeasonScorecards extends HTMLElement {
         const scoreCells = s.scores.map((v) => `<td>${fmt(v)}</td>`).join('');
         const weeks = s.weeksShot !== null ? s.weeksShot : '-';
         const rowClass = s.isDummy ? ' class="dummy-row"' : '';
-        return `<tr${rowClass}><td>${s.name}</td><td>${rookieMark}</td><td>${fmt(s.w0Display)}</td>${scoreCells}<td>${weeks}</td><td>${fmt(s.finalAvg)}</td></tr>`;
+        return `<tr${rowClass}><td>${escapeHtml(s.name)}</td><td>${rookieMark}</td><td>${fmt(s.w0Display)}</td>${scoreCells}<td>${weeks}</td><td>${fmt(s.finalAvg)}</td></tr>`;
       })
       .join('\n        ');
 
@@ -133,7 +138,7 @@ class SeasonScorecards extends HTMLElement {
     const chevronSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 320 512" class="collapsible__chevron" aria-hidden="true" focusable="false"><path fill="currentColor" d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8H32c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/></svg>`;
 
     return `
-    <button class="collapsible"><span class="collapsible__label">${block.teamName}</span>${chevronSvg}</button>
+    <button class="collapsible"><span class="collapsible__label">${escapeHtml(block.teamName)}</span>${chevronSvg}</button>
     <div class="scorecard">
       <table class="scorecard-tables">
         <tr><th></th><th>R</th>${headerCells}<th>Weeks Shot</th><th>Avg</th></tr>


### PR DESCRIPTION
## Summary
- Executes **WS3-07 (F-07)** and **WS3-10 (F-23)** from `.specs/reviews/2026-07-deep-review/backlog.md`
- home-standings, season-scorecards, and scoresheet-generator interpolated Firestore-sourced names directly into `innerHTML` templates — a hostile team/shooter/captain name (admin-write today, but one rules slip away from user-write) executes as markup on the public pages
- The async year/team select handlers had no re-entrancy protection: a slow earlier load could render over a newer selection (merged rosters / wrong-year tables)

## Changes
- Escape every interpolated Firestore name via the shared `escapeHtml` (from WS3-06): accolade shooter/team names and standings teamName/captain in `home-standings.ts`; collapsible team label and shooter rows in `season-scorecards.ts`; team heading, shooter rows, and dummy-row prefix in `scoresheet-generator.ts`
- Generation-counter guards (`_loadGen`) on `home-standings._loadYear`, `season-scorecards._loadYear`, `scoresheet-generator._changeYear`, and `score-entry-tab._populateShooterRows` — a superseded call returns instead of rendering
- The machine-detectable rule for this pattern (`innerhtml-interpolation`) already exists in `scripts/forbidden-patterns.json` (landed with WS2-07 in #202), so the ruleset half of WS3-07 was already satisfied

## Production-equivalence verification
- Admin-SDK scan of **all 8 prod seasons (6,834 rendered name strings** — team names, captains, rosters, week teamResults, shooterScores, accolades, standings rows): **zero contain `&<>"'`**, so `escapeHtml` is an identity transform on all live data — rendered output is byte-identical to https://citl.club
- Preview channel deployed from this branch: https://citl-baed2--preview-ceziogdi.web.app
- Acceptance test in the seeded emulator: injected team `<b>Bold</b> & "Co"` + shooter `<img src=x onerror=alert(1)> O'Hare` into team doc, season standings, week teamResults, and accolades → all three views render the names **literally**, DOM contains no injected `<b>`/`<img>` elements, no `alert` fires (including the scoresheet dummy-row prefix path)

## Testing
- [x] `npm run typecheck` clean
- [x] `npm test` — 228 unit tests pass
- [x] `npm run test:rules` — 47 rules tests pass
- [x] Emulator XSS acceptance test (above) passes on home standings, scorecards, and scoresheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)