### PR TITLE
fix(announcements): bound the query server-side; declare the composite index (WS-3)

### DIFF
--- a/.specs/technical/firestore-schema.md
+++ b/.specs/technical/firestore-schema.md
@@ -120,9 +120,11 @@ Auto-ID via `addDoc`.
 
 **Access:** Read — public. Write — admin only.
 
-**Query:** `where('year', '==', year)`, then sorted by `postedAt desc` **in memory**
-(`getAnnouncements` in `src/repositories/score-repository.ts`). Sorting client-side is a
-deliberate choice so the query needs no composite index — `firestore.indexes.json` is empty.
+**Query:** `where('year', '==', year)` + `orderBy('postedAt', 'desc')` + `limit(20)`
+(`getAnnouncements` in `src/repositories/score-repository.ts`). Backed by the
+`year ASC, postedAt DESC` composite index declared in `firestore.indexes.json` — the only
+composite index in the project. That file is the source of truth: CI deploys it with
+`--force`, which deletes any console-created index absent from it.
 
 **TypeScript interface:** `Announcement` — `src/types/announcement.ts`
 
@@ -257,7 +259,8 @@ overwritten any number of times before the week is published.
 queries by week number (`weekNumber <= maxWeekNumber`) without a composite index.
 
 **No composite index needed:** range queries on `weekNumber` rely on Firestore's automatic
-single-field index. `firestore.indexes.json` is empty.
+single-field index. (The only composite index in `firestore.indexes.json` belongs to
+`announcements` — see above.)
 
 **TypeScript interface:** `SeasonEntry` — `src/types/score.ts`
 
@@ -304,15 +307,16 @@ and from `accolades` in any published week.
 
 ## Composite Indexes Required
 
-**None.** `firestore.indexes.json` is empty by design (`{"indexes": [], "fieldOverrides": []}`),
-and CI deploys it with `--force`.
+**One**, declared in `firestore.indexes.json` (the source of truth — CI deploys it with
+`--force`, which deletes any console-created index absent from the file):
 
-Every query in the codebase is served by a direct document-ID lookup, an automatic
-single-field index, or an equality filter followed by an in-memory sort:
+- `announcements` — `year ASC, postedAt DESC`, backing
+  `where('year', '==', year) + orderBy('postedAt', 'desc') + limit(20)`
+  (`getAnnouncements` in `src/repositories/score-repository.ts`, F-24).
 
-- `announcements` — `where('year', '==', year)` then sorts by `postedAt desc` in memory
-  (`getAnnouncements` in `src/repositories/score-repository.ts`), avoiding a `year` +
-  `postedAt` composite index.
+Every other query is served by a direct document-ID lookup or an automatic single-field
+index:
+
 - `seasons/{year}/entries` — range queries on `weekNumber` use the automatic single-field
   index; the `"{weekNumber}_{teamId}"` composite ID also lets the repository build entry
   references directly with no query at all.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,15 @@
 {
-  "indexes": [],
+  "$comment": "Source of truth for composite indexes. CI deploys this file with --force, which DELETES any console-created index that is not declared here — always add indexes to this file, never only in the console.",
+  "indexes": [
+    {
+      "$comment": "getAnnouncements: where('year','==',N) + orderBy('postedAt','desc') (score-repository.ts, F-24).",
+      "collectionGroup": "announcements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "year", "order": "ASCENDING" },
+        { "fieldPath": "postedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/src/repositories/score-repository.ts
+++ b/src/repositories/score-repository.ts
@@ -540,13 +540,16 @@ export class ScoreRepository {
 
   async getAnnouncements(year: number): Promise<Result<Announcement[]>> {
     try {
+      // Server-side order + bound (F-24). Requires the year+postedAt
+      // composite index declared in firestore.indexes.json.
       const q = query(
         collection(this.db, 'announcements'),
         where('year', '==', year),
+        orderBy('postedAt', 'desc'),
+        limit(20),
       );
       const snap = await getDocs(q);
       const announcements = snap.docs.map((d) => ({ id: d.id, ...d.data() } as Announcement));
-      announcements.sort((a, b) => b.postedAt.toMillis() - a.postedAt.toMillis());
       return success(announcements);
     } catch (err) {
       return failure(`Failed to load announcements: ${(err as Error).message}`, 'FIRESTORE_ERROR');


### PR DESCRIPTION
## Summary
- Executes **WS3-11 (F-24)** from `.specs/reviews/2026-07-deep-review/backlog.md`
- `getAnnouncements` fetched every announcement doc for a year unbounded and sorted client-side; `firestore.indexes.json` was empty while claiming to be the declared index source CI force-deploys

## Changes
- `score-repository.ts` getAnnouncements: `where('year','==',year) + orderBy('postedAt','desc') + limit(20)`, in-memory sort removed
- `firestore.indexes.json`: declare the backing `announcements(year ASC, postedAt DESC)` composite index, with a `$comment` warning that the CI deploy's `--force` deletes any console-created index absent from the file (verified: firebase-tools v15 `validateSpec` accepts the `$comment` keys)
- `.specs/technical/firestore-schema.md`: the three "indexes.json is empty by design / announcements sorts in memory" passages now describe the declared index (coordinates with WS1-07's index section)

## Deploy sequencing
I attempted to pre-deploy the index (`firebase deploy --only firestore:indexes`) per the backlog's "deploy the index before/with the query change", but prod deploys are outside this session's permissions. Two options:
1. Run `npx firebase deploy --only firestore:indexes` yourself before merging (safest), or
2. Just merge — deploy-production deploys `firestore:indexes` in the same run that ships hosting; the collection is 13 docs so the index backfills in seconds, and browsers keep serving the old (index-free) bundle for up to an hour anyway.

## Behavior equivalence
- Prod has **13 announcements, all year 2026** (admin-SDK count) — under the limit, and the server order equals the old in-memory sort (same field, same direction), so rendered output is identical
- The changed method verified against the seeded emulator via the dev server: returns rows ordered `postedAt desc`

## Testing
- [x] `npm run typecheck` clean
- [x] `npm test` — 228 unit tests pass
- [x] `npm run test:rules` — 47 rules tests pass
- [x] firebase-tools `validateSpec` accepts the new indexes file (same validation the CI deploy runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)