### PR TITLE
fix(hosting): apply no-cache to the SPA shell path "/"

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -61,6 +61,15 @@
         ]
       },
       {
+        "source": "/",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
         "source": "**",
         "headers": [
           {


### PR DESCRIPTION
## Summary
- Completes F-04/WS4-04: post-deploy verification of #211 showed `/index.html` serving `no-cache` but `https://citl.club/` still serving `max-age=3600` — Firebase's **default**, not our configured value.
- Root cause: Hosting matches header globs against the *request path*, not the file the SPA rewrite serves. `**/*.html` never matched `/`, so the shell URL every visitor hits (hash routing) was never governed by our header config at all — including before #211.

## Changes
- `firebase.json`: add a headers block for `"source": "/"` with `Cache-Control: no-cache`, alongside the existing `**/*.html` block.
- Deliberately not `**`: a catch-all cache-control block would collide with the hashed-asset `immutable` policy; with hash routing, `/` is the only real-world shell entry path.

## Testing
- [x] Live proof on preview channel `hdr-root-nocache`: `/` → `no-cache`, `/index.html` → `no-cache`, hashed asset → `public, max-age=31536000, immutable`
- [x] `firebase.json` parses; full battery green (lint, typecheck, 236 unit, 57 rules, 15 functions, build)
- [ ] Post-deploy: `curl -sI https://citl.club/ | grep -i cache-control` shows `no-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)