### PR TITLE
fix(scoring): propagate follow-up failures, normalize names, fix cache gaps (WS-3)

### DIFF
--- a/src/components/admin-tabs/roster-modal.ts
+++ b/src/components/admin-tabs/roster-modal.ts
@@ -252,9 +252,16 @@ export function openRosterModal(opts: RosterModalOptions): void {
     const displayName = teams?.find((t) => t.id === teamId)?.name ?? teamId;
     saveBtn.disabled = true;
 
-    // Process deferred shooter removals before saving
+    // Process deferred shooter removals before saving. A failed removal
+    // aborts the save — continuing would silently drop the removal while
+    // the modal reports success (F-25).
     for (const name of pendingRemovals) {
-      await scoreService.removeShooterFromRoster(year, teamId, name);
+      const removal = await scoreService.removeShooterFromRoster(year, teamId, name);
+      if (!removal.success && removal.code !== 'NOT_FOUND') {
+        saveBtn.disabled = false;
+        showToast('error', `Failed to remove ${name}: ${removal.error}`);
+        return;
+      }
     }
     pendingRemovals.length = 0;
 

--- a/src/components/admin-tabs/team-management-tab.ts
+++ b/src/components/admin-tabs/team-management-tab.ts
@@ -312,6 +312,11 @@ export class TeamManagementTab implements AdminTab {
     if (result.success) {
       showToast('success', `Team "${teamName}" deleted from ${year}.`);
       void this._ctx?.refreshTeams();
+    } else if (result.code === 'STANDINGS_RECOMPUTE_FAILED') {
+      // The team is gone; only the standings refresh failed. Republishing a
+      // week (or retrying the delete flow) rebuilds them.
+      showToast('warning', `Team "${teamName}" deleted, but standings recompute failed — republish a week to rebuild standings.`);
+      void this._ctx?.refreshTeams();
     } else {
       showToast('error', `Failed to delete team: ${result.error}`);
     }

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -287,7 +287,10 @@ export class ScoreRepository {
       const q = query(
         collection(this.db, 'seasons', String(year), 'entries'),
         where('weekNumber', '<=', maxWeekNumber),
-        limit(maxWeekNumber * 10),
+        // Fixed bound: 15 weeks × the 20-team cap getTeams enforces. The old
+        // maxWeekNumber*10 silently clipped an 11+-team season when
+        // publishing week 1 (F-47).
+        limit(15 * 20),
       );
       const snap = await getDocs(q);
       const entries: SeasonEntry[] = [];

--- a/src/services/score-service.test.ts
+++ b/src/services/score-service.test.ts
@@ -14,10 +14,10 @@
  * instead of the correct 40.5.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ScoreService } from './score-service';
 import { buildPriorAvgMap, computeShooterAverage } from './scoring-engine';
-import { success } from '@/repositories/score-repository';
+import { success, failure } from '@/repositories/score-repository';
 import type { ScoreRepository } from '@/repositories/score-repository';
 import type { Team, WeekResult, SeasonEntry } from '@/types/score';
 import type { Shooter } from '@/types/shooter';
@@ -846,10 +846,11 @@ describe('removeShooterFromRoster — validation', () => {
     if (!result.success) expect(result.code).toBe('NOT_FOUND');
   });
 
-  it('clears the teams cache on successful deletion', async () => {
+  it('clears the teams cache on successful removal — next getTeams hits the repository', async () => {
     const team = makeTeam('Team', [makeRosterShooter('Alice')]);
+    let getTeamsCalls = 0;
     const repo: Partial<ScoreRepository> = {
-      getTeams: async () => success([team]),
+      getTeams: async () => { getTeamsCalls++; return success([team]); },
       getTeam: async () => success(team),
       getEntry: async () => success(null),
       getAllWeekResults: async () => success([]),
@@ -857,8 +858,28 @@ describe('removeShooterFromRoster — validation', () => {
     };
     const svc = new ScoreService(repo as unknown as ScoreRepository);
     await svc.getTeams(2026); // populate cache
+    await svc.getTeams(2026); // served from cache
+    expect(getTeamsCalls).toBe(1);
     const result = await svc.removeShooterFromRoster(2026, 'team-1', 'Alice');
     expect(result.success).toBe(true);
+    await svc.getTeams(2026); // invalidated — must re-fetch
+    expect(getTeamsCalls).toBe(2);
+  });
+
+  it('returns failure when the accolade-cleanup weeks read fails (nothing written) — F-25', async () => {
+    const team = makeTeam('Team', [makeRosterShooter('Alice')]);
+    let wrote = false;
+    const repo: Partial<ScoreRepository> = {
+      getTeam: async () => success(team),
+      getEntry: async () => success(null),
+      getAllWeekResults: async () => failure('network down', 'FIRESTORE_READ_ERROR'),
+      removeShooterFromRosterAndEntries: async () => { wrote = true; return success(undefined); },
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    const result = await svc.removeShooterFromRoster(2026, 'team-1', 'Alice');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.code).toBe('FIRESTORE_READ_ERROR');
+    expect(wrote).toBe(false); // failed before any write — retry is clean
   });
 });
 
@@ -877,18 +898,110 @@ describe('deleteTeam — validation', () => {
     if (!result.success) expect(result.code).toBe('VALIDATION_ERROR');
   });
 
-  it('clears the teams cache on successful deletion', async () => {
+  it('clears the teams cache on successful deletion — next getTeams hits the repository', async () => {
+    let getTeamsCalls = 0;
     const repo: Partial<ScoreRepository> = {
-      getTeams: async () => success([]),
+      getTeams: async () => { getTeamsCalls++; return success([]); },
       deleteTeam: async () => success(undefined),
       getAllWeekResults: async () => success([]),
     };
     const svc = new ScoreService(repo as unknown as ScoreRepository);
-    // Populate cache
-    await svc.getTeams(2026);
-    // Delete clears cache
+    await svc.getTeams(2026); // populate cache
+    await svc.getTeams(2026); // served from cache
+    expect(getTeamsCalls).toBe(1);
     const result = await svc.deleteTeam(2026, 'team-1');
     expect(result.success).toBe(true);
+    await svc.getTeams(2026); // invalidated — must re-fetch
+    expect(getTeamsCalls).toBe(2);
+  });
+
+  it('returns STANDINGS_RECOMPUTE_FAILED when the weeks read fails after deletion (F-25)', async () => {
+    const repo: Partial<ScoreRepository> = {
+      deleteTeam: async () => success(undefined),
+      getAllWeekResults: async () => failure('network down', 'FIRESTORE_READ_ERROR'),
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    const result = await svc.deleteTeam(2026, 'team-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.code).toBe('STANDINGS_RECOMPUTE_FAILED');
+  });
+
+  it('returns STANDINGS_RECOMPUTE_FAILED when the standings write fails after deletion (F-25)', async () => {
+    const repo: Partial<ScoreRepository> = {
+      deleteTeam: async () => success(undefined),
+      getAllWeekResults: async () => success([makeWeekResult([{ name: 'A', total: 40 }])]),
+      updateSeason: async () => failure('write denied', 'FIRESTORE_WRITE_ERROR'),
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    const result = await svc.deleteTeam(2026, 'team-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.code).toBe('STANDINGS_RECOMPUTE_FAILED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache behavior — hit, TTL expiry, null caching, prior-year routing
+// ---------------------------------------------------------------------------
+
+describe('ScoreService cache (F-30, F-48)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('getTeams: repeated calls within TTL issue exactly one repository read', async () => {
+    let calls = 0;
+    const repo: Partial<ScoreRepository> = {
+      getTeams: async () => { calls++; return success([]); },
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    await svc.getTeams(2026);
+    await svc.getTeams(2026);
+    await svc.getTeams(2026);
+    expect(calls).toBe(1);
+  });
+
+  it('getTeams: re-fetches after CACHE_TTL_MS (1 hr) expires', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const repo: Partial<ScoreRepository> = {
+      getTeams: async () => { calls++; return success([]); },
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    await svc.getTeams(2026);
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+    await svc.getTeams(2026);
+    expect(calls).toBe(2);
+  });
+
+  it('getSeason: caches null — repeated lookups of a missing season hit the repo once (F-48)', async () => {
+    let calls = 0;
+    const repo: Partial<ScoreRepository> = {
+      getSeason: async () => { calls++; return success(null); },
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    const r1 = await svc.getSeason(2030);
+    const r2 = await svc.getSeason(2030);
+    expect(r1.success && r1.data === null).toBe(true);
+    expect(r2.success && r2.data === null).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it('computeRosterDefaults: prior-year reads are cached — second call issues no new repo reads (F-48)', async () => {
+    const team = makeTeam('Team', [makeShooter('Alice', 40)]);
+    let teamsCalls = 0;
+    let weeksCalls = 0;
+    const repo: Partial<ScoreRepository> = {
+      getTeam: async () => success(team),
+      getTeams: async () => { teamsCalls++; return success([]); },
+      getAllWeekResults: async () => { weeksCalls++; return success([]); },
+    };
+    const svc = new ScoreService(repo as unknown as ScoreRepository);
+    await svc.computeRosterDefaults(2026, 'team');
+    expect(teamsCalls).toBe(2); // year-1 and year-2
+    expect(weeksCalls).toBe(2);
+    await svc.computeRosterDefaults(2026, 'team');
+    expect(teamsCalls).toBe(2); // served from cache
+    expect(weeksCalls).toBe(2);
   });
 });
 
@@ -1190,6 +1303,48 @@ describe('publishWeek — dummy auto-injection via _buildSeasonData', () => {
     const dummies = shooterScores.filter((s) => s.name.toUpperCase().includes('DUMMY'));
     expect(dummies).toHaveLength(0);
     expect(capturedWr?.teamResults[0]?.targets).toBe(200); // 5 × 40
+  });
+});
+
+describe('publishWeek — shooter-name normalization (F-51)', () => {
+  it('matches a case-variant entry name to the rostered shooter — no phantom 35-avg duplicate', async () => {
+    // Roster spelling is "John Smith" with a 45 going-in average; the saved
+    // entry says "john smith". Pre-fix, the mismatch spawned a phantom
+    // substitute with a fresh 35 average: team targets 220 then beat the
+    // (wrong) going-in sum 4×45+35=215 and awarded a +5 bonus. Post-fix the
+    // going-in sum is 5×45=225 and no bonus is due.
+    const entry = makeEntry({
+      weekNumber: 1,
+      teamId: 'alphas',
+      teamName: 'Alphas',
+      shooters: ['john smith', 'Bob', 'Cal', 'Dan', 'Ed'].map((name) => ({
+        name, score1: 22, score2: 22,
+      })),
+    });
+    const team: Team = {
+      id: 'alphas',
+      name: 'Alphas',
+      captain: '',
+      shooters: ['John Smith', 'Bob', 'Cal', 'Dan', 'Ed'].map((n) => makeShooter(n, 45)),
+      totals: { targets: [], rankPoints: [], bonusPoints: [] },
+    };
+    let captured: WeekResult | undefined;
+    const svc = new ScoreService(makePublishRepo({
+      entries: [entry],
+      teams: [team],
+      onPublish: (wr) => { captured = wr; },
+    }));
+    const result = await svc.publishWeek(2026, 1);
+    expect(result.success).toBe(true);
+
+    const tr = captured!.teamResults.find((t) => t.teamName === 'Alphas')!;
+    const johns = tr.shooterScores.filter(
+      (s) => s.name.toLowerCase().trim() === 'john smith',
+    );
+    expect(johns).toHaveLength(1); // no roster+entry duplicate
+    expect(tr.shooterScores).toHaveLength(5); // exactly the 5 entry shooters
+    expect(tr.targets).toBe(220);
+    expect(tr.bonusPoints).toBe(0); // phantom 35-avg shooter would have made this 5
   });
 });
 

--- a/src/services/score-service.ts
+++ b/src/services/score-service.ts
@@ -67,7 +67,9 @@ export class ScoreService {
     if (cached !== undefined) return success(cached);
 
     const result = await this.repository.getSeason(year);
-    if (result.success && result.data) setCache(this.cache, cacheKey, result.data);
+    // Cache nulls too — a nonexistent season is as cacheable as a real one,
+    // and skipping it made every repeat lookup a fresh Firestore read (F-48).
+    if (result.success) setCache(this.cache, cacheKey, result.data);
     return result;
   }
 
@@ -116,7 +118,7 @@ export class ScoreService {
     if (cached !== undefined) return success(cached);
 
     const result = await this.repository.getWeekResult(year, weekNumber);
-    if (result.success && result.data) setCache(this.cache, cacheKey, result.data);
+    if (result.success) setCache(this.cache, cacheKey, result.data);
     return result;
   }
 
@@ -144,7 +146,7 @@ export class ScoreService {
     if (cached !== undefined) return success(cached);
 
     const result = await this.repository.getLatestWeekResult(year);
-    if (result.success && result.data) setCache(this.cache, cacheKey, result.data);
+    if (result.success) setCache(this.cache, cacheKey, result.data);
     return result;
   }
 
@@ -252,9 +254,13 @@ export class ScoreService {
       );
       // DNS shooters and auto-created dummy positions were given computed dummy scores in
       // _buildSeasonData. Include all of them in shooterScores (score1/score2 null = computed).
-      const entryShooterNames = new Set(teamEntry?.shooters.map((s) => s.name) ?? []);
+      // Compare normalized so a case/whitespace variant in the saved entry
+      // doesn't duplicate the roster shooter here (F-51).
+      const entryShooterNames = new Set(
+        teamEntry?.shooters.map((s) => normalizeShooterName(s.name)) ?? [],
+      );
       const extraScores: ShooterScore[] = team.shooters
-        .filter((s) => !entryShooterNames.has(s.name) && s.scores[wi] !== null)
+        .filter((s) => !entryShooterNames.has(normalizeShooterName(s.name)) && s.scores[wi] !== null)
         .map((s) => ({ name: s.name, score1: null, score2: null, total: s.scores[wi] as number }));
       return {
         teamId: resolveTeamId(team.name),
@@ -353,7 +359,13 @@ export class ScoreService {
     };
 
     const result = await this.repository.createTeam(year, teamId, newTeam);
-    if (result.success) this.cache.delete(`teams:${year}`);
+    if (result.success) {
+      this.cache.delete(`teams:${year}`);
+      // createTeam also seeds the season doc; drop any cached null/stale
+      // season so the new year appears without waiting out the TTL (F-48).
+      this.cache.delete(`season:${year}`);
+      this.cache.delete('seasons:all');
+    }
     return result;
   }
 
@@ -363,13 +375,15 @@ export class ScoreService {
     }
     if (!teamId) return failure('teamId is required', 'VALIDATION_ERROR');
 
-    // Fire all five reads in parallel — one round-trip
+    // Fire all five reads in parallel — one round-trip. Prior-year reads go
+    // through the cached getters so repeated modal opens don't re-query
+    // immutable history (F-48); year-of-range failures degrade to [] below.
     const [currentResult, prior1Result, prior2Result, prior1WeeksResult, prior2WeeksResult] = await Promise.all([
       this.repository.getTeam(year, teamId),
-      this.repository.getTeams(year - 1),
-      this.repository.getTeams(year - 2),
-      this.repository.getAllWeekResults(year - 1),
-      this.repository.getAllWeekResults(year - 2),
+      this.getTeams(year - 1),
+      this.getTeams(year - 2),
+      this.getAllWeekResults(year - 1),
+      this.getAllWeekResults(year - 2),
     ]);
 
     if (!currentResult.success) return currentResult;
@@ -413,10 +427,10 @@ export class ScoreService {
       return failure('shooterName is required', 'VALIDATION_ERROR');
 
     const [prior1Result, prior2Result, prior1WeeksResult, prior2WeeksResult] = await Promise.all([
-      this.repository.getTeams(year - 1),
-      this.repository.getTeams(year - 2),
-      this.repository.getAllWeekResults(year - 1),
-      this.repository.getAllWeekResults(year - 2),
+      this.getTeams(year - 1),
+      this.getTeams(year - 2),
+      this.getAllWeekResults(year - 1),
+      this.getAllWeekResults(year - 2),
     ]);
 
     const prior1Teams = prior1Result.success ? prior1Result.data : [];
@@ -512,19 +526,35 @@ export class ScoreService {
     if (!teamId) return failure('teamId is required', 'VALIDATION_ERROR');
 
     const result = await this.repository.deleteTeam(year, teamId);
-    if (result.success) {
-      this.cache.delete(`teams:${year}`);
-      this.cache.delete(`weeks:${year}`);
-      this.cache.delete(`latest:${year}`);
-      this.cache.delete(`season:${year}`);
-      for (let w = 1; w <= 15; w++) this.cache.delete(`week:${year}:${w}`);
+    if (!result.success) return result;
 
-      // Recompute standings from the updated week docs (deleted team already removed by repo)
-      const weeksResult = await this.repository.getAllWeekResults(year);
-      if (weeksResult.success && weeksResult.data.length > 0) {
-        const newStandings = _recomputeStandingsFromWeeks(weeksResult.data);
-        await this.repository.updateSeason(year, { standings: newStandings } as Partial<Season>);
-        this.cache.delete(`season:${year}`);
+    this.cache.delete(`teams:${year}`);
+    this.cache.delete(`weeks:${year}`);
+    this.cache.delete(`latest:${year}`);
+    this.cache.delete(`season:${year}`);
+    for (let w = 1; w <= 15; w++) this.cache.delete(`week:${year}:${w}`);
+
+    // Recompute standings from the updated week docs (deleted team already
+    // removed by repo). The team IS deleted at this point, so a follow-up
+    // failure must not read as "delete failed" — it returns the dedicated
+    // STANDINGS_RECOMPUTE_FAILED code so the UI can say "deleted, but
+    // standings are stale — retry" (F-25).
+    const weeksResult = await this.repository.getAllWeekResults(year);
+    if (!weeksResult.success) {
+      return failure(
+        `Team deleted, but standings recompute failed: ${weeksResult.error}`,
+        'STANDINGS_RECOMPUTE_FAILED',
+      );
+    }
+    if (weeksResult.data.length > 0) {
+      const newStandings = _recomputeStandingsFromWeeks(weeksResult.data);
+      const update = await this.repository.updateSeason(year, { standings: newStandings } as Partial<Season>);
+      this.cache.delete(`season:${year}`);
+      if (!update.success) {
+        return failure(
+          `Team deleted, but standings recompute failed: ${update.error}`,
+          'STANDINGS_RECOMPUTE_FAILED',
+        );
       }
     }
     return result;
@@ -586,18 +616,19 @@ export class ScoreService {
       });
     }
 
-    // Compute accolade patches: remove the shooter's accolades from any published weeks
+    // Compute accolade patches: remove the shooter's accolades from any published weeks.
+    // Nothing has been written yet, so a failed read is a clean hard failure —
+    // proceeding would silently skip the accolade cleanup (F-25).
     const weekAccoladePatches: { weekNumber: number; accolades: NonNullable<WeekResult['accolades']> }[] = [];
     const weeksResult = await this.repository.getAllWeekResults(year);
-    if (weeksResult.success) {
-      for (const wr of weeksResult.data) {
-        if (!wr.accolades || wr.accolades.length === 0) continue;
-        const filtered = wr.accolades.filter(
-          (a) => normalizeShooterName(a.shooterName) !== normalizedTarget,
-        );
-        if (filtered.length !== wr.accolades.length) {
-          weekAccoladePatches.push({ weekNumber: wr.weekNumber, accolades: filtered });
-        }
+    if (!weeksResult.success) return weeksResult;
+    for (const wr of weeksResult.data) {
+      if (!wr.accolades || wr.accolades.length === 0) continue;
+      const filtered = wr.accolades.filter(
+        (a) => normalizeShooterName(a.shooterName) !== normalizedTarget,
+      );
+      if (filtered.length !== wr.accolades.length) {
+        weekAccoladePatches.push({ weekNumber: wr.weekNumber, accolades: filtered });
       }
     }
 
@@ -752,14 +783,17 @@ function _buildSeasonData(
   const teams = firestoreTeams.map((firestoreTeam) => {
     const teamEntries = entryMap.get(firestoreTeam.name) ?? new Map<number, SeasonEntry>();
 
-    const seenNames = new Set<string>();
+    // Track entry shooters by normalized name (display spelling as the value)
+    // so a case/whitespace variant of a rostered shooter never spawns a
+    // phantom substitute row with a fresh 35 average (F-51).
+    const seenNames = new Map<string, string>();
     for (const [wn, entry] of teamEntries) {
       if (wn > maxWeek) continue;
-      for (const s of entry.shooters) seenNames.add(s.name);
+      for (const s of entry.shooters) seenNames.set(normalizeShooterName(s.name), s.name);
     }
 
     const rosterShooters: ScorecardShooter[] = (firestoreTeam.shooters ?? []).map((rs) => {
-      seenNames.delete(rs.name);
+      seenNames.delete(normalizeShooterName(rs.name));
       return {
         name: rs.name,
         rookie: rs.rookie ?? false,
@@ -771,7 +805,7 @@ function _buildSeasonData(
       };
     });
 
-    const subShooters: ScorecardShooter[] = [...seenNames].map((name) => ({
+    const subShooters: ScorecardShooter[] = [...seenNames.values()].map((name) => ({
       name,
       rookie: false,
       isDummy: isDummyName(name),
@@ -788,7 +822,8 @@ function _buildSeasonData(
       if (!entry) continue;
       const wi = wn - 1;
       for (const entryShooter of entry.shooters) {
-        const shooter = shooters.find((s) => s.name === entryShooter.name);
+        const entryKey = normalizeShooterName(entryShooter.name);
+        const shooter = shooters.find((s) => normalizeShooterName(s.name) === entryKey);
         if (shooter) shooter.scores[wi] = entryShooter.total;
       }
 


### PR DESCRIPTION
## Summary
- Executes **WS3-08 (F-25)**, **WS3-12 (F-30)**, **WS3-15 (F-51)**, **WS3-16 (F-47)**, and **WS3-17 (F-48)** from `.specs/reviews/2026-07-deep-review/backlog.md`
- `deleteTeam`/`removeShooterFromRoster` reported unconditional success even when their follow-up reads/writes failed, leaving standings stale or accolades uncleaned with no signal to the admin
- Case-variant shooter names in saved entries corrupted publish math; `getEntries` had an implicit 10-team ceiling; the service cache had inconsistent routing and never cached nulls; the cache tests asserted nothing about caching

## Changes
- `score-service.ts` deleteTeam: a failed standings recompute after deletion returns `STANDINGS_RECOMPUTE_FAILED` instead of success; `team-management-tab.ts` shows a warning toast ("deleted, but standings recompute failed — republish a week") and still refreshes the list
- `score-service.ts` removeShooterFromRoster: a failed accolade-cleanup weeks read aborts **before any write** (clean retry); `roster-modal.ts` aborts its save when a deferred removal fails instead of silently dropping it
- Publish path (F-51): `_buildSeasonData` tracks entry shooters by `normalizeShooterName` key (display spelling preserved) and matches scores normalized; `publishWeek`'s DNS/extra-scores set compares normalized — "john smith" in an entry now matches rostered "John Smith" instead of spawning a phantom 35-average substitute that flips the +5 target bonus
- `score-repository.ts` getEntries: `limit(15 * 20)` (15 weeks × the 20-team cap `getTeams` enforces) replaces `limit(maxWeekNumber * 10)`, which clipped 11+-team seasons when publishing week 1 (F-47)
- Cache consistency (F-48): `computeRosterDefaults`/`computeShooterDefaults` prior-year reads go through the cached `getTeams`/`getAllWeekResults`; `getSeason`/`getWeekResult`/`getLatestWeekResult` cache null results; `createTeam` invalidates `season:{year}` + `seasons:all` (it seeds the season doc)
- Real cache tests (F-30): the two "clears the teams cache" tests now count repository calls across delete→getTeams; added a cache-hit test, a `vi.useFakeTimers` TTL-expiry test, a cached-null test, and a computeRosterDefaults call-count test

## Behavior notes
- No public page renders differently for existing data — the normalization only changes what a **future publish** writes when an entry's spelling differs from the roster (the bug being fixed)
- Mutation-verified: deleting a `this.cache.delete('teams:…')` line fails 2 tests

## Testing
- [x] `npm run typecheck` clean
- [x] `npm test` — 236 unit tests pass (8 new)
- [x] `npm run test:rules` — 47 rules tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)