### PR TITLE
test(repository): emulator tests for rename/delete cascades; coverage script (WS-3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.0",
         "@types/dompurify": "^3.0.5",
+        "@vitest/coverage-v8": "^4.1.10",
         "firebase-admin": "^13.0.0",
         "firebase-functions-test": "^3.4.1",
         "firebase-tools": "^15.0.0",
@@ -354,7 +355,6 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -365,7 +365,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -402,7 +401,6 @@
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -711,7 +709,6 @@
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -4236,9 +4233,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4776,32 +4773,73 @@
       ],
       "peer": true
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4810,7 +4848,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4822,26 +4860,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4849,14 +4887,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4865,9 +4903,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4875,15 +4913,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5267,6 +5305,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -9278,8 +9335,7 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -9826,7 +9882,6 @@
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9855,7 +9910,6 @@
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -9871,7 +9925,6 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -9904,7 +9957,6 @@
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -11488,6 +11540,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -15349,19 +15413,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -15372,8 +15436,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -15389,13 +15453,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -15414,6 +15480,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "grant-admin": "node scripts/grant-admin.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:rules": "firebase emulators:exec --only firestore --project citl-rules-test 'vitest run --config tests/rules/vitest.config.ts'",
     "test:functions": "firebase emulators:exec --only auth,firestore --project citl-fn-test 'vitest run --config tests/functions/vitest.config.ts'"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.0",
     "@types/dompurify": "^3.0.5",
+    "@vitest/coverage-v8": "^4.1.10",
     "firebase-admin": "^13.0.0",
     "firebase-functions-test": "^3.4.1",
     "firebase-tools": "^15.0.0",

--- a/tests/rules/repository-cascades.test.ts
+++ b/tests/rules/repository-cascades.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Emulator tests for ScoreRepository's multi-document cascades (F-29):
+ * cascadeTeamRename and deleteTeam — the highest-risk batch logic in the
+ * repository, previously covered by zero tests.
+ *
+ * Reuses the rules-test harness (same emulator, same CI job). The repository
+ * runs through an admin-role context, so these tests also prove the batches
+ * are permitted by the live security rules, not just by the Admin SDK.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import type { RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { asRole, seed, setupTestEnv } from './_helpers.js';
+import { ScoreRepository } from '../../src/repositories/score-repository';
+
+let env: RulesTestEnvironment;
+
+beforeAll(async () => { env = await setupTestEnv(); });
+beforeEach(async () => {
+  await env.clearFirestore();
+  await seedSeasonData();
+});
+afterAll(async () => { await env.cleanup(); });
+
+const YEAR = 2026;
+
+function adminRepo(): ScoreRepository {
+  return new ScoreRepository(asRole(env, 'admin-uid', 'admin'));
+}
+
+/** Read a doc's data through the privileged context (bypasses rules). */
+async function readDoc(...path: [string, ...string[]]): Promise<Record<string, unknown> | null> {
+  let out: Record<string, unknown> | null = null;
+  await seed(env, async (db) => {
+    const snap = await getDoc(doc(db, ...path));
+    out = snap.exists() ? (snap.data() as Record<string, unknown>) : null;
+  });
+  return out;
+}
+
+interface SeededTeamResult { teamId: string; teamName: string; [k: string]: unknown }
+interface SeededAccolade { shooterName: string; teamName: string; [k: string]: unknown }
+
+async function seedSeasonData(): Promise<void> {
+  await seed(env, async (db) => {
+    await setDoc(doc(db, 'seasons', String(YEAR)), {
+      year: YEAR,
+      status: 'active',
+      currentWeek: 2,
+      standings: [
+        { rank: 1, teamId: 'eagles', teamName: 'Eagles', totalRankPoints: 60, totalBonusPoints: 10, totalTargets: 400 },
+        { rank: 2, teamId: 'hawks', teamName: 'Hawks', totalRankPoints: 56, totalBonusPoints: 8, totalTargets: 380 },
+      ],
+    });
+    await setDoc(doc(db, 'seasons', String(YEAR), 'teams', 'eagles'), { name: 'Eagles', captain: 'Alice', shooters: [] });
+    await setDoc(doc(db, 'seasons', String(YEAR), 'teams', 'hawks'), { name: 'Hawks', captain: 'Bob', shooters: [] });
+    for (const wk of [1, 2]) {
+      await setDoc(doc(db, 'seasons', String(YEAR), 'entries', `${wk}_eagles`), {
+        weekNumber: wk, teamId: 'eagles', teamName: 'Eagles',
+        shooters: [{ name: 'Alice', score1: 20, score2: 20, total: 40 }],
+      });
+      await setDoc(doc(db, 'seasons', String(YEAR), 'entries', `${wk}_hawks`), {
+        weekNumber: wk, teamId: 'hawks', teamName: 'Hawks',
+        shooters: [{ name: 'Bob', score1: 19, score2: 19, total: 38 }],
+      });
+      await setDoc(doc(db, 'seasons', String(YEAR), 'weeks', String(wk)), {
+        weekNumber: wk,
+        publishedAt: `2026-03-1${wk}`,
+        teamResults: [
+          { teamId: 'eagles', teamName: 'Eagles', targets: 200, rankPoints: 30, bonusPoints: 5, shooterScores: [{ name: 'Alice', score1: 20, score2: 20, total: 40 }] },
+          { teamId: 'hawks', teamName: 'Hawks', targets: 190, rankPoints: 28, bonusPoints: 4, shooterScores: [{ name: 'Bob', score1: 19, score2: 19, total: 38 }] },
+        ],
+        accolades: [{ shooterName: 'Alice', teamName: 'Eagles', streak: 25, weekNumber: wk }],
+      });
+    }
+  });
+}
+
+describe('cascadeTeamRename', () => {
+  it('renames the team in every entry and every published week; other teams untouched', async () => {
+    const result = await adminRepo().cascadeTeamRename(YEAR, 'eagles', 'Eagles', 'Falcons');
+    expect(result.success).toBe(true);
+
+    for (const wk of [1, 2]) {
+      const eaglesEntry = await readDoc('seasons', String(YEAR), 'entries', `${wk}_eagles`);
+      expect(eaglesEntry?.['teamName']).toBe('Falcons');
+      const hawksEntry = await readDoc('seasons', String(YEAR), 'entries', `${wk}_hawks`);
+      expect(hawksEntry?.['teamName']).toBe('Hawks');
+
+      const week = await readDoc('seasons', String(YEAR), 'weeks', String(wk));
+      const results = week?.['teamResults'] as SeededTeamResult[];
+      expect(results.find((tr) => tr.teamId === 'eagles')?.teamName).toBe('Falcons');
+      expect(results.find((tr) => tr.teamId === 'hawks')?.teamName).toBe('Hawks');
+    }
+  });
+
+  it('is a no-op for a name that appears nowhere', async () => {
+    const result = await adminRepo().cascadeTeamRename(YEAR, 'ghosts', 'Ghosts', 'Specters');
+    expect(result.success).toBe(true);
+    const week = await readDoc('seasons', String(YEAR), 'weeks', '1');
+    const results = week?.['teamResults'] as SeededTeamResult[];
+    expect(results.map((tr) => tr.teamName).sort()).toEqual(['Eagles', 'Hawks']);
+  });
+});
+
+describe('deleteTeam', () => {
+  it('removes the team doc, its entries, its teamResults/accolades, and its standings row', async () => {
+    const result = await adminRepo().deleteTeam(YEAR, 'eagles');
+    expect(result.success).toBe(true);
+
+    expect(await readDoc('seasons', String(YEAR), 'teams', 'eagles')).toBeNull();
+    for (const wk of [1, 2]) {
+      expect(await readDoc('seasons', String(YEAR), 'entries', `${wk}_eagles`)).toBeNull();
+
+      const week = await readDoc('seasons', String(YEAR), 'weeks', String(wk));
+      const results = week?.['teamResults'] as SeededTeamResult[];
+      expect(results.map((tr) => tr.teamId)).toEqual(['hawks']);
+      // Accolades belonging to the deleted team are cascade-removed too
+      expect((week?.['accolades'] as SeededAccolade[])).toHaveLength(0);
+    }
+
+    const season = await readDoc('seasons', String(YEAR));
+    const standings = season?.['standings'] as { teamId: string }[];
+    expect(standings.map((s) => s.teamId)).toEqual(['hawks']);
+  });
+
+  it('leaves the other team fully intact', async () => {
+    const result = await adminRepo().deleteTeam(YEAR, 'eagles');
+    expect(result.success).toBe(true);
+
+    const hawks = await readDoc('seasons', String(YEAR), 'teams', 'hawks');
+    expect(hawks?.['name']).toBe('Hawks');
+    for (const wk of [1, 2]) {
+      const entry = await readDoc('seasons', String(YEAR), 'entries', `${wk}_hawks`);
+      expect(entry?.['teamName']).toBe('Hawks');
+      const week = await readDoc('seasons', String(YEAR), 'weeks', String(wk));
+      const results = week?.['teamResults'] as SeededTeamResult[];
+      expect(results.find((tr) => tr.teamId === 'hawks')?.['targets']).toBe(190);
+    }
+  });
+
+  it('deleting a nonexistent team succeeds without disturbing existing data', async () => {
+    const result = await adminRepo().deleteTeam(YEAR, 'ghosts');
+    expect(result.success).toBe(true);
+    const week = await readDoc('seasons', String(YEAR), 'weeks', '1');
+    expect((week?.['teamResults'] as SeededTeamResult[])).toHaveLength(2);
+    const season = await readDoc('seasons', String(YEAR));
+    expect((season?.['standings'] as unknown[])).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Executes **WS3-13 (F-29)** from `.specs/reviews/2026-07-deep-review/backlog.md`
- `cascadeTeamRename` and `deleteTeam` are the repository's two multi-document batch cascades — a regression there corrupts entries, published weeks, accolades, or standings — and they had zero test coverage
- The repo had no way to measure the coverage gap (zero tests under src/components, src/views, src/modules, src/repositories)

## Changes
- `tests/rules/repository-cascades.test.ts` (5 tests): rename cascades to every entry + published week without touching other teams (plus a no-op case); delete removes the team doc, its entries, its `teamResults`, its accolades, and its standings row while leaving the other team fully intact (plus a nonexistent-team case)
- Tests reuse the rules-test harness and run `ScoreRepository` through an **admin-role context**, so they execute in the existing `test-rules` CI job and additionally prove the batches pass the live security rules (an Admin-SDK harness would have masked a rules regression)
- `@vitest/coverage-v8` devDependency + non-gating `"test:coverage": "vitest run --coverage"` script — current baseline: 58.4% statements overall; repositories at 9.8% (now measurable). No percentage gate, per the backlog's "do NOT chase a coverage number"

## Testing
- [x] `npm run typecheck` clean
- [x] `npm test` — 228 unit tests pass
- [x] `npm run test:rules` — 52 tests pass (47 rules + 5 new cascade tests)
- [x] `npm run test:coverage` produces the v8 text report

🤖 Generated with [Claude Code](https://claude.com/claude-code)