### PR TITLE
fix(hosting): serve HTML shell with no-cache (WS4-04)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -56,7 +56,7 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "public, max-age=3600, must-revalidate"
+            "value": "no-cache"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Ends the up-to-1-hour stale-shell window after every deploy: `**/*.html` previously served with `public, max-age=3600, must-revalidate`, so returning visitors kept an old `index.html` (and, in a rare eviction race, a blank page referencing purged hashed assets).
- Executes WS4-04 from [.specs/reviews/2026-07-deep-review/backlog.md](../blob/main/.specs/reviews/2026-07-deep-review/backlog.md) (finding F-04).

## Changes
- `firebase.json`: `**/*.html` Cache-Control changed from `public, max-age=3600, must-revalidate` to `no-cache` (revalidate every navigation; ~4 KB shell → one 304 per visit).
- Hashed assets (`js|css|svg|png|…`) keep the immutable 1-year policy — untouched.

## Testing
- [x] `npm run typecheck` — clean
- [x] `npm test` — 236/236 unit tests pass
- [x] `npm run build` — succeeds
- [x] `npm run test:rules` and `npm run test:functions` — emulator suites pass
- [ ] Post-deploy: `curl -sI https://citl.club/ | grep -i cache-control` shows `no-cache`; hashed assets still serve `immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)