### PR TITLE
feat(awards): finish the season-awards pipeline — compute, finalize, and display trophies (spec 004)

### DIFF
--- a/.specs/features/004-season-awards/spec.md
+++ b/.specs/features/004-season-awards/spec.md
@@ -1,0 +1,399 @@
+# Feature: Season Awards — Finish the Pipeline and Display Trophies
+
+**Feature ID**: 004-season-awards
+**Created**: 2026-07-12
+**Status**: Approved (Tyler, 2026-07-12) — in implementation
+**Source**: Maintainer decision (Tyler, 2026-07-12) recorded in
+[backlog WS5-02](../../reviews/2026-07-deep-review/backlog.md) — promotion of finding
+[F-26 (P2)](../../reviews/2026-07-deep-review/report.md) to a full feature.
+**Authoritative business rules**: [scoring-engine.md §"Season Awards"](../scoring-engine.md)
+— Highest Average, Rookie of the Year, Most Improved; min 6 weeks shot; dummies excluded.
+**Those rules are NOT restated here** — the engine already implements them correctly per its
+tests; this spec finishes the placements, the shape, the guard, the trigger, and the display.
+
+---
+
+## Overview
+
+The season-awards pipeline in `src/services/scoring-engine.ts` is half-built dead code
+(F-26): `computeSeasonAwards` implements the three shooter awards correctly but hardcodes all
+four team-placement fields to `null` in both return branches, nothing in the app calls it,
+nothing writes `Season.awards`, its return type (`ComputedAwards`) differs from the
+Firestore-stored `SeasonAwards` documented in `src/types/season.ts`, and its helper
+`computeMostImprovedScore` divides by zero at `startingAvg = 50`.
+
+The 2026 season is at week 12 of 15 and ends soon — trophies must be calculable. This feature:
+
+1. Computes team placements (first/second place + points) from final season standings.
+2. Reconciles the awards type to ONE canonical shape — the flat shape all seven historical
+   prod documents already use (DD-1).
+3. Guards the `startingAvg ≥ 50` divide-by-zero (DD-4).
+4. Adds an admin-triggered season-end flow: preview awards, then finalize — writing `awards`
+   and `status: 'complete'` to `seasons/{year}` (DD-3). Awards are computed from **published
+   week documents** — the same public data the scorecards page renders — never from draft
+   entries.
+5. Displays awards on the home page for the selected season, including historical years (DD-2).
+6. Closes the backfill question: **no backfill is needed** (DD-5) and corrects the emulator
+   seed fixtures to the canonical shape (DD-6).
+
+No Firestore rules change, no schema migration, no Cloud Functions.
+
+## Verified Production Evidence (2026-07-12)
+
+Read-only firebase-admin inspection of prod `citl-baed2` (gcloud ADC), 2026-07-12:
+
+- `seasons/{2019..2025}` — all seven have `status: "complete"` AND a populated `awards`
+  field in the **flat legacy shape** (migrated from the legacy AWS site):
+  `{ firstPlaceTeam: string, firstPlacePoints: number, secondPlaceTeam: string,
+  secondPlacePoints: number, highestAvgShooter: string, highestAvg: number,
+  rookieOfYear: string, rookieAvg: number, mostImproved: string, improvement: string }`.
+  Example (2025): firstPlaceTeam "Sights Impaired" 433 pts; secondPlaceTeam
+  "Full Choke Artists" 415; highestAvgShooter "Randy Jones" 44.428…; rookieOfYear
+  "Micheal Benjamin" 43.285…; mostImproved "Micheal Benjamin", improvement "55.24%".
+- `improvement` is a **formatted percent string** (e.g. "66.15%"); `rookieOfYear` /
+  `mostImproved` are plain name strings; there is **no team attribution** for shooter awards.
+- `seasons/2026` — `status: "active"`, `currentWeek: 12`, `awards` entirely **absent**,
+  12 week docs.
+- **Consequence**: the nested `SeasonAwards` shape in `src/types/season.ts` (and in the
+  emulator seed fixtures) exists **nowhere in prod**. Prod matches `ComputedAwards`
+  (minus its nulls). Only 2026 ever needs computing; historical backfill is a non-issue.
+
+## User Stories
+
+- As a league member, I want to see the season trophies (team placements, Highest Average,
+  Rookie of the Year, Most Improved) on the site when a season ends, so the winners are
+  published the same place standings are.
+- As a league member, I want to select a previous year and see that year's awards, so the
+  seven seasons of league history stay browsable.
+- As the league admin, I want a season-end action that computes the awards from published
+  results, shows me a preview, and writes them once I confirm — so trophies come from the
+  engine, not hand calculation.
+- As the league admin, I want a re-runnable finalize action, so a scoring correction
+  (republish) can't strand stale awards.
+- As the maintainer, I want ONE awards type that matches what prod actually stores, and
+  award numbers that agree with the scorecards page everyone can see, so no future agent
+  wires up the shape mismatch (or the draft-data mismatch) F-26 warned about.
+
+## Acceptance Criteria
+
+- [ ] **AC-1**: `computeSeasonAwards` returns a complete flat `SeasonAwards` including
+      `firstPlaceTeam`/`firstPlacePoints`/`secondPlaceTeam`/`secondPlacePoints` derived from
+      the passed final standings (rank 1 and rank 2 rows; points =
+      `totalRankPoints + totalBonusPoints`). Both return branches fill placements — a season
+      with standings but zero award-eligible shooters still gets placements. Unit tests cover
+      2-team, 1-team, and 0-team standings.
+- [ ] **AC-2**: `computeMostImprovedScore(50, x)` and any `startingAvg > 50` return `0` —
+      no `Infinity`/`NaN` is reachable in the awards path (unit tests pin the edge).
+- [ ] **AC-3**: Exactly one awards type exists: `SeasonAwards` in `src/types/season.ts` with
+      the flat prod field set (all fields nullable). `grep -rn "ComputedAwards" src/ scripts/`
+      returns nothing; the nested shape is deleted. `npm run typecheck` passes.
+- [ ] **AC-4**: In the admin panel, an admin can preview awards for the selected year and then
+      finalize: `seasons/{year}` gains `awards` (canonical shape) and `status: 'complete'`.
+      Re-running preview + finalize overwrites cleanly (idempotent). Preview/finalize read
+      **only published data** (season doc, team docs, published week docs) — never the
+      `entries` draft audit trail.
+- [ ] **AC-5**: The home page shows an awards section for the selected season when
+      `season.awards` is non-null — including all seven historical years — and renders **no
+      awards section** (not an empty shell, not placeholder text) when `awards` is null/absent
+      or the season is active. Every rendered string passes through `escapeHtml()`; every
+      field is null-guarded (repository reads are unvalidated casts, F-09).
+- [ ] **AC-6**: The home page issues **zero additional Firestore reads** for awards — they
+      ride the season document `home-standings` already loads.
+- [ ] **AC-7**: No changes to `firestore.rules` (`seasons/{year}` update is already
+      admin-only); the existing rules suite passes unmodified.
+- [ ] **AC-8**: Emulator seed fixtures emit the canonical flat shape; seeded 2025 has a full
+      awards object (including a non-null `mostImproved`) so the UI is verifiable via
+      `npm run dev:seeded`; the E2E steps in tasks.md Group 6 pass — including re-finalizing
+      seeded 2025 (15 published weeks, real shooter awards) and finalizing seeded 2024
+      (5 published weeks → warning + zero-eligible branch with placements).
+- [ ] **AC-9**: File-size budgets hold: `score-service.ts` stays at ≤ 750 (it is at 749 —
+      this feature adds **nothing** to it); every new file ≤ 500 lines; no touched file
+      crosses 750.
+- [ ] **AC-10**: `npm run typecheck`, `npm test`, `npm run test:rules`, and
+      `npm run test:functions` pass; docs and the review ledger are updated (tasks Group 7).
+
+## Constitutional Constraints
+
+- **§I.1 Progressive Complexity**: no new platform, no Cloud Function, no schema migration.
+  The one structural addition (a small dedicated service, DD-3) is forced by the 750-line
+  hook limit on `score-service.ts`, following the spec-003 split precedent.
+- **§II.3 / §II.4 Layering**: engine stays pure (compute in `scoring-engine.ts`, I/O in the
+  service/repository); new service lives in `src/services/`; components reach it only via
+  the composition root `getServices()` (constitution §II.4 → `src/components/README.md`
+  contract, hook rule `no-private-service-in-component`).
+- **§III.2 Security**: the finalize write is enforced by the existing
+  `seasons/{year}` admin-only rule in [`firestore.rules`](../../../firestore.rules) — not by
+  client-side checks; existing rules tests (`tests/rules/`) already pin this authz. The
+  awards computation itself depends only on **publicly readable** collections (seasons,
+  teams, weeks) — no admin-only `entries` reads.
+- **§III.3 Loading States**: the home-page awards render inside the existing
+  `home-standings` skeleton→data→error flow — no new async component, no new loading text.
+- **§III.4 / §VI.1 Cost**: zero added public-page reads (AC-6). Finalize is a once-a-year
+  admin action whose reads go through the shared cached `ScoreService`
+  (`buildScorecardData`: teams + published weeks for the year and its two prior years —
+  well under 100 document reads). No new Cloud Function → the `firebase-deploy-runbook`
+  post-deploy steps are **N/A**.
+- **§III.5 / §IV.2 Code Quality & Forbidden Patterns**: strict TS, `@/` imports,
+  `escapeHtml()` for all Firestore-sourced strings, no God modules; the machine ruleset in
+  [`scripts/forbidden-patterns.json`](../../../scripts/forbidden-patterns.json) is unchanged
+  and must pass on every edit.
+
+## Design Decisions
+
+### DD-1: The canonical `SeasonAwards` type is the FLAT prod shape
+
+**Decision**: Redefine `SeasonAwards` in `src/types/season.ts` as the flat field set prod
+already stores (identical to today's `ComputedAwards`, all ten fields nullable). Delete the
+nested `SeasonAwards` and the `ComputedAwards` name entirely. `improvement` remains a
+formatted percent string (e.g. `"55.24%"`) and `highestAvg`/`rookieAvg` remain raw floats —
+exactly what the seven prod docs contain; formatting/rounding is a display concern (DD-2).
+
+**Rationale**: seven seasons of prod data already use the flat shape (verified 2026-07-12);
+adopting it means **zero prod migration** and historical display works on day one. The engine
+already returns this shape, so the "reconciliation" is a type rename plus deletions.
+
+**Rejected — migrate prod to the nested shape**: would require a one-off admin script
+touching seven production documents; would have to invent per-award `teamName` attribution
+that the legacy data never captured (it does not exist and cannot be recovered for
+2019–2024 without archaeology); and buys nothing — no UI requirement needs team attribution
+on shooter awards. Rejected on §I.1 grounds.
+
+**Known quirk, accepted**: `improvement` as a pre-formatted string is a modeling smell
+(display data at rest), but changing it to a number means migrating seven prod docs for zero
+functional gain. Documented here so nobody "fixes" it casually.
+
+### DD-2: Display surface = `home-standings`, "Season" view; no-data = render nothing
+
+**Decision**: Render the awards inside `src/components/home-standings.ts`, in `_renderTable`,
+**only when the week selector is `"Season"`** and `this._season.awards != null` — a
+"Season Awards" section above the standings table, structurally parallel to the existing
+weekly-accolades section (`_renderAccolades`). Rows: First Place (team — points), Second
+Place (team — points), Highest Average (name — avg, `toFixed(2)`), Rookie of the Year
+(name — avg, `toFixed(2)`; row omitted when null), Most Improved (name — improvement string;
+row omitted when null). Individual null fields are skipped, whole section omitted if every
+field is null. **No-data behavior**: active seasons (2026 until finalized) and any season
+without `awards` show no awards section at all — the standings view is unchanged.
+
+**Rationale**: `home-standings` already owns the year selector and already loads the season
+document via `getSeason` — awards ride along with **zero extra Firestore reads** (AC-6), and
+the complete-season default view is already "Season", so historical years show awards
+immediately on selection. The component is 310 lines; ~+80 keeps it under the 500 target.
+The existing skeleton covers the load (§III.3) since awards render in the same
+`#hs-table` innerHTML pass — no new async state exists.
+
+**Rejected — a separate `<season-awards>` component**: it would either duplicate the season
+fetch or need cross-component year-selection eventing; neither is justified for one section
+(§I.1). **Rejected — Scorecards page**: awards are league-level results; the home page is
+where league-level results (standings, accolades) live; scorecards are per-team detail.
+
+### DD-3: Season-end trigger = admin "Season End" tab, two-phase (preview → finalize), via a new small service computing from PUBLISHED data
+
+**Decision**: a new admin tab **"Season End"** (`src/components/admin-tabs/season-end-tab.ts`,
+implementing the existing `AdminTab` lifecycle from `admin-tabs/types.ts`), registered in
+`admin-panel.ts` after "Announcements". Flow:
+
+1. **Preview** — button "Compute awards preview" calls
+   `seasonAwardsService.previewAwards(year)` (read-only), renders the ten award fields in a
+   read-only table via `textContent`/`escapeHtml`, and enables step 2. If
+   `season.currentWeek < 15`, show a non-blocking warning ("only N of 15 weeks published")
+   — the league can legitimately end short (weekDateOverrides supports cancelled weeks), so
+   warn, never hard-block.
+2. **Finalize** — `btn-danger` button "Finalize season" (enabled only after a successful
+   preview for the currently selected year; disabled again on year change), guarded by a
+   confirm dialog, calls `seasonAwardsService.finalizeSeason(year)`, then
+   `ctx.refreshSeason()` and a success toast.
+
+**Semantics**: idempotent and re-runnable — finalize always recomputes from current published
+data and overwrites `awards` + `status: 'complete'`. This is deliberate: republishing a
+corrected week resets `status` to `'active'` (the repository `publishWeek` always writes
+`status: 'active'`) and leaves the previously written awards stale — the admin's recovery is
+simply to re-run finalize. The tab surfaces this by showing the season's current status and
+whether awards exist.
+
+**Data source — published week documents, NOT draft entries.** The `entries/{week}_{teamId}`
+docs are the raw pre-publish audit trail (see the `SeasonEntry` doc comment in
+`src/types/score.ts`) and are admin-only readable; they may contain never-published edits,
+and complete seasons may have **no** entry docs at all (seeded 2025 has zero; prod entry
+coverage across 2026 weeks 1–12 is unverified). Awards must come from the same published
+truth as everything else the public sees:
+
+- **Placements** = the stored `season.standings` (the published, F-05-protected rows the
+  public watched all season), NOT a fresh recompute — awards match the displayed final
+  standings by construction.
+- **Shooter awards** = per-shooter season lines assembled from `getTeams(year)` +
+  `getAllWeekResults(year)` (+ the two prior years for rookie/W0 derivation) — exactly the
+  path the public scorecards page already uses:
+  `ScoreService.buildScorecardData(year)` → `buildScorecardTeamBlock(...)`, which produces
+  per shooter: name, rookie, isDummy, W0/starting average, `scores[15]`, weeksShot. Note:
+  rookie flags and starting averages are **derived from prior-year published data**
+  (`isShooterRookie`, prior-avg maps, `computeShooterStartingAvg`) — roster docs are not the
+  derivation source anywhere in the live paths — and `buildScorecardData` already handles
+  that derivation plus the roster-removed-shooter rules.
+
+**Consistency property (explicit rationale)**: because awards consume the *same* derivation
+as the scorecards page, the trophies are guaranteed to agree with the scorecard lines every
+member can inspect — a Highest Average award is always verifiable against the displayed
+scorecard. Computing from drafts (or from a parallel roster-based derivation) could produce
+trophies that contradict the public record.
+
+**New service** — `src/services/season-awards-service.ts` (`SeasonAwardsService`, target
+≤ 150 lines), because `score-service.ts` sits at 749/750 lines and must not grow (AC-9);
+precedent: spec-003 decomposition. Constructed **only** in the composition root
+(`src/services/app-services.ts`, added to `AppServices`); tests construct it directly with
+stubs and never import `app-services`.
+
+- `constructor(repository: ScoreRepository, scoreService: ScoreService)` — reads go through
+  the shared `ScoreService` (cached, `Result`-typed: `getSeason`, `buildScorecardData`);
+  the write uses `repository.updateSeason(year, { awards, status: 'complete' })` (already
+  exists); after a successful write it calls `scoreService.clearCache()` so the home page and
+  admin panel see the finalized season immediately. `clearCache()` is deliberately blunt —
+  data volumes are tiny and it guarantees both `season:{year}` and `seasons:all` are fresh.
+- `previewAwards(year): Promise<Result<SeasonAwards>>` — fail (`NO_DATA`) when the season
+  doc is missing or `currentWeek < 1`; otherwise `scoreService.buildScorecardData(year)` →
+  `toAwardShooterInputs(viewData.teams)` (pure adapter, below) →
+  `computeSeasonAwards(inputs, season.standings ?? [])`. Every failed `Result` propagates
+  unchanged (no throws — F-09 convention).
+- `finalizeSeason(year): Promise<Result<SeasonAwards>>` — `previewAwards` + write +
+  invalidate.
+
+**Engine change**: `computeSeasonAwards(shooters: AwardShooterInput[], finalStandings:
+SeasonStandings[]): SeasonAwards`, where `AwardShooterInput = { name, teamName, isDummy,
+rookie, startingAvg, scores }` (declared in `src/types/season.ts`). The engine remains the
+single authority for eligibility and averages: it still excludes dummies, still derives
+`weeksShot` from `scores`, still applies `MIN_WEEKS = 6`, and still computes `finalAvg` at
+full precision via `computeShooterAverage(startingAvg, scores, 14)` — the adapter passes raw
+facts, never conclusions (the scorecard row's display-rounded `finalAvg`/`weeksShot` fields
+are ignored; prod awards store full-precision averages, e.g. 44.428…, while the scorecard
+displays 1-decimal rounding). Placements come from the rank-1/rank-2 standings rows
+(points = `totalRankPoints + totalBonusPoints`), nulls when fewer than 2/1 teams exist,
+filled in **both** return branches.
+
+**Adapter** — `toAwardShooterInputs(blocks: ScorecardTeamBlock[]): AwardShooterInput[]`,
+a pure exported function in `src/services/scorecard-builder.ts` (it owns the block shape;
+its types-only import rule holds). Mapping per `ScorecardRowShooter`:
+`w0Display: number | '-'` → `startingAvg`; rows whose `w0Display` is not numeric are
+**skipped** — those are only dummy/padding rows (real rostered shooters always receive a
+numeric derived W0), and the engine would exclude them via `isDummy` anyway; `isDummy` is
+still passed through so the engine remains the exclusion authority for numeric-W0 dummies.
+Unit-tested directly.
+
+The [scoring-engine.md](../scoring-engine.md) §"Outputs — computeSeasonAwards" paragraph
+(which currently documents the null placements) is updated to the new flat-input signature;
+the §"Season Awards" rules section is untouched.
+
+**Rejected — computing shooter awards from `getEntries` + `buildSeasonData`** (the publish
+path's assembly): entries are draft audit data — using them would contradict the F-05
+argument this spec makes for placements, would break on complete seasons that have no entry
+docs (seeded 2025 has none; prod coverage is unguaranteed), and would add an admin-only read
+dependency to a computation over public results. **Rejected — extending the Score Entry
+tab**: `score-entry-tab.ts` is 593 lines; adding preview UI pushes it toward the hard limit,
+and season lifecycle is a distinct responsibility the `AdminTab` seam exists for.
+**Rejected — a Cloud Function / scheduled trigger**: the client SDK + existing admin rules
+fully cover this write (§VI.1 requires functions to solve problems they cannot); a
+once-a-year human action needs human judgment (short seasons, corrections), not a scheduler.
+
+### DD-4: Divide-by-zero guard — `startingAvg ≥ 50` → improvement score `0`
+
+**Decision**: `computeMostImprovedScore` returns `0` whenever `startingAvg >= 50`.
+
+**Rationale**: the formula `100 × (finalAvg − startingAvg) / (50 − startingAvg)` measures the
+fraction of *possible* improvement achieved; a shooter starting at the 50 cap has no possible
+improvement, so 0 is the semantically honest score (not an award-winning one — any genuinely
+improved shooter scores > 0 and beats them; decliners score < 0 and lose to them, which is
+correct). `startingAvg > 50` is impossible under the scoring rules (scores cap at 50) but is
+guarded identically rather than letting a bad historical import produce a sign-flipped
+denominator. Rejected: returning `-Infinity`/`null`/skipping the shooter — all three
+complicate the reducer and the type for an edge whose correct value is simply "no
+improvement possible".
+
+### DD-5: Historical backfill — CLOSED, not needed
+
+All seven historical seasons (2019–2025) already carry complete awards in the canonical flat
+shape (verified in prod 2026-07-12 — see Evidence above). Only 2026 will ever be finalized
+by the new flow. No backfill script, no migration, nothing to schedule. The WS5-02 backlog
+question "subject to what historical award data exists" is answered: it all exists.
+
+### DD-6: Seed fixtures corrected to the canonical shape
+
+`scripts/fixtures/seed-data.js` `buildAwards` currently emits the nested shape (which exists
+nowhere in prod) with `mostImproved: null`. It is rewritten to emit the flat canonical shape
+with **all ten fields populated** for the seeded complete season (2025): placements derived
+from the fixture standings (mirroring `totalRankPoints + totalBonusPoints` of ranks 1–2) and
+a computed most-improved (same formula, same `"NN.NN%"` string format, same ≥ 50 guard). The
+seeded active season (2024) keeps no `awards` field — that is the no-data display case. The
+fixture stays plain JS mirroring the shape; it must not import the TS engine.
+
+## Architecture Approach
+
+Dependency direction throughout: `components → modules → services → repositories` (never
+reverse); engine, `scorecard-builder`, and the adapter remain pure.
+
+| File | Layer | Action |
+|---|---|---|
+| `src/types/season.ts` | types | **Modify**: flat `SeasonAwards` (DD-1); new `AwardShooterInput` (DD-3); delete nested shape + `ComputedAwards`; update the stale mismatch comments |
+| `src/services/scoring-engine.ts` | services (pure) | **Modify**: `computeMostImprovedScore` guard (DD-4); `computeSeasonAwards(shooters, finalStandings)` — flat-input signature, placements filled in both branches (DD-3); imports `SeasonStandings`/`AwardShooterInput` as types only |
+| `src/services/scoring-engine.test.ts` | tests | **Modify**: signature updates; new placement + ≥ 50 edge cases |
+| `src/services/scorecard-builder.ts` | services (pure) | **Modify** (~+30 lines): exported pure `toAwardShooterInputs(blocks)` adapter (DD-3) |
+| adapter tests (in the file that already tests `buildScorecardTeamBlock`, else a new `scorecard-builder.test.ts`) | tests | **Modify/New**: adapter mapping tests incl. `'-'`-W0 row skipping |
+| `src/services/season-awards-service.ts` | services | **New** (≤ 150 lines): `SeasonAwardsService` — `previewAwards`, `finalizeSeason`, reads via `buildScorecardData` (DD-3) |
+| `src/services/season-awards-service.test.ts` | tests | **New**: stub-repository tests (never imports `app-services`) |
+| `src/services/app-services.ts` | services (composition root) | **Modify**: `AppServices` gains `seasonAwardsService` |
+| `src/components/admin-tabs/season-end-tab.ts` | components | **New** (≤ 250 lines): `SeasonEndTab implements AdminTab` (DD-3) |
+| `src/components/admin-panel.ts` | components | **Modify** (~+15 lines): register tab button/panel/lifecycle |
+| `src/components/home-standings.ts` | components | **Modify** (~+80 lines): `_renderAwards` in the Season view (DD-2) |
+| `src/styles/` (standings/home partial) | styles | **Modify**: `awards-section` styling (reuse `accolades-*` patterns/tokens where possible) |
+| `scripts/fixtures/seed-data.js` | tooling | **Modify**: flat `buildAwards` (DD-6) |
+| `.specs/technical/firestore-schema.md` | docs | **Modify**: `awards` field note (flat shape, verified 2026-07-12); drop `ComputedAwards` from the interfaces list |
+| `.specs/features/scoring-engine.md` | docs | **Modify**: §"Outputs — computeSeasonAwards" only (new flat-input signature/complete output); rules sections untouched |
+| `.specs/reviews/2026-07-deep-review/report.md` + `backlog.md` | docs | **Modify**: §0 remediation ledger row for F-26; WS5-02 marked done (final task) |
+
+**Explicitly unchanged**: `firestore.rules` (+ indexes), `score-service.ts`,
+`score-repository.ts` (`updateSeason` already exists), the `entries` collection and every
+read path over it, Cloud Functions, `score-entry-tab.ts`.
+
+## Implementation Plan
+
+Ordered task groups with acceptance criteria and validation gates live in
+[tasks.md](./tasks.md). Summary: (1) types + engine + guard + adapter with tests → (2)
+`SeasonAwardsService` + composition-root wiring with tests → (3) Season End admin tab →
+(4) home-page awards display → (5) seed-fixture correction → (6) emulator E2E verification →
+(7) docs + review-ledger close-out. Single PR, one commit per group.
+
+## Testing Checklist
+
+- [ ] Engine: placements derived from 2-team/1-team/0-team standings; both return branches
+      (eligible and empty-eligible) carry placements; points equal
+      `totalRankPoints + totalBonusPoints` of ranks 1–2
+- [ ] Engine: `computeMostImprovedScore(50, 45) === 0`, `(55, 40) === 0`; existing
+      improvement cases unchanged; awards path never yields non-finite numbers
+- [ ] Engine: existing shooter-award rules tests (min 6 weeks, dummy exclusion, rookie
+      subset) still pass under the flat-input signature; award `finalAvg` is full-precision
+      (not the scorecard's 1-decimal display rounding)
+- [ ] Adapter: `toAwardShooterInputs` maps `ScorecardRowShooter` → `AwardShooterInput`
+      (`w0Display` → `startingAvg`); skips non-numeric-W0 rows; passes `isDummy` through
+- [ ] Service: `previewAwards` happy path over a stub repository serving teams + published
+      weeks (prior years included so the real `buildScorecardData` exercises rookie/W0
+      derivation over the stubs); `NO_DATA` on missing season / zero published weeks;
+      failure propagation from `buildScorecardData`; **no `getEntries` call anywhere in the
+      awards path**; `finalizeSeason` writes `{ awards, status: 'complete' }` via
+      `updateSeason` and calls `clearCache()`; `app-services` never imported in tests
+- [ ] Consistency property: for a fixture season, award winners agree with the scorecard
+      rows `buildScorecardData` produces from the same stubs (same derivation; full
+      precision vs. display rounding aside)
+- [ ] Rules: existing suite passes unmodified (no rules change — AC-7)
+- [ ] Emulator E2E (tasks.md Group 6): seeded 2025 shows awards on Home; 2024 shows none;
+      re-finalizing 2025 (15 published weeks) computes real shooter awards; finalizing 2024
+      (5 weeks) exercises the <15 warning + zero-eligible branch with placements; Home
+      updates without a hard reload; re-finalize is idempotent
+- [ ] Post-deploy prod spot-check: select 2025 on citl.club → awards match the prod doc
+      (Sights Impaired 433 / Full Choke Artists 415 / Randy Jones 44.43 / Micheal Benjamin
+      43.29 / Micheal Benjamin "55.24%")
+- [ ] `npm run typecheck` + all three suites green; `/check` passes; no file > 750 lines
+
+## Open Questions — RESOLVED (maintainer review, Tyler, 2026-07-12)
+
+1. **Finalize confirmation strength** — **standard confirm dialog.** No type-the-year gate;
+   finalize is non-destructive and re-runnable.
+2. **"Reopen season" action** — **out of scope, confirmed.** Republishing any week already
+   flips `status` back to `'active'` (existing behavior), and re-finalize recovers.
+3. **Rounding on display** — **`toFixed(2)` confirmed** (stored floats untouched).

--- a/.specs/features/004-season-awards/spec.md
+++ b/.specs/features/004-season-awards/spec.md
@@ -164,6 +164,12 @@ functional gain. Documented here so nobody "fixes" it casually.
 
 ### DD-2: Display surface = `home-standings`, "Season" view; no-data = render nothing
 
+> **Refinement (Tyler, 2026-07-12, pre-merge)**: the awards render as a design-system
+> table (`.awards-table`, mirroring `.standing-table`: Award | Winner | Result) with
+> plain-emoji trophy icons (🏆 🥈 🎯 ⭐ 📈 — no custom assets, consistent with ADR-008),
+> replacing the initially shipped badge list. Row-omission and null-guard semantics
+> below are unchanged.
+
 **Decision**: Render the awards inside `src/components/home-standings.ts`, in `_renderTable`,
 **only when the week selector is `"Season"`** and `this._season.awards != null` — a
 "Season Awards" section above the standings table, structurally parallel to the existing

--- a/.specs/features/004-season-awards/spec.md
+++ b/.specs/features/004-season-awards/spec.md
@@ -2,7 +2,7 @@
 
 **Feature ID**: 004-season-awards
 **Created**: 2026-07-12
-**Status**: Approved (Tyler, 2026-07-12) — in implementation
+**Status**: Implemented — PR #220
 **Source**: Maintainer decision (Tyler, 2026-07-12) recorded in
 [backlog WS5-02](../../reviews/2026-07-deep-review/backlog.md) — promotion of finding
 [F-26 (P2)](../../reviews/2026-07-deep-review/report.md) to a full feature.

--- a/.specs/features/004-season-awards/tasks.md
+++ b/.specs/features/004-season-awards/tasks.md
@@ -19,16 +19,16 @@ returns complete awards; no NaN edge; pure adapter from scorecard blocks.
 **Commit**: `feat(engine): compute team placements in season awards; adopt flat SeasonAwards shape`
 **AC**: AC-1, AC-2, AC-3 · **DD**: DD-1, DD-3 (engine + adapter), DD-4
 
-- [ ] **1.1 (S)** `src/types/season.ts`: replace the nested `SeasonAwards` with the flat
+- [x] **1.1 (S)** `src/types/season.ts`: replace the nested `SeasonAwards` with the flat
       ten-field shape (today's `ComputedAwards` field set, all fields nullable); delete
       `ComputedAwards`; add `AwardShooterInput` (`{ name, teamName, isDummy, rookie,
       startingAvg, scores }` — see DD-3); rewrite the doc comments — note the shape matches
       all seven prod documents (verified 2026-07-12, spec.md §"Verified Production
       Evidence") and that `improvement` is a formatted percent string by prod precedent
       (DD-1 quirk note). `Season.awards` stays `SeasonAwards | null`.
-- [ ] **1.2 (S)** `src/services/scoring-engine.ts` — `computeMostImprovedScore`: add the
+- [x] **1.2 (S)** `src/services/scoring-engine.ts` — `computeMostImprovedScore`: add the
       guard `if (startingAvg >= 50) return 0;` with a one-line comment referencing DD-4.
-- [ ] **1.3 (M)** `src/services/scoring-engine.ts` — rework `computeSeasonAwards` to
+- [x] **1.3 (M)** `src/services/scoring-engine.ts` — rework `computeSeasonAwards` to
       `computeSeasonAwards(shooters: AwardShooterInput[], finalStandings:
       SeasonStandings[]): SeasonAwards` (DD-3): the eligibility loop runs over the flat
       input list (dummy exclusion, `weeksShot` from `scores`, `MIN_WEEKS = 6`, full-precision
@@ -38,13 +38,13 @@ returns complete awards; no NaN edge; pure adapter from scorecard blocks.
       (points = `totalRankPoints + totalBonusPoints`); nulls when the rows don't exist.
       **Both** return branches (empty-eligible and normal) carry the derived placements.
       Type-only imports for `SeasonStandings` / `AwardShooterInput` / `SeasonAwards`.
-- [ ] **1.4 (S)** `src/services/scorecard-builder.ts`: add exported pure
+- [x] **1.4 (S)** `src/services/scorecard-builder.ts`: add exported pure
       `toAwardShooterInputs(blocks: ScorecardTeamBlock[]): AwardShooterInput[]` (DD-3):
       per row map `w0Display` → `startingAvg`, carry `name`/`rookie`/`isDummy`/`scores` and
       the block's `teamName`; **skip** rows with non-numeric `w0Display` (dummy/padding
       rows only — comment why); ignore the row's display-oriented `finalAvg`/`weeksShot`.
       Header import rule (types-only) unchanged.
-- [ ] **1.5 (M)** Tests — `src/services/scoring-engine.test.ts` (and the adapter's test
+- [x] **1.5 (M)** Tests — `src/services/scoring-engine.test.ts` (and the adapter's test
       home per the spec's Architecture table):
       - update all `computeSeasonAwards` call sites to flat inputs + standings;
       - placements from a 2+-team standings fixture (assert names + point sums);
@@ -56,7 +56,7 @@ returns complete awards; no NaN edge; pure adapter from scorecard blocks.
       - award `finalAvg` full-precision (not 1-decimal rounded);
       - adapter: field mapping, `'-'`-W0 row skipped, `isDummy` passed through, `teamName`
         attached from the block.
-- [ ] **1.6 (S)** Grep gate: no `ComputedAwards` anywhere in `src/` or `scripts/`.
+- [x] **1.6 (S)** Grep gate: no `ComputedAwards` anywhere in `src/` or `scripts/`.
 
 **Validation**:
 ```
@@ -75,7 +75,7 @@ fully unit-tested.
 **Commit**: `feat(services): add SeasonAwardsService (preview + finalize season)`
 **AC**: AC-4 (service half), AC-9 · **DD**: DD-3
 
-- [ ] **2.1 (M)** Create `src/services/season-awards-service.ts` (≤ 150 lines):
+- [x] **2.1 (M)** Create `src/services/season-awards-service.ts` (≤ 150 lines):
       `SeasonAwardsService` with `constructor(repository: ScoreRepository, scoreService:
       ScoreService)`; header comment states the import rule (types, scoring-engine,
       scorecard-builder, score-service, repositories — never components/modules), that the
@@ -91,7 +91,7 @@ fully unit-tested.
       - `finalizeSeason(year): Promise<Result<SeasonAwards>>` — `previewAwards`, then
         `repository.updateSeason(year, { awards, status: 'complete' })`, then
         `scoreService.clearCache()`, return the awards.
-- [ ] **2.2 (M)** Create `src/services/season-awards-service.test.ts` (stub repository
+- [x] **2.2 (M)** Create `src/services/season-awards-service.test.ts` (stub repository
       pattern from `score-service.test.ts`; **never** import `app-services`). Stubs serve:
       season doc (with standings), teams + published week docs for the target year, and
       teams/weeks for the two prior years (may be empty) so the real `buildScorecardData`
@@ -106,7 +106,7 @@ fully unit-tested.
         `clearCache` observed (spy); failure from `updateSeason` propagates (no cache-clear
         after a failed write);
       - idempotency: second finalize recomputes and rewrites without error.
-- [ ] **2.3 (S)** `src/services/app-services.ts`: add `seasonAwardsService:
+- [x] **2.3 (S)** `src/services/app-services.ts`: add `seasonAwardsService:
       SeasonAwardsService` to `AppServices`, constructed in `getServices()` from the same
       repository + the shared `scoreService`.
 
@@ -127,7 +127,7 @@ wc -l src/services/score-service.ts                      # still 749 — MUST be
 **Commit**: `feat(admin): add Season End tab — preview and finalize season awards`
 **AC**: AC-4, AC-7 · **DD**: DD-3
 
-- [ ] **3.1 (L)** Create `src/components/admin-tabs/season-end-tab.ts` (≤ 250 lines):
+- [x] **3.1 (L)** Create `src/components/admin-tabs/season-end-tab.ts` (≤ 250 lines):
       `SeasonEndTab implements AdminTab`, `constructor(seasonAwardsService)`.
       - `mount(host, ctx)`: static innerHTML skeleton of the section (status line, preview
         button, empty preview container, disabled `btn-danger` finalize button, `aria-live`
@@ -146,12 +146,12 @@ wc -l src/services/score-service.ts                      # still 749 — MUST be
         message, finalize stays enabled.
       - `onYearChange`/`onSeasonChanged`: clear preview, disable finalize, refresh status
         line. Re-entrancy: disable buttons while a call is in flight.
-- [ ] **3.2 (S)** `src/components/admin-panel.ts`: import + construct `SeasonEndTab`
+- [x] **3.2 (S)** `src/components/admin-panel.ts`: import + construct `SeasonEndTab`
       (service from `getServices().seasonAwardsService`); add the tab button
       (`data-tab="season-end"`, label "Season End") after Announcements; add the panel div;
       extend `TabName`, `_switchTab` list, and `_lifecycleTabs`; mount with the shared ctx.
       Year row stays visible for this tab.
-- [ ] **3.3 (S)** Styling: reuse existing admin classes (`admin-form-row`, `admin-status`,
+- [x] **3.3 (S)** Styling: reuse existing admin classes (`admin-form-row`, `admin-status`,
       `btn-danger`, table classes); add minimal new rules only if needed, in the styles
       partial that owns admin styling.
 
@@ -172,7 +172,7 @@ when absent.
 **Commit**: `feat(home): show season awards for the selected season`
 **AC**: AC-5, AC-6 · **DD**: DD-2
 
-- [ ] **4.1 (M)** `src/components/home-standings.ts`: add `_renderAwards(awards:
+- [x] **4.1 (M)** `src/components/home-standings.ts`: add `_renderAwards(awards:
       SeasonAwards): string` (private, mirrors `_renderAccolades` structure). In
       `_renderTable`, when `weekKey === 'season'` and `this._season?.awards != null`,
       prepend the awards section to the `#hs-table` innerHTML. Rows per DD-2: First/Second
@@ -180,10 +180,10 @@ when absent.
       (omit when null), Most Improved (omit when null; improvement string rendered as-is).
       Null-guard **every** field independently (unvalidated repository casts, F-09); omit
       the whole section if no field renders. `escapeHtml()` on every string.
-- [ ] **4.2 (S)** Styles: add `awards-section` styling in the partial that owns
+- [x] **4.2 (S)** Styles: add `awards-section` styling in the partial that owns
       home-standings/accolades styles, reusing the `accolades-*` visual language and design
       tokens (`--c-*`); dark mode via tokens (no extra work).
-- [ ] **4.3 (S)** Confirm zero new reads: no new service/repository calls in
+- [x] **4.3 (S)** Confirm zero new reads: no new service/repository calls in
       `home-standings.ts` — awards come from the already-fetched `this._season` (AC-6);
       skeleton flow unchanged (§III.3 satisfied by the existing `_standingsSkeleton`).
 
@@ -202,7 +202,7 @@ grep -n "scoreService\." src/components/home-standings.ts   # same call set as b
 **Commit**: `fix(seed): emit canonical flat SeasonAwards in emulator fixtures`
 **AC**: AC-8 · **DD**: DD-6
 
-- [ ] **5.1 (M)** `scripts/fixtures/seed-data.js` — rewrite `buildAwards` to return the flat
+- [x] **5.1 (M)** `scripts/fixtures/seed-data.js` — rewrite `buildAwards` to return the flat
       ten-field shape: placements from the fixture standings (rank 1/2 rows,
       `totalRankPoints + totalBonusPoints`); highest-average and rookie logic as today but
       emitting `highestAvgShooter`/`highestAvg`/`rookieOfYear`/`rookieAvg` flat fields;
@@ -210,7 +210,7 @@ grep -n "scoreService\." src/components/home-standings.ts   # same call set as b
       formatting (plain JS mirror — do not import the TS engine). Update `buildSeason`
       call sites/signature as needed so seeded 2025 (complete) carries full awards and
       seeded 2024 (active) carries **no** awards field.
-- [ ] **5.2 (S)** Reseed and inspect: `npm run seed:emulator -- clear` then seed; verify the
+- [x] **5.2 (S)** Reseed and inspect: `npm run seed:emulator -- clear` then seed; verify the
       2025 season doc's `awards` has all ten fields non-null and 2024 has none (Emulator UI
       or a read via the seeding script's status mode).
 
@@ -229,24 +229,24 @@ would have broken an entries-based computation and now must succeed; 2024 is act
 5 published weeks (no shooter reaches the 6-week minimum).
 **AC**: AC-4, AC-5, AC-8
 
-- [ ] **6.1** `npm run dev:seeded` → Home → select 2025 + "Season" view → awards section
+- [x] **6.1** `npm run dev:seeded` → Home → select 2025 + "Season" view → awards section
       renders with all five rows (seeded fixture values); select 2024 → **no** awards
       section; week views never show awards.
-- [ ] **6.2** Sign in as admin (see the emulator auth-popup workaround notes) → Admin →
+- [x] **6.2** Sign in as admin (see the emulator auth-popup workaround notes) → Admin →
       Season End tab, year **2025** → status line shows `complete`, awards exist → preview
       renders ten fields computed from the 15 published weeks (real shooter awards — proves
       the published-data path works with no entries docs) → finalize + confirm → toast;
       Home 2025 "Season" view now shows the engine-computed awards (values may differ from
       the seed fixture's approximations — that overwrite is expected and correct).
-- [ ] **6.3** Season End tab, year **2024** → status `active`, week 5, no awards → preview
+- [x] **6.3** Season End tab, year **2024** → status `active`, week 5, no awards → preview
       shows the "only 5 of 15 weeks" warning, placements filled from standings, shooter
       awards null (zero-eligible branch — AC-1) → finalize → Home 2024 "Season" view shows
       the awards section with placement rows and the null shooter rows omitted (DD-2
       row-omission behavior exercised).
-- [ ] **6.4** Navigate Home **without reload** after each finalize → updated awards visible
+- [x] **6.4** Navigate Home **without reload** after each finalize → updated awards visible
       (cache invalidation proof). Re-run preview + finalize on 2025 → identical result, no
       error (idempotency).
-- [ ] **6.5** Full gate: `npm run typecheck && npm test && npm run test:rules &&
+- [x] **6.5** Full gate: `npm run typecheck && npm test && npm run test:rules &&
       npm run test:functions && npm run build`, then `/check`.
 
 ---
@@ -257,25 +257,25 @@ would have broken an entries-based computation and now must succeed; 2024 is act
 **Commit**: `docs(specs): update awards shape docs; close F-26 / WS5-02 in review ledger`
 **AC**: AC-10
 
-- [ ] **7.1 (S)** `.specs/technical/firestore-schema.md`: update the `seasons/{year}`
+- [x] **7.1 (S)** `.specs/technical/firestore-schema.md`: update the `seasons/{year}`
       `awards` row — flat shape (reference `SeasonAwards` in `src/types/season.ts`), note
       "verified against prod 2026-07-12; all seven historical seasons populated"; remove
       `ComputedAwards` from the TypeScript-interfaces line.
-- [ ] **7.2 (S)** `.specs/features/scoring-engine.md` §"Outputs — computeSeasonAwards":
+- [x] **7.2 (S)** `.specs/features/scoring-engine.md` §"Outputs — computeSeasonAwards":
       rewrite to the new flat-input signature — `computeSeasonAwards(shooters:
       AwardShooterInput[], finalStandings)` returns the complete flat `SeasonAwards`;
       placements from the caller-supplied final standings; inputs adapted from the
       scorecard-page derivation (`toAwardShooterInputs`) so awards always match the public
       scorecards. **Do not touch** the §"Season Awards" rules section (authoritative
       business rules).
-- [ ] **7.3 (S)** `.specs/reviews/2026-07-deep-review/report.md` §0 remediation ledger: add
+- [x] **7.3 (S)** `.specs/reviews/2026-07-deep-review/report.md` §0 remediation ledger: add
       a row — F-26 → this feature's PR, note "finished (not deleted) per WS5-02 decision;
       placements computed, shape reconciled flat, NaN edge guarded, admin finalize flow
       computing from published week docs + historical display shipped; backfill closed
       (prod already populated)".
-- [ ] **7.4 (S)** `.specs/reviews/2026-07-deep-review/backlog.md` WS5-02: mark done with a
+- [x] **7.4 (S)** `.specs/reviews/2026-07-deep-review/backlog.md` WS5-02: mark done with a
       pointer to `features/004-season-awards/` (or its archive path) and the PR number.
-- [ ] **7.5 (S)** Set spec.md + tasks.md Status to "Implemented — PR #NNN" (archive move to
+- [x] **7.5 (S)** Set spec.md + tasks.md Status to "Implemented — PR #NNN" (archive move to
       `features/archive/` happens after merge per `.specs/README.md` lifecycle).
 
 **Validation**: link-check the four edited docs' relative links; `/check` clean.

--- a/.specs/features/004-season-awards/tasks.md
+++ b/.specs/features/004-season-awards/tasks.md
@@ -2,7 +2,7 @@
 
 **Feature**: 004-season-awards
 **Spec**: [spec.md](./spec.md)
-**Status**: Approved (Tyler, 2026-07-12) — in implementation
+**Status**: Implemented — PR #220
 
 Each numbered group is one prospective commit; commit only when every box is checked and the
 group's validation gate passes. AC refs map to spec.md §"Acceptance Criteria"; DD refs to

--- a/.specs/features/004-season-awards/tasks.md
+++ b/.specs/features/004-season-awards/tasks.md
@@ -1,0 +1,293 @@
+# Task Breakdown: Season Awards
+
+**Feature**: 004-season-awards
+**Spec**: [spec.md](./spec.md)
+**Status**: Approved (Tyler, 2026-07-12) — in implementation
+
+Each numbered group is one prospective commit; commit only when every box is checked and the
+group's validation gate passes. AC refs map to spec.md §"Acceptance Criteria"; DD refs to
+§"Design Decisions". Single PR (`feat/season-awards`), branched from `main`.
+
+**Complexity legend**: S = <30min · M = 30min–2h · L = >2h
+
+---
+
+## Group 1 — Canonical type + engine placements + guard + adapter
+
+**Goal**: one flat `SeasonAwards` type; `computeSeasonAwards` takes flat shooter inputs and
+returns complete awards; no NaN edge; pure adapter from scorecard blocks.
+**Commit**: `feat(engine): compute team placements in season awards; adopt flat SeasonAwards shape`
+**AC**: AC-1, AC-2, AC-3 · **DD**: DD-1, DD-3 (engine + adapter), DD-4
+
+- [ ] **1.1 (S)** `src/types/season.ts`: replace the nested `SeasonAwards` with the flat
+      ten-field shape (today's `ComputedAwards` field set, all fields nullable); delete
+      `ComputedAwards`; add `AwardShooterInput` (`{ name, teamName, isDummy, rookie,
+      startingAvg, scores }` — see DD-3); rewrite the doc comments — note the shape matches
+      all seven prod documents (verified 2026-07-12, spec.md §"Verified Production
+      Evidence") and that `improvement` is a formatted percent string by prod precedent
+      (DD-1 quirk note). `Season.awards` stays `SeasonAwards | null`.
+- [ ] **1.2 (S)** `src/services/scoring-engine.ts` — `computeMostImprovedScore`: add the
+      guard `if (startingAvg >= 50) return 0;` with a one-line comment referencing DD-4.
+- [ ] **1.3 (M)** `src/services/scoring-engine.ts` — rework `computeSeasonAwards` to
+      `computeSeasonAwards(shooters: AwardShooterInput[], finalStandings:
+      SeasonStandings[]): SeasonAwards` (DD-3): the eligibility loop runs over the flat
+      input list (dummy exclusion, `weeksShot` from `scores`, `MIN_WEEKS = 6`, full-precision
+      `finalAvg` via `computeShooterAverage(startingAvg, scores, 14)` — all unchanged logic,
+      no `SeasonData` traversal). Derive `firstPlaceTeam`/`firstPlacePoints` from the rank-1
+      standings row and `secondPlaceTeam`/`secondPlacePoints` from the rank-2 row
+      (points = `totalRankPoints + totalBonusPoints`); nulls when the rows don't exist.
+      **Both** return branches (empty-eligible and normal) carry the derived placements.
+      Type-only imports for `SeasonStandings` / `AwardShooterInput` / `SeasonAwards`.
+- [ ] **1.4 (S)** `src/services/scorecard-builder.ts`: add exported pure
+      `toAwardShooterInputs(blocks: ScorecardTeamBlock[]): AwardShooterInput[]` (DD-3):
+      per row map `w0Display` → `startingAvg`, carry `name`/`rookie`/`isDummy`/`scores` and
+      the block's `teamName`; **skip** rows with non-numeric `w0Display` (dummy/padding
+      rows only — comment why); ignore the row's display-oriented `finalAvg`/`weeksShot`.
+      Header import rule (types-only) unchanged.
+- [ ] **1.5 (M)** Tests — `src/services/scoring-engine.test.ts` (and the adapter's test
+      home per the spec's Architecture table):
+      - update all `computeSeasonAwards` call sites to flat inputs + standings;
+      - placements from a 2+-team standings fixture (assert names + point sums);
+      - 1-team standings → second-place fields null; empty standings → all four null;
+      - empty-eligible branch (no shooter with ≥ 6 weeks) still returns placements;
+      - `computeMostImprovedScore(50, 45) === 0`, `(55, 40) === 0`, existing improvement
+        cases unchanged; a `startingAvg = 50` shooter in the pool scores 0 and loses to any
+        positive improvement;
+      - award `finalAvg` full-precision (not 1-decimal rounded);
+      - adapter: field mapping, `'-'`-W0 row skipped, `isDummy` passed through, `teamName`
+        attached from the block.
+- [ ] **1.6 (S)** Grep gate: no `ComputedAwards` anywhere in `src/` or `scripts/`.
+
+**Validation**:
+```
+npm run typecheck && npm test
+grep -rn "ComputedAwards" src/ scripts/        # empty (AC-3)
+wc -l src/services/scoring-engine.ts           # < 600 (AC-9)
+wc -l src/services/scorecard-builder.ts        # < 320 (AC-9)
+```
+
+---
+
+## Group 2 — SeasonAwardsService + composition root
+
+**Goal**: preview/finalize orchestration over PUBLISHED data behind the composition root;
+fully unit-tested.
+**Commit**: `feat(services): add SeasonAwardsService (preview + finalize season)`
+**AC**: AC-4 (service half), AC-9 · **DD**: DD-3
+
+- [ ] **2.1 (M)** Create `src/services/season-awards-service.ts` (≤ 150 lines):
+      `SeasonAwardsService` with `constructor(repository: ScoreRepository, scoreService:
+      ScoreService)`; header comment states the import rule (types, scoring-engine,
+      scorecard-builder, score-service, repositories — never components/modules), that the
+      class is constructed only in `app-services.ts` (tests construct directly), and that
+      the awards path reads **published data only — never `entries`** (DD-3).
+      - `previewAwards(year): Promise<Result<SeasonAwards>>` — `scoreService.getSeason`;
+        failure `NO_DATA` if season null or `currentWeek < 1`; then
+        `scoreService.buildScorecardData(year)` (cached; already performs the prior-year
+        rookie/W0 derivation and roster-removed-shooter rules) →
+        `toAwardShooterInputs(viewData.teams)` →
+        `computeSeasonAwards(inputs, season.standings ?? [])`. Propagate every failed
+        `Result` unchanged (no throws — F-09 convention).
+      - `finalizeSeason(year): Promise<Result<SeasonAwards>>` — `previewAwards`, then
+        `repository.updateSeason(year, { awards, status: 'complete' })`, then
+        `scoreService.clearCache()`, return the awards.
+- [ ] **2.2 (M)** Create `src/services/season-awards-service.test.ts` (stub repository
+      pattern from `score-service.test.ts`; **never** import `app-services`). Stubs serve:
+      season doc (with standings), teams + published week docs for the target year, and
+      teams/weeks for the two prior years (may be empty) so the real `buildScorecardData`
+      runs over them. Cases:
+      - preview happy path (fixture teams/weeks/standings → full flat awards);
+      - consistency property: the award winners agree with the scorecard rows
+        `scoreService.buildScorecardData(year)` returns for the same stubs;
+      - `NO_DATA` on missing season; `NO_DATA` on `currentWeek: 0`;
+      - failure propagation from `buildScorecardData` (e.g. teams + weeks both failing);
+      - stub asserts `getEntries` is **never called** in the awards path (AC-4);
+      - finalize: `updateSeason` called with `{ awards, status: 'complete' }`;
+        `clearCache` observed (spy); failure from `updateSeason` propagates (no cache-clear
+        after a failed write);
+      - idempotency: second finalize recomputes and rewrites without error.
+- [ ] **2.3 (S)** `src/services/app-services.ts`: add `seasonAwardsService:
+      SeasonAwardsService` to `AppServices`, constructed in `getServices()` from the same
+      repository + the shared `scoreService`.
+
+**Validation**:
+```
+npm run typecheck && npm test
+grep -rn "new SeasonAwardsService" src/ | grep -v test   # only app-services.ts
+grep -n "getEntries" src/services/season-awards-service.ts   # empty (AC-4)
+wc -l src/services/season-awards-service.ts              # <= 150
+wc -l src/services/score-service.ts                      # still 749 — MUST be untouched (AC-9)
+```
+
+---
+
+## Group 3 — Admin "Season End" tab
+
+**Goal**: two-phase preview → finalize UX in the admin panel.
+**Commit**: `feat(admin): add Season End tab — preview and finalize season awards`
+**AC**: AC-4, AC-7 · **DD**: DD-3
+
+- [ ] **3.1 (L)** Create `src/components/admin-tabs/season-end-tab.ts` (≤ 250 lines):
+      `SeasonEndTab implements AdminTab`, `constructor(seasonAwardsService)`.
+      - `mount(host, ctx)`: static innerHTML skeleton of the section (status line, preview
+        button, empty preview container, disabled `btn-danger` finalize button, `aria-live`
+        status element per the `setStatus` pattern in `admin-shared.ts`). All dynamic values
+        rendered via `textContent`/`escapeHtml` (component contract,
+        `src/components/README.md`).
+      - Status line from `ctx.getSeasonData()`: year, `status`, `currentWeek`, whether
+        `awards` already exist ("Awards last written: yes/no").
+      - Preview click → `previewAwards(ctx.getYear())`; render the ten fields in a read-only
+        table; show the non-blocking `currentWeek < 15` warning ("only N of 15 weeks
+        published") when applicable; enable finalize on success; render failure message on
+        failed `Result`.
+      - Finalize click → confirm dialog (standard confirm — resolved Open Question 1) →
+        `finalizeSeason(year)` → on success:
+        `ctx.refreshSeason()`, success toast, re-render status line; on failure: status
+        message, finalize stays enabled.
+      - `onYearChange`/`onSeasonChanged`: clear preview, disable finalize, refresh status
+        line. Re-entrancy: disable buttons while a call is in flight.
+- [ ] **3.2 (S)** `src/components/admin-panel.ts`: import + construct `SeasonEndTab`
+      (service from `getServices().seasonAwardsService`); add the tab button
+      (`data-tab="season-end"`, label "Season End") after Announcements; add the panel div;
+      extend `TabName`, `_switchTab` list, and `_lifecycleTabs`; mount with the shared ctx.
+      Year row stays visible for this tab.
+- [ ] **3.3 (S)** Styling: reuse existing admin classes (`admin-form-row`, `admin-status`,
+      `btn-danger`, table classes); add minimal new rules only if needed, in the styles
+      partial that owns admin styling.
+
+**Validation**:
+```
+npm run typecheck && npm test && npm run test:rules   # rules suite unmodified (AC-7)
+wc -l src/components/admin-tabs/season-end-tab.ts     # <= 250
+wc -l src/components/admin-panel.ts                   # < 260
+```
+Hook must pass on every edit (`scripts/check-constitution.sh` via PostToolUse).
+
+---
+
+## Group 4 — Home-page awards display
+
+**Goal**: awards visible for the selected season, historical years included; nothing shown
+when absent.
+**Commit**: `feat(home): show season awards for the selected season`
+**AC**: AC-5, AC-6 · **DD**: DD-2
+
+- [ ] **4.1 (M)** `src/components/home-standings.ts`: add `_renderAwards(awards:
+      SeasonAwards): string` (private, mirrors `_renderAccolades` structure). In
+      `_renderTable`, when `weekKey === 'season'` and `this._season?.awards != null`,
+      prepend the awards section to the `#hs-table` innerHTML. Rows per DD-2: First/Second
+      Place (team — N pts), Highest Average (name — `avg.toFixed(2)`), Rookie of the Year
+      (omit when null), Most Improved (omit when null; improvement string rendered as-is).
+      Null-guard **every** field independently (unvalidated repository casts, F-09); omit
+      the whole section if no field renders. `escapeHtml()` on every string.
+- [ ] **4.2 (S)** Styles: add `awards-section` styling in the partial that owns
+      home-standings/accolades styles, reusing the `accolades-*` visual language and design
+      tokens (`--c-*`); dark mode via tokens (no extra work).
+- [ ] **4.3 (S)** Confirm zero new reads: no new service/repository calls in
+      `home-standings.ts` — awards come from the already-fetched `this._season` (AC-6);
+      skeleton flow unchanged (§III.3 satisfied by the existing `_standingsSkeleton`).
+
+**Validation**:
+```
+npm run typecheck && npm test
+wc -l src/components/home-standings.ts                # < 420
+grep -n "scoreService\." src/components/home-standings.ts   # same call set as before (AC-6)
+```
+
+---
+
+## Group 5 — Seed fixtures to canonical shape
+
+**Goal**: emulator data matches prod's shape; UI verifiable locally.
+**Commit**: `fix(seed): emit canonical flat SeasonAwards in emulator fixtures`
+**AC**: AC-8 · **DD**: DD-6
+
+- [ ] **5.1 (M)** `scripts/fixtures/seed-data.js` — rewrite `buildAwards` to return the flat
+      ten-field shape: placements from the fixture standings (rank 1/2 rows,
+      `totalRankPoints + totalBonusPoints`); highest-average and rookie logic as today but
+      emitting `highestAvgShooter`/`highestAvg`/`rookieOfYear`/`rookieAvg` flat fields;
+      most-improved computed with the same formula + `>= 50 → 0` guard + `"NN.NN%"`
+      formatting (plain JS mirror — do not import the TS engine). Update `buildSeason`
+      call sites/signature as needed so seeded 2025 (complete) carries full awards and
+      seeded 2024 (active) carries **no** awards field.
+- [ ] **5.2 (S)** Reseed and inspect: `npm run seed:emulator -- clear` then seed; verify the
+      2025 season doc's `awards` has all ten fields non-null and 2024 has none (Emulator UI
+      or a read via the seeding script's status mode).
+
+**Validation**:
+```
+npm run seed:emulator -- status    # or manual Emulator UI check of seasons/2025 + seasons/2024
+```
+
+---
+
+## Group 6 — Emulator E2E verification (no commit — gate before PR)
+
+**Goal**: whole pipeline proven end-to-end locally. Note the seeded data split (DD-3):
+2025 is complete with 15 published weeks and **zero entries docs** — exactly the case that
+would have broken an entries-based computation and now must succeed; 2024 is active with
+5 published weeks (no shooter reaches the 6-week minimum).
+**AC**: AC-4, AC-5, AC-8
+
+- [ ] **6.1** `npm run dev:seeded` → Home → select 2025 + "Season" view → awards section
+      renders with all five rows (seeded fixture values); select 2024 → **no** awards
+      section; week views never show awards.
+- [ ] **6.2** Sign in as admin (see the emulator auth-popup workaround notes) → Admin →
+      Season End tab, year **2025** → status line shows `complete`, awards exist → preview
+      renders ten fields computed from the 15 published weeks (real shooter awards — proves
+      the published-data path works with no entries docs) → finalize + confirm → toast;
+      Home 2025 "Season" view now shows the engine-computed awards (values may differ from
+      the seed fixture's approximations — that overwrite is expected and correct).
+- [ ] **6.3** Season End tab, year **2024** → status `active`, week 5, no awards → preview
+      shows the "only 5 of 15 weeks" warning, placements filled from standings, shooter
+      awards null (zero-eligible branch — AC-1) → finalize → Home 2024 "Season" view shows
+      the awards section with placement rows and the null shooter rows omitted (DD-2
+      row-omission behavior exercised).
+- [ ] **6.4** Navigate Home **without reload** after each finalize → updated awards visible
+      (cache invalidation proof). Re-run preview + finalize on 2025 → identical result, no
+      error (idempotency).
+- [ ] **6.5** Full gate: `npm run typecheck && npm test && npm run test:rules &&
+      npm run test:functions && npm run build`, then `/check`.
+
+---
+
+## Group 7 — Docs + review-ledger close-out
+
+**Goal**: sources of truth updated; F-26 / WS5-02 closed.
+**Commit**: `docs(specs): update awards shape docs; close F-26 / WS5-02 in review ledger`
+**AC**: AC-10
+
+- [ ] **7.1 (S)** `.specs/technical/firestore-schema.md`: update the `seasons/{year}`
+      `awards` row — flat shape (reference `SeasonAwards` in `src/types/season.ts`), note
+      "verified against prod 2026-07-12; all seven historical seasons populated"; remove
+      `ComputedAwards` from the TypeScript-interfaces line.
+- [ ] **7.2 (S)** `.specs/features/scoring-engine.md` §"Outputs — computeSeasonAwards":
+      rewrite to the new flat-input signature — `computeSeasonAwards(shooters:
+      AwardShooterInput[], finalStandings)` returns the complete flat `SeasonAwards`;
+      placements from the caller-supplied final standings; inputs adapted from the
+      scorecard-page derivation (`toAwardShooterInputs`) so awards always match the public
+      scorecards. **Do not touch** the §"Season Awards" rules section (authoritative
+      business rules).
+- [ ] **7.3 (S)** `.specs/reviews/2026-07-deep-review/report.md` §0 remediation ledger: add
+      a row — F-26 → this feature's PR, note "finished (not deleted) per WS5-02 decision;
+      placements computed, shape reconciled flat, NaN edge guarded, admin finalize flow
+      computing from published week docs + historical display shipped; backfill closed
+      (prod already populated)".
+- [ ] **7.4 (S)** `.specs/reviews/2026-07-deep-review/backlog.md` WS5-02: mark done with a
+      pointer to `features/004-season-awards/` (or its archive path) and the PR number.
+- [ ] **7.5 (S)** Set spec.md + tasks.md Status to "Implemented — PR #NNN" (archive move to
+      `features/archive/` happens after merge per `.specs/README.md` lifecycle).
+
+**Validation**: link-check the four edited docs' relative links; `/check` clean.
+
+---
+
+## Post-merge / post-deploy
+
+- [ ] Deploy via the normal pipeline (no new Cloud Function → no runbook IAM steps, spec
+      §"Constitutional Constraints").
+- [ ] Prod spot-check: citl.club → 2025 "Season" view → awards match the prod doc values
+      (Sights Impaired 433 / Full Choke Artists 415 / Randy Jones 44.43 / Micheal Benjamin
+      43.29 / "55.24%"); 2026 shows no awards section until finalized.
+- [ ] When the 2026 season ends: admin runs Season End → preview → finalize on prod; verify
+      Home shows 2026 awards.

--- a/.specs/features/scoring-engine.md
+++ b/.specs/features/scoring-engine.md
@@ -155,9 +155,15 @@ Returns a new `SeasonData` with `totals` populated.
 
 ### Outputs — computeSeasonAwards
 
-Returns a partial `SeasonAwards` with shooter-based awards only.
-Team standings awards (`firstPlaceTeam`, etc.) are computed separately
-from cumulative rank+bonus totals and are returned as `null`.
+`computeSeasonAwards(shooters: AwardShooterInput[], finalStandings: SeasonStandings[])`
+returns the complete flat `SeasonAwards` (spec 004). Team placements derive from the
+rank-1/rank-2 rows of the caller-supplied final standings
+(points = `totalRankPoints + totalBonusPoints`) and are present in every branch; each
+field is null when its source row/shooter does not exist. Shooter inputs are adapted
+from the published scorecard derivation via `toAwardShooterInputs`
+(`scorecard-builder.ts`), so awards always agree with the public scorecards page.
+`computeMostImprovedScore` returns `0` when `startingAvg >= 50` (no possible
+improvement; guards the divide-by-zero).
 
 ### Season Standings Order (cumulative)
 

--- a/.specs/reviews/2026-07-deep-review/backlog.md
+++ b/.specs/reviews/2026-07-deep-review/backlog.md
@@ -284,7 +284,7 @@ Remove `lookupYardage` from src/utils/yardage.ts (+ its test cases; the app rend
 
 **Acceptance**: typecheck + tests pass; grep for the three names returns nothing outside git history.
 
-### WS5-02 · P2 · M · Season-awards pipeline (F-26) — **DECIDED: finish (Tyler, 2026-07-12)**
+### WS5-02 · P2 · M · Season-awards pipeline (F-26) — **DONE ([PR #220](https://github.com/salmoncow/citl/pull/220), 2026-07-12) via [`features/004-season-awards/`](../../features/004-season-awards/spec.md)**
 **Decision: FINISH, as its own feature spec — NOT in the WS-5 sweep.** The pipeline went
 unnoticed because no season end has occurred since the migration; the current season ends soon
 and trophies must be calculated. Feature requirements (for `@speckit` →

--- a/.specs/reviews/2026-07-deep-review/report.md
+++ b/.specs/reviews/2026-07-deep-review/report.md
@@ -32,8 +32,9 @@ The findings below are a **frozen snapshot as of 2026-07-09**; they are not edit
 | [#213](https://github.com/salmoncow/citl/pull/213) | WS-4 lint gate (WS4-05) | F-28 |
 | [#214](https://github.com/salmoncow/citl/pull/214) | WS-4 composition root (WS4-01, spec 003 PR-1) | F-01 |
 | [#215](https://github.com/salmoncow/citl/pull/215) | WS-4 score-service split (WS4-02, spec 003 PR-2) | F-21 *(file accepted at 749 lines — see backlog FU-02 for the optional API-splitting follow-up)* |
+| [#220](https://github.com/salmoncow/citl/pull/220) | Feature 004 season awards (WS5-02 — maintainer decided **finish**, not delete) | F-26 *(finished: placements computed from final standings, shape reconciled to the flat prod `SeasonAwards`, `startingAvg ≥ 50` NaN edge guarded, admin Season End preview→finalize flow computing from published week docs, historical awards displayed per selected season on Home; backfill closed — prod 2019–2025 already populated, verified 2026-07-12. `validateFirebaseConfig` remains in WS-5 sweep scope)* |
 
-**Still open** (tracked in [backlog.md](backlog.md)): the WS-5 P3 sweep (F-26 awards decision, F-44–F-46, F-49, F-50, F-52, F-54, F-56, F-58, plus the F-15 archive-lifecycle remainder) and the two post-WS-4 follow-ups appended to the backlog 2026-07-12 (FU-01 standings-derivation unification per spec 003 DD-4; FU-02 optional score-service API split per spec 003 Open Question 1). F-63's meta-consolidation landed in #201; anything not listed above is open.
+**Still open** (tracked in [backlog.md](backlog.md)): the WS-5 P3 sweep (F-44–F-46, F-49, F-50, F-52, F-54, F-56, F-58, plus the F-15 archive-lifecycle remainder and the `validateFirebaseConfig` half of F-26's finding text) and the two post-WS-4 follow-ups appended to the backlog 2026-07-12 (FU-01 standings-derivation unification per spec 003 DD-4; FU-02 optional score-service API split per spec 003 Open Question 1). F-63's meta-consolidation landed in #201; anything not listed above is open.
 
 ---
 

--- a/.specs/technical/firestore-schema.md
+++ b/.specs/technical/firestore-schema.md
@@ -141,7 +141,7 @@ Document ID: string year (e.g. `"2025"`).
 | `status` | `'active' \| 'complete'` | |
 | `currentWeek` | `number` | 1–15; reflects last published week |
 | `standings` | `SeasonStandings[]` | Denormalized array — see note below |
-| `awards` | `SeasonAwards \| null` | End-of-season awards; null mid-season |
+| `awards` | `SeasonAwards \| null` | End-of-season awards, flat ten-field shape (`src/types/season.ts`); null/absent mid-season. Written by the admin Season End finalize flow (spec 004); verified against prod 2026-07-12 — all seven historical seasons (2019–2025) populated |
 | `weekDateOverrides` | `Partial<Record<string, string \| null>>` | Optional; overrides computed shoot dates per week number |
 
 **Denormalized standings:** The `standings` array is written on every publish so the
@@ -150,7 +150,7 @@ is an intentional O(1) read trade-off; keep it in sync on every publish.
 
 **Access:** Read — public. Write — admin only.
 
-**TypeScript interfaces:** `Season`, `SeasonAwards`, `SeasonStandings`, `ComputedAwards` — `src/types/season.ts`
+**TypeScript interfaces:** `Season`, `SeasonAwards`, `SeasonStandings`, `AwardShooterInput` — `src/types/season.ts`
 
 ---
 
@@ -332,6 +332,6 @@ this section — the two must always match.
 |-----------|------|
 | `Shooter`, `Accolade` | `src/types/shooter.ts` |
 | `Team`, `TeamTotals`, `ShooterScore`, `TeamResult`, `WeekResult`, `SeasonEntry`, `StandingRow` | `src/types/score.ts` |
-| `Season`, `SeasonAwards`, `SeasonStandings`, `ComputedAwards` | `src/types/season.ts` |
+| `Season`, `SeasonAwards`, `SeasonStandings`, `AwardShooterInput` | `src/types/season.ts` |
 | `ScorecardShooter` (display layer only) | `src/types/scorecard.ts` |
 | `Announcement` | `src/types/announcement.ts` |

--- a/scripts/fixtures/seed-data.js
+++ b/scripts/fixtures/seed-data.js
@@ -201,23 +201,42 @@ function buildStandings(teams, throughWeekIdx) {
   return rows;
 }
 
+/**
+ * Flat SeasonAwards shape (src/types/season.ts) — the shape all seven prod
+ * seasons store. Plain-JS mirror of the engine's rules; must not import the
+ * TS engine. Complete seasons only: placements come from the full-season
+ * standings (rank 1/2, points = rank + bonus totals).
+ */
 export function buildAwards(teams) {
-  let top = { shooterName: '', teamName: '', avg: -1 };
-  let rookie = { shooterName: '', teamName: '', avg: -1 };
+  const standings = buildStandings(teams, WEEKS_PER_SEASON - 1);
+  const first = standings.find((r) => r.rank === 1) ?? null;
+  const second = standings.find((r) => r.rank === 2) ?? null;
+
+  let top = null; //     { name, avg }
+  let rookie = null; //  { name, avg }
+  let improved = null; // { name, score }
   for (const team of teams) {
     for (const s of team.shooters) {
-      if (s.finalAvg !== null && s.finalAvg > top.avg) {
-        top = { shooterName: s.name, teamName: team.name, avg: s.finalAvg };
-      }
-      if (s.rookie && s.finalAvg !== null && s.finalAvg > rookie.avg) {
-        rookie = { shooterName: s.name, teamName: team.name, avg: s.finalAvg };
-      }
+      if (s.finalAvg === null) continue;
+      if (!top || s.finalAvg > top.avg) top = { name: s.name, avg: s.finalAvg };
+      if (s.rookie && (!rookie || s.finalAvg > rookie.avg)) rookie = { name: s.name, avg: s.finalAvg };
+      // Most Improved formula with the startingAvg >= 50 guard (engine DD-4).
+      const score = s.startingAvg >= 50 ? 0 : (100 * (s.finalAvg - s.startingAvg)) / (50 - s.startingAvg);
+      if (!improved || score > improved.score) improved = { name: s.name, score };
     }
   }
+
   return {
-    highestAvg: top,
-    rookieOfYear: rookie.avg >= 0 ? rookie : null,
-    mostImproved: null,
+    firstPlaceTeam: first ? first.teamName : null,
+    firstPlacePoints: first ? first.totalRankPoints + first.totalBonusPoints : null,
+    secondPlaceTeam: second ? second.teamName : null,
+    secondPlacePoints: second ? second.totalRankPoints + second.totalBonusPoints : null,
+    highestAvgShooter: top ? top.name : null,
+    highestAvg: top ? top.avg : null,
+    rookieOfYear: rookie ? rookie.name : null,
+    rookieAvg: rookie ? rookie.avg : null,
+    mostImproved: improved ? improved.name : null,
+    improvement: improved ? `${improved.score.toFixed(2)}%` : null,
   };
 }
 
@@ -241,7 +260,9 @@ export function buildSeason(year, status, currentWeek, teams, awards) {
     status,
     currentWeek,
     standings,
-    awards,
+    // Active seasons carry NO awards field, matching prod (2026 has the
+    // field absent until the Season End finalize flow writes it).
+    ...(awards ? { awards } : {}),
   };
 }
 

--- a/src/components/admin-panel.ts
+++ b/src/components/admin-panel.ts
@@ -9,6 +9,7 @@
  *   - Team Management — team list with inline editing + roster modal
  *   - Score Entry     — weekly entry form, date override, publish
  *   - Announcements   — site banner + per-year announcements
+ *   - Season End      — preview + finalize season awards (spec 004)
  *   - Users           — hosts <admin-users-panel> (owner-only dropdown)
  *
  * No shadow DOM. All user values rendered via textContent (never innerHTML),
@@ -24,13 +25,14 @@ import { buildOptions } from './admin-tabs/admin-shared';
 import { TeamManagementTab } from './admin-tabs/team-management-tab';
 import { ScoreEntryTab } from './admin-tabs/score-entry-tab';
 import { AnnouncementsTab } from './admin-tabs/announcements-tab';
+import { SeasonEndTab } from './admin-tabs/season-end-tab';
 import type { AdminTab, AdminTabContext } from './admin-tabs/types';
 
-const { scoreService } = getServices();
+const { scoreService, seasonAwardsService } = getServices();
 
 const CURRENT_YEAR = new Date().getFullYear();
 
-type TabName = 'team-mgmt' | 'score-entry' | 'announcements' | 'users';
+type TabName = 'team-mgmt' | 'score-entry' | 'announcements' | 'season-end' | 'users';
 
 class AdminPanel extends HTMLElement {
   private _teamsData: Team[] | null = null;
@@ -41,10 +43,11 @@ class AdminPanel extends HTMLElement {
   private readonly _teamMgmtTab = new TeamManagementTab(scoreService);
   private readonly _scoreEntryTab = new ScoreEntryTab(scoreService);
   private readonly _announcementsTab = new AnnouncementsTab(scoreService);
+  private readonly _seasonEndTab = new SeasonEndTab(seasonAwardsService);
 
   /** All tabs that implement the AdminTab lifecycle (excludes self-managed Users tab). */
   private get _lifecycleTabs(): AdminTab[] {
-    return [this._teamMgmtTab, this._scoreEntryTab, this._announcementsTab];
+    return [this._teamMgmtTab, this._scoreEntryTab, this._announcementsTab, this._seasonEndTab];
   }
 
   connectedCallback(): void {
@@ -54,6 +57,7 @@ class AdminPanel extends HTMLElement {
           <button class="admin-tab-btn is-active" data-tab="team-mgmt">Team Management</button>
           <button class="admin-tab-btn" data-tab="score-entry">Score Entry</button>
           <button class="admin-tab-btn" data-tab="announcements">Announcements</button>
+          <button class="admin-tab-btn" data-tab="season-end">Season End</button>
           <button class="admin-tab-btn" data-tab="users">Users</button>
         </div>
 
@@ -65,6 +69,7 @@ class AdminPanel extends HTMLElement {
         <div id="ap-panel-team-mgmt" class="admin-tab-content"></div>
         <div id="ap-panel-score-entry" class="admin-tab-content admin-tab-panel--hidden"></div>
         <div id="ap-panel-announcements" class="admin-tab-content admin-tab-panel--hidden"></div>
+        <div id="ap-panel-season-end" class="admin-tab-content admin-tab-panel--hidden"></div>
         <div id="ap-panel-users" class="admin-tab-content admin-tab-panel--hidden">
           <admin-users-panel></admin-users-panel>
         </div>
@@ -74,6 +79,7 @@ class AdminPanel extends HTMLElement {
     this._teamMgmtTab.mount(this.querySelector<HTMLElement>('#ap-panel-team-mgmt')!, ctx);
     this._scoreEntryTab.mount(this.querySelector<HTMLElement>('#ap-panel-score-entry')!, ctx);
     this._announcementsTab.mount(this.querySelector<HTMLElement>('#ap-panel-announcements')!, ctx);
+    this._seasonEndTab.mount(this.querySelector<HTMLElement>('#ap-panel-season-end')!, ctx);
 
     for (const btn of this.querySelectorAll<HTMLButtonElement>('.admin-tab-btn')) {
       btn.addEventListener('click', () => this._switchTab((btn.dataset['tab'] ?? '') as TabName));
@@ -103,6 +109,7 @@ class AdminPanel extends HTMLElement {
       { id: 'ap-panel-team-mgmt', name: 'team-mgmt' },
       { id: 'ap-panel-score-entry', name: 'score-entry' },
       { id: 'ap-panel-announcements', name: 'announcements' },
+      { id: 'ap-panel-season-end', name: 'season-end' },
       { id: 'ap-panel-users', name: 'users' },
     ]) {
       const el = this.querySelector(`#${id}`);
@@ -114,6 +121,7 @@ class AdminPanel extends HTMLElement {
 
     if (tab === 'score-entry') this._scoreEntryTab.onActivate?.();
     else if (tab === 'announcements') this._announcementsTab.onActivate?.();
+    else if (tab === 'season-end') this._seasonEndTab.onActivate?.();
   }
 
   // ── Shared data refresh ──────────────────────────────────────────────────

--- a/src/components/admin-tabs/season-end-tab.ts
+++ b/src/components/admin-tabs/season-end-tab.ts
@@ -1,0 +1,224 @@
+/**
+ * Season End tab — two-phase season finalize (spec 004 DD-3).
+ *
+ * Preview computes the season awards read-only from PUBLISHED data
+ * (SeasonAwardsService); Finalize writes { awards, status: 'complete' } to
+ * the season document. Finalize is idempotent — re-running after a week
+ * correction recomputes and overwrites (the documented recovery path; there
+ * is no separate "reopen" action).
+ *
+ * The mount skeleton is static HTML; every dynamic value is rendered via
+ * textContent (component contract, src/components/README.md).
+ */
+
+import { SeasonAwardsService } from '@/services/season-awards-service';
+import { showToast } from '@/modules/ui';
+import type { SeasonAwards } from '@/types/season';
+import { setStatus } from './admin-shared';
+import type { AdminTab, AdminTabContext } from './types';
+
+const WEEK_COUNT = 15;
+
+/** Preview rows: label + formatted value ("—" when the field is null). */
+function previewRows(awards: SeasonAwards): { label: string; value: string }[] {
+  const pts = (team: string | null, points: number | null): string =>
+    team === null ? '—' : `${team} — ${points ?? '?'} pts`;
+  const avg = (name: string | null, average: number | null): string =>
+    name === null ? '—' : `${name} — ${average === null ? '?' : average.toFixed(2)} avg`;
+  return [
+    { label: 'First Place', value: pts(awards.firstPlaceTeam, awards.firstPlacePoints) },
+    { label: 'Second Place', value: pts(awards.secondPlaceTeam, awards.secondPlacePoints) },
+    { label: 'Highest Average', value: avg(awards.highestAvgShooter, awards.highestAvg) },
+    { label: 'Rookie of the Year', value: avg(awards.rookieOfYear, awards.rookieAvg) },
+    {
+      label: 'Most Improved',
+      value: awards.mostImproved === null ? '—' : `${awards.mostImproved} — ${awards.improvement ?? '?'}`,
+    },
+  ];
+}
+
+export class SeasonEndTab implements AdminTab {
+  private _host: HTMLElement | null = null;
+  private _ctx: AdminTabContext | null = null;
+  private readonly _seasonAwardsService: SeasonAwardsService;
+
+  /** Year of the last successful preview; finalize only enabled for it. */
+  private _previewedYear: number | null = null;
+  /** Re-entrancy guard: both buttons disabled while a call is in flight. */
+  private _busy = false;
+
+  constructor(seasonAwardsService: SeasonAwardsService) {
+    this._seasonAwardsService = seasonAwardsService;
+  }
+
+  mount(host: HTMLElement, ctx: AdminTabContext): void {
+    this._host = host;
+    this._ctx = ctx;
+
+    host.innerHTML = `
+      <h3>Season End</h3>
+      <p class="admin-publish-note">
+        Compute the season trophies from published results, review the preview, then finalize.
+        Finalizing writes the awards to the season and marks it complete. It is safe to re-run:
+        if a week is corrected and republished, run Preview and Finalize again.
+      </p>
+      <p id="se-season-status" class="admin-status" aria-live="polite"></p>
+      <p id="se-week-warning" class="admin-status admin-status--error" hidden></p>
+      <div class="admin-form-row">
+        <button id="se-preview-btn" class="btn-primary">Compute Awards Preview</button>
+      </div>
+      <div id="se-preview-wrapper" class="admin-table-wrapper" hidden>
+        <table>
+          <tbody id="se-preview-body"></tbody>
+        </table>
+      </div>
+      <div class="admin-form-row">
+        <button id="se-finalize-btn" class="btn-danger" disabled>Finalize Season</button>
+      </div>
+      <p id="se-status" class="admin-status" aria-live="polite"></p>`;
+
+    host.querySelector('#se-preview-btn')!.addEventListener('click', () => void this._preview());
+    host.querySelector('#se-finalize-btn')!.addEventListener('click', () => void this._finalize());
+
+    this._renderSeasonStatus();
+  }
+
+  onYearChange(): void {
+    this._clearPreview();
+    this._renderSeasonStatus();
+  }
+
+  onSeasonChanged(): void {
+    this._renderSeasonStatus();
+  }
+
+  onActivate(): void {
+    this._renderSeasonStatus();
+  }
+
+  // ── Rendering ────────────────────────────────────────────────────────────
+
+  private _renderSeasonStatus(): void {
+    const el = this._host?.querySelector('#se-season-status');
+    if (!el) return;
+    const season = this._ctx?.getSeasonData();
+    if (!season) {
+      el.textContent = 'No season data loaded for this year.';
+      return;
+    }
+    const awardsState = season.awards ? 'awards written' : 'no awards yet';
+    el.textContent =
+      `Season ${season.year}: status ${season.status}, ` +
+      `week ${season.currentWeek} of ${WEEK_COUNT}, ${awardsState}.`;
+  }
+
+  private _renderPreview(awards: SeasonAwards): void {
+    const host = this._host;
+    if (!host) return;
+    const table = host.querySelector<HTMLElement>('#se-preview-wrapper')!;
+    const body = host.querySelector('#se-preview-body')!;
+    body.textContent = '';
+    for (const row of previewRows(awards)) {
+      const tr = document.createElement('tr');
+      const th = document.createElement('th');
+      th.scope = 'row';
+      th.textContent = row.label;
+      const td = document.createElement('td');
+      td.textContent = row.value;
+      tr.append(th, td);
+      body.appendChild(tr);
+    }
+    table.hidden = false;
+  }
+
+  private _clearPreview(): void {
+    const host = this._host;
+    if (!host) return;
+    this._previewedYear = null;
+    host.querySelector<HTMLElement>('#se-preview-wrapper')!.hidden = true;
+    host.querySelector('#se-preview-body')!.textContent = '';
+    host.querySelector<HTMLButtonElement>('#se-finalize-btn')!.disabled = true;
+    host.querySelector<HTMLElement>('#se-week-warning')!.hidden = true;
+    this._setStatus('', '');
+  }
+
+  // ── Actions ──────────────────────────────────────────────────────────────
+
+  private async _preview(): Promise<void> {
+    const ctx = this._ctx;
+    if (!ctx || this._busy) return;
+    const year = ctx.getYear();
+
+    this._setBusy(true);
+    this._setStatus('Computing preview…', '');
+    const result = await this._seasonAwardsService.previewAwards(year);
+    this._setBusy(false);
+
+    if (!result.success) {
+      this._clearPreview();
+      this._setStatus(`Preview failed: ${result.error}`, 'error');
+      return;
+    }
+
+    this._previewedYear = year;
+    this._renderPreview(result.data);
+
+    const warning = this._host?.querySelector<HTMLElement>('#se-week-warning');
+    const season = ctx.getSeasonData();
+    if (warning) {
+      if (season && season.currentWeek < WEEK_COUNT) {
+        warning.textContent =
+          `Only ${season.currentWeek} of ${WEEK_COUNT} weeks are published. ` +
+          'Finalize anyway only if the season genuinely ended early.';
+        warning.hidden = false;
+      } else {
+        warning.hidden = true;
+      }
+    }
+
+    this._host!.querySelector<HTMLButtonElement>('#se-finalize-btn')!.disabled = false;
+    this._setStatus('Preview ready. Review the values above, then finalize.', 'success');
+  }
+
+  private async _finalize(): Promise<void> {
+    const ctx = this._ctx;
+    if (!ctx || this._busy) return;
+    const year = ctx.getYear();
+    if (this._previewedYear !== year) return; // stale preview — button should be disabled
+
+    const ok = window.confirm(
+      `Finalize season ${year}? This writes the previewed awards and marks the season complete. ` +
+      'You can re-run Preview + Finalize later if a week is corrected.',
+    );
+    if (!ok) return;
+
+    this._setBusy(true);
+    this._setStatus('Finalizing…', '');
+    const result = await this._seasonAwardsService.finalizeSeason(year);
+    this._setBusy(false);
+
+    if (!result.success) {
+      this._setStatus(`Finalize failed: ${result.error}`, 'error');
+      return;
+    }
+
+    showToast('success', `Season ${year} finalized — awards written.`);
+    this._setStatus(`Season ${year} finalized.`, 'success');
+    void ctx.refreshSeason();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private _setBusy(busy: boolean): void {
+    this._busy = busy;
+    const host = this._host;
+    if (!host) return;
+    host.querySelector<HTMLButtonElement>('#se-preview-btn')!.disabled = busy;
+    const finalizeBtn = host.querySelector<HTMLButtonElement>('#se-finalize-btn')!;
+    finalizeBtn.disabled = busy || this._previewedYear === null;
+  }
+
+  private _setStatus(message: string, type: '' | 'success' | 'error'): void {
+    setStatus(this._host?.querySelector('#se-status') ?? null, message, type);
+  }
+}

--- a/src/components/admin-tabs/season-end-tab.ts
+++ b/src/components/admin-tabs/season-end-tab.ts
@@ -11,7 +11,7 @@
  * textContent (component contract, src/components/README.md).
  */
 
-import { SeasonAwardsService } from '@/services/season-awards-service';
+import type { SeasonAwardsService } from '@/services/season-awards-service';
 import { showToast } from '@/modules/ui';
 import type { SeasonAwards } from '@/types/season';
 import { setStatus } from './admin-shared';

--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -9,7 +9,7 @@ import { getServices } from '@/services/app-services';
 import { compareStandings } from '@/services/scoring-engine';
 import { escapeHtml } from '@/modules/ui';
 import type { Team, WeekResult } from '@/types/score';
-import type { Season } from '@/types/season';
+import type { Season, SeasonAwards } from '@/types/season';
 import type { Accolade } from '@/types/shooter';
 
 const { scoreService } = getServices();
@@ -211,9 +211,79 @@ class HomeStandings extends HTMLElement {
       accolades = weekResult.accolades ?? [];
     }
 
+    // Season awards ride the already-loaded season doc — zero extra reads
+    // (spec 004 AC-6). Rendered only in the Season view and only when the
+    // finalize flow (or the legacy migration) has written awards.
+    const awardsHtml =
+      weekKey === 'season' && this._season?.awards
+        ? this._renderAwards(this._season.awards)
+        : '';
+
     this.querySelector('#hs-table')!.innerHTML =
+      awardsHtml +
       this._renderAccolades(accolades) +
       this._buildTable(rows, subtitle);
+  }
+
+  /**
+   * Season Awards section (spec 004 DD-2). Each field is null-guarded
+   * independently (repository reads are unvalidated casts); rows with a
+   * missing winner are omitted, and the whole section is omitted when no
+   * row renders.
+   */
+  private _renderAwards(awards: SeasonAwards): string {
+    const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+    const items: { badge: string; name: string; detail: string }[] = [];
+    if (typeof awards.firstPlaceTeam === 'string') {
+      items.push({
+        badge: 'First Place',
+        name: awards.firstPlaceTeam,
+        detail: num(awards.firstPlacePoints) ? `${awards.firstPlacePoints} pts` : '',
+      });
+    }
+    if (typeof awards.secondPlaceTeam === 'string') {
+      items.push({
+        badge: 'Second Place',
+        name: awards.secondPlaceTeam,
+        detail: num(awards.secondPlacePoints) ? `${awards.secondPlacePoints} pts` : '',
+      });
+    }
+    if (typeof awards.highestAvgShooter === 'string') {
+      items.push({
+        badge: 'Highest Average',
+        name: awards.highestAvgShooter,
+        detail: num(awards.highestAvg) ? `${awards.highestAvg.toFixed(2)} avg` : '',
+      });
+    }
+    if (typeof awards.rookieOfYear === 'string') {
+      items.push({
+        badge: 'Rookie of the Year',
+        name: awards.rookieOfYear,
+        detail: num(awards.rookieAvg) ? `${awards.rookieAvg.toFixed(2)} avg` : '',
+      });
+    }
+    if (typeof awards.mostImproved === 'string') {
+      items.push({
+        badge: 'Most Improved',
+        name: awards.mostImproved,
+        detail: typeof awards.improvement === 'string' ? awards.improvement : '',
+      });
+    }
+    if (items.length === 0) return '';
+
+    const lis = items.map((item) => `
+      <li class="awards-item">
+        <span class="awards-badge">${escapeHtml(item.badge)}</span>
+        <span class="awards-item__name">${escapeHtml(item.name)}</span>
+        <span class="awards-item__detail">${escapeHtml(item.detail)}</span>
+      </li>`).join('');
+
+    return `
+    <div class="awards-section">
+      <h3 class="awards-section__heading">Season Awards</h3>
+      <ul class="awards-list">${lis}</ul>
+    </div>`;
   }
 
   private _renderAccolades(accolades: Accolade[]): string {

--- a/src/components/home-standings.ts
+++ b/src/components/home-standings.ts
@@ -226,63 +226,80 @@ class HomeStandings extends HTMLElement {
   }
 
   /**
-   * Season Awards section (spec 004 DD-2). Each field is null-guarded
-   * independently (repository reads are unvalidated casts); rows with a
-   * missing winner are omitted, and the whole section is omitted when no
-   * row renders.
+   * Season Awards table (spec 004 DD-2, table refinement 2026-07-12). Each
+   * field is null-guarded independently (repository reads are unvalidated
+   * casts); rows with a missing winner are omitted, and the whole section is
+   * omitted when no row renders. Icons are plain emoji — no icon font or
+   * custom assets (ADR-008).
    */
   private _renderAwards(awards: SeasonAwards): string {
     const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
 
-    const items: { badge: string; name: string; detail: string }[] = [];
+    const rows: { icon: string; award: string; winner: string; result: string }[] = [];
     if (typeof awards.firstPlaceTeam === 'string') {
-      items.push({
-        badge: 'First Place',
-        name: awards.firstPlaceTeam,
-        detail: num(awards.firstPlacePoints) ? `${awards.firstPlacePoints} pts` : '',
+      rows.push({
+        icon: '\u{1F3C6}', // 🏆
+        award: 'First Place',
+        winner: awards.firstPlaceTeam,
+        result: num(awards.firstPlacePoints) ? `${awards.firstPlacePoints} pts` : '—',
       });
     }
     if (typeof awards.secondPlaceTeam === 'string') {
-      items.push({
-        badge: 'Second Place',
-        name: awards.secondPlaceTeam,
-        detail: num(awards.secondPlacePoints) ? `${awards.secondPlacePoints} pts` : '',
+      rows.push({
+        icon: '\u{1F948}', // 🥈
+        award: 'Second Place',
+        winner: awards.secondPlaceTeam,
+        result: num(awards.secondPlacePoints) ? `${awards.secondPlacePoints} pts` : '—',
       });
     }
     if (typeof awards.highestAvgShooter === 'string') {
-      items.push({
-        badge: 'Highest Average',
-        name: awards.highestAvgShooter,
-        detail: num(awards.highestAvg) ? `${awards.highestAvg.toFixed(2)} avg` : '',
+      rows.push({
+        icon: '\u{1F3AF}', // 🎯
+        award: 'Highest Average',
+        winner: awards.highestAvgShooter,
+        result: num(awards.highestAvg) ? `${awards.highestAvg.toFixed(2)} avg` : '—',
       });
     }
     if (typeof awards.rookieOfYear === 'string') {
-      items.push({
-        badge: 'Rookie of the Year',
-        name: awards.rookieOfYear,
-        detail: num(awards.rookieAvg) ? `${awards.rookieAvg.toFixed(2)} avg` : '',
+      rows.push({
+        icon: '\u{2B50}', // ⭐
+        award: 'Rookie of the Year',
+        winner: awards.rookieOfYear,
+        result: num(awards.rookieAvg) ? `${awards.rookieAvg.toFixed(2)} avg` : '—',
       });
     }
     if (typeof awards.mostImproved === 'string') {
-      items.push({
-        badge: 'Most Improved',
-        name: awards.mostImproved,
-        detail: typeof awards.improvement === 'string' ? awards.improvement : '',
+      rows.push({
+        icon: '\u{1F4C8}', // 📈
+        award: 'Most Improved',
+        winner: awards.mostImproved,
+        result: typeof awards.improvement === 'string' ? awards.improvement : '—',
       });
     }
-    if (items.length === 0) return '';
+    if (rows.length === 0) return '';
 
-    const lis = items.map((item) => `
-      <li class="awards-item">
-        <span class="awards-badge">${escapeHtml(item.badge)}</span>
-        <span class="awards-item__name">${escapeHtml(item.name)}</span>
-        <span class="awards-item__detail">${escapeHtml(item.detail)}</span>
-      </li>`).join('');
+    const trs = rows.map((row) => `
+        <tr>
+          <td class="awards-table__award">
+            <span class="awards-table__icon" aria-hidden="true">${row.icon}</span>${escapeHtml(row.award)}
+          </td>
+          <td class="awards-table__winner">${escapeHtml(row.winner)}</td>
+          <td class="awards-table__result">${escapeHtml(row.result)}</td>
+        </tr>`).join('');
 
     return `
     <div class="awards-section">
       <h3 class="awards-section__heading">Season Awards</h3>
-      <ul class="awards-list">${lis}</ul>
+      <table class="awards-table">
+        <thead>
+          <tr>
+            <th>Award</th>
+            <th>Winner</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>${trs}</tbody>
+      </table>
     </div>`;
   }
 

--- a/src/services/app-services.ts
+++ b/src/services/app-services.ts
@@ -18,10 +18,12 @@
 import { db } from '@/firebase-config';
 import { createRepositoryFactory, type RepositoryFactory } from '@/repositories/repository-factory';
 import { ScoreService } from '@/services/score-service';
+import { SeasonAwardsService } from '@/services/season-awards-service';
 
 export interface AppServices {
   repositoryFactory: RepositoryFactory;
   scoreService: ScoreService;
+  seasonAwardsService: SeasonAwardsService;
 }
 
 let instance: AppServices | null = null;
@@ -29,8 +31,10 @@ let instance: AppServices | null = null;
 export function getServices(): AppServices {
   if (!instance) {
     const repositoryFactory = createRepositoryFactory({ db });
-    const scoreService = new ScoreService(repositoryFactory.getScoreRepository());
-    instance = Object.freeze({ repositoryFactory, scoreService });
+    const repository = repositoryFactory.getScoreRepository();
+    const scoreService = new ScoreService(repository);
+    const seasonAwardsService = new SeasonAwardsService(repository, scoreService);
+    instance = Object.freeze({ repositoryFactory, scoreService, seasonAwardsService });
   }
   return instance;
 }

--- a/src/services/scorecard-builder.test.ts
+++ b/src/services/scorecard-builder.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @file scorecard-builder.test.ts
+ * Unit tests for toAwardShooterInputs — the pure adapter from rendered
+ * scorecard blocks to the flat inputs computeSeasonAwards consumes
+ * (spec 004 DD-3). Pure function — no mocks needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ScorecardRowShooter, ScorecardTeamBlock } from '@/types/scorecard';
+import { toAwardShooterInputs } from './scorecard-builder';
+
+const makeRow = (overrides: Partial<ScorecardRowShooter> = {}): ScorecardRowShooter => ({
+  name: 'Alice',
+  rookie: false,
+  isDummy: false,
+  w0Display: 42.5,
+  scores: new Array<number | null>(15).fill(null),
+  weeksShot: null,
+  finalAvg: 42.5,
+  ...overrides,
+});
+
+const makeBlock = (teamName: string, shooters: ScorecardRowShooter[]): ScorecardTeamBlock => ({
+  teamName,
+  shooters,
+  targets: new Array<number | null>(15).fill(null),
+  rankPoints: new Array<number | null>(15).fill(null),
+  bonusPoints: new Array<number | null>(15).fill(null),
+});
+
+describe('toAwardShooterInputs', () => {
+  it('maps row fields and attaches the block teamName', () => {
+    const scores = new Array<number | null>(15).fill(null);
+    scores[0] = 44;
+    const inputs = toAwardShooterInputs([
+      makeBlock('Sights Impaired', [makeRow({ name: 'Randy', rookie: true, w0Display: 38.25, scores })]),
+    ]);
+    expect(inputs).toEqual([
+      {
+        name: 'Randy',
+        teamName: 'Sights Impaired',
+        isDummy: false,
+        rookie: true,
+        startingAvg: 38.25,
+        scores,
+      },
+    ]);
+  });
+
+  it("skips rows whose w0Display is '-' (dummy/padding rows only)", () => {
+    const inputs = toAwardShooterInputs([
+      makeBlock('Team A', [
+        makeRow({ name: 'Real', w0Display: 40 }),
+        makeRow({ name: 'A DUMMY2', isDummy: true, w0Display: '-' }),
+      ]),
+    ]);
+    expect(inputs.map((i) => i.name)).toEqual(['Real']);
+  });
+
+  it('passes numeric-W0 dummies through with isDummy intact (engine stays the exclusion authority)', () => {
+    const inputs = toAwardShooterInputs([
+      makeBlock('Team A', [makeRow({ name: 'A DUMMY1', isDummy: true, w0Display: 41.3 })]),
+    ]);
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]!.isDummy).toBe(true);
+    expect(inputs[0]!.startingAvg).toBe(41.3);
+  });
+
+  it('flattens multiple blocks in order and ignores display finalAvg/weeksShot', () => {
+    const inputs = toAwardShooterInputs([
+      makeBlock('Team A', [makeRow({ name: 'A1', finalAvg: '—' as unknown as string, weeksShot: 3 })]),
+      makeBlock('Team B', [makeRow({ name: 'B1' }), makeRow({ name: 'B2' })]),
+    ]);
+    expect(inputs.map((i) => `${i.teamName}/${i.name}`)).toEqual(['Team A/A1', 'Team B/B1', 'Team B/B2']);
+    expect(inputs[0]).not.toHaveProperty('finalAvg');
+    expect(inputs[0]).not.toHaveProperty('weeksShot');
+  });
+
+  it('returns [] for empty blocks', () => {
+    expect(toAwardShooterInputs([])).toEqual([]);
+    expect(toAwardShooterInputs([makeBlock('Empty', [])])).toEqual([]);
+  });
+});

--- a/src/services/scorecard-builder.ts
+++ b/src/services/scorecard-builder.ts
@@ -12,6 +12,7 @@
 import { computeDummyScore, computeShooterAverage, computeShooterStartingAvg, getLastWord, isDummyName, isShooterRookie, mean, normalizeShooterName, sortShootersWithCaptainFirst } from '@/services/scoring-engine';
 import type { Team, WeekResult, SeasonEntry } from '@/types/score';
 import type { SeasonData, ScorecardShooter, ScorecardRowShooter, ScorecardTeamBlock } from '@/types/scorecard';
+import type { AwardShooterInput } from '@/types/season';
 
 export function buildSeasonData(
   year: number,
@@ -269,4 +270,32 @@ export function buildScorecardTeamBlock(args: {
     rankPoints,
     bonusPoints,
   };
+}
+
+/**
+ * Adapt rendered scorecard blocks into the flat per-shooter inputs
+ * computeSeasonAwards consumes (spec 004 DD-3), so trophies are always
+ * computed from the same published-data derivation the scorecards page
+ * displays. Rows without a numeric w0Display are skipped — only dummy/padding
+ * rows can lack a numeric W0 (rostered shooters always get a derived going-in
+ * average), and the engine excludes numeric-W0 dummies via isDummy. The row's
+ * display-rounded finalAvg/weeksShot are ignored; the engine recomputes at
+ * full precision. Pure — no I/O.
+ */
+export function toAwardShooterInputs(blocks: ScorecardTeamBlock[]): AwardShooterInput[] {
+  const inputs: AwardShooterInput[] = [];
+  for (const block of blocks) {
+    for (const row of block.shooters) {
+      if (typeof row.w0Display !== 'number') continue;
+      inputs.push({
+        name: row.name,
+        teamName: block.teamName,
+        isDummy: row.isDummy,
+        rookie: row.rookie,
+        startingAvg: row.w0Display,
+        scores: row.scores,
+      });
+    }
+  }
+  return inputs;
 }

--- a/src/services/scoring-engine.test.ts
+++ b/src/services/scoring-engine.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { ScorecardShooter, SeasonData, Team as ScTeam, TeamTotals } from '@/types/scorecard';
+import type { ScorecardShooter, SeasonData, TeamTotals } from '@/types/scorecard';
 import type { AwardShooterInput, SeasonStandings } from '@/types/season';
 import type { Team as PriorTeam, TeamResult } from '@/types/score';
 import type { Shooter } from '@/types/shooter';

--- a/src/services/scoring-engine.test.ts
+++ b/src/services/scoring-engine.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ScorecardShooter, SeasonData, Team as ScTeam, TeamTotals } from '@/types/scorecard';
+import type { AwardShooterInput, SeasonStandings } from '@/types/season';
 import type { Team as PriorTeam, TeamResult } from '@/types/score';
 import type { Shooter } from '@/types/shooter';
 import {
@@ -616,6 +617,15 @@ describe('computeMostImprovedScore', () => {
     // 100 * (45-30) / (50-30) = 100 * 15/20 = 75
     expect(computeMostImprovedScore(30, 45)).toBe(75);
   });
+
+  it('guards the divide-by-zero: startingAvg=50 → 0, never Infinity/NaN (DD-4)', () => {
+    expect(computeMostImprovedScore(50, 45)).toBe(0);
+    expect(computeMostImprovedScore(50, 50)).toBe(0);
+  });
+
+  it('guards impossible startingAvg>50 (bad import) → 0, not a sign-flipped score', () => {
+    expect(computeMostImprovedScore(55, 40)).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -623,51 +633,97 @@ describe('computeMostImprovedScore', () => {
 // ---------------------------------------------------------------------------
 
 describe('computeSeasonAwards', () => {
-  const makeTeam = (name: string, shooters: ScorecardShooter[]): ScTeam => ({
+  const makeAwardShooter = (
+    name: string,
+    startingAvg: number,
+    scores: (number | null)[],
+    opts: { rookie?: boolean; isDummy?: boolean; teamName?: string } = {},
+  ): AwardShooterInput => ({
     name,
-    shooters,
-    totals: makeEmptyTotals(),
+    teamName: opts.teamName ?? 'Team A',
+    isDummy: opts.isDummy ?? false,
+    rookie: opts.rookie ?? false,
+    startingAvg,
+    scores,
   });
 
-  const makeSeasonData = (teams: ScTeam[]): SeasonData => ({ season: 2024, teams });
+  const makeStandingsRow = (
+    rank: number,
+    teamName: string,
+    totalRankPoints: number,
+    totalBonusPoints: number,
+  ): SeasonStandings => ({
+    rank,
+    teamId: teamName.toLowerCase().replace(/\s+/g, '-'),
+    teamName,
+    totalRankPoints,
+    totalBonusPoints,
+    totalTargets: 5000,
+  });
 
-  it('returns all null when no shooters have >= 6 weeks shot', () => {
-    const scores = nScores(5, 40); // 5 < 6 weeks
-    const data = makeSeasonData([
-      makeTeam('Team A', [makeScorecardShooter('Alice', 35, scores)]),
-    ]);
-    const awards = computeSeasonAwards(data);
+  const twoTeamStandings = [
+    makeStandingsRow(1, 'Sights Impaired', 400, 33), // 433 pts
+    makeStandingsRow(2, 'Full Choke Artists', 390, 25), // 415 pts
+  ];
+
+  it('derives placements from the rank-1/rank-2 standings rows (points = rank + bonus)', () => {
+    const awards = computeSeasonAwards([makeAwardShooter('Bob', 35, nScores(6, 40))], twoTeamStandings);
+    expect(awards.firstPlaceTeam).toBe('Sights Impaired');
+    expect(awards.firstPlacePoints).toBe(433);
+    expect(awards.secondPlaceTeam).toBe('Full Choke Artists');
+    expect(awards.secondPlacePoints).toBe(415);
+  });
+
+  it('one-team standings → second-place fields null', () => {
+    const awards = computeSeasonAwards([], [makeStandingsRow(1, 'Solo', 100, 5)]);
+    expect(awards.firstPlaceTeam).toBe('Solo');
+    expect(awards.firstPlacePoints).toBe(105);
+    expect(awards.secondPlaceTeam).toBeNull();
+    expect(awards.secondPlacePoints).toBeNull();
+  });
+
+  it('empty standings → all four placement fields null', () => {
+    const awards = computeSeasonAwards([makeAwardShooter('Bob', 35, nScores(6, 40))], []);
+    expect(awards.firstPlaceTeam).toBeNull();
+    expect(awards.firstPlacePoints).toBeNull();
+    expect(awards.secondPlaceTeam).toBeNull();
+    expect(awards.secondPlacePoints).toBeNull();
+  });
+
+  it('empty-eligible branch still carries placements (no shooter with >= 6 weeks)', () => {
+    const awards = computeSeasonAwards([makeAwardShooter('Alice', 35, nScores(5, 40))], twoTeamStandings);
+    expect(awards.firstPlaceTeam).toBe('Sights Impaired');
+    expect(awards.secondPlacePoints).toBe(415);
+    expect(awards.highestAvgShooter).toBeNull();
+  });
+
+  it('shooter awards all null when no shooters have >= 6 weeks shot', () => {
+    const awards = computeSeasonAwards([makeAwardShooter('Alice', 35, nScores(5, 40))], []);
     expect(awards.highestAvgShooter).toBeNull();
     expect(awards.rookieOfYear).toBeNull();
     expect(awards.mostImproved).toBeNull();
   });
 
-  it('returns all null when all eligible shooters are dummies', () => {
-    const data = makeSeasonData([
-      makeTeam('Team A', [
-        makeScorecardShooter('DUMMY 1', 35, nScores(6, 40), { isDummy: true }),
-      ]),
-    ]);
-    expect(computeSeasonAwards(data).highestAvgShooter).toBeNull();
+  it('shooter awards all null when all eligible shooters are dummies', () => {
+    const awards = computeSeasonAwards(
+      [makeAwardShooter('DUMMY 1', 35, nScores(6, 40), { isDummy: true })],
+      [],
+    );
+    expect(awards.highestAvgShooter).toBeNull();
   });
 
   it('identifies single eligible non-rookie as highestAvgShooter; rookieOfYear is null', () => {
-    const data = makeSeasonData([
-      makeTeam('Team A', [makeScorecardShooter('Bob', 35, nScores(6, 40))]),
-    ]);
-    const awards = computeSeasonAwards(data);
+    const awards = computeSeasonAwards([makeAwardShooter('Bob', 35, nScores(6, 40))], []);
     expect(awards.highestAvgShooter).toBe('Bob');
     expect(awards.highestAvg).toBe(40);
     expect(awards.rookieOfYear).toBeNull();
   });
 
   it('single eligible rookie wins both highestAvg and rookieOfYear', () => {
-    const data = makeSeasonData([
-      makeTeam('Team A', [
-        makeScorecardShooter('Rex', 35, nScores(6, 40), { rookie: true }),
-      ]),
-    ]);
-    const awards = computeSeasonAwards(data);
+    const awards = computeSeasonAwards(
+      [makeAwardShooter('Rex', 35, nScores(6, 40), { rookie: true })],
+      [],
+    );
     expect(awards.highestAvgShooter).toBe('Rex');
     expect(awards.rookieOfYear).toBe('Rex');
   });
@@ -675,15 +731,33 @@ describe('computeSeasonAwards', () => {
   it('identifies most improved shooter with formatted percentage', () => {
     // X: startingAvg=35 → finalAvg=40  → 100*5/15  ≈ 33.33%
     // Y: startingAvg=20 → finalAvg=40  → 100*20/30 ≈ 66.67% (wins)
-    const data = makeSeasonData([
-      makeTeam('Team A', [
-        makeScorecardShooter('X', 35, nScores(6, 40)),
-        makeScorecardShooter('Y', 20, nScores(6, 40)),
-      ]),
-    ]);
-    const awards = computeSeasonAwards(data);
+    const awards = computeSeasonAwards(
+      [makeAwardShooter('X', 35, nScores(6, 40)), makeAwardShooter('Y', 20, nScores(6, 40))],
+      [],
+    );
     expect(awards.mostImproved).toBe('Y');
     expect(awards.improvement).toBe('66.67%');
+  });
+
+  it('a startingAvg=50 shooter scores 0 improvement and loses to any genuine improver', () => {
+    // Cap: 50 → 45 would divide by zero unguarded; scores 0 (DD-4).
+    // Imp: 35 → 40 → 33.33% (wins).
+    const awards = computeSeasonAwards(
+      [makeAwardShooter('Cap', 50, nScores(6, 45)), makeAwardShooter('Imp', 35, nScores(6, 40))],
+      [],
+    );
+    expect(awards.mostImproved).toBe('Imp');
+    expect(awards.improvement).toBe('33.33%');
+    expect(Number.isFinite(awards.highestAvg as number)).toBe(true);
+  });
+
+  it('award finalAvg is full-precision, not display-rounded', () => {
+    // 7 weeks: 45,44,46,45,44,46,44 → 314/7 = 44.857142857…
+    const scores = nullScores15();
+    [45, 44, 46, 45, 44, 46, 44].forEach((v, i) => { scores[i] = v; });
+    const awards = computeSeasonAwards([makeAwardShooter('Precise', 35, scores)], []);
+    expect(awards.highestAvg).toBeCloseTo(44.857142857142854, 12);
+    expect(awards.highestAvg).not.toBe(44.9);
   });
 });
 

--- a/src/services/scoring-engine.ts
+++ b/src/services/scoring-engine.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ScorecardShooter, SeasonData } from '@/types/scorecard';
-import type { ComputedAwards } from '@/types/season';
+import type { AwardShooterInput, SeasonAwards, SeasonStandings } from '@/types/season';
 import type { Team, TeamResult, WeekResult } from '@/types/score';
 import type { Accolade } from '@/types/shooter';
 
@@ -395,10 +395,6 @@ export function computeSeasonTotals(seasonData: SeasonData): SeasonData {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute the Most Improved percentage score.
- * Formula: 100 × (finalAvg − startingAvg) / (50 − startingAvg)
- */
-/**
  * Compute the starting average for a shooter entering a new season.
  * If found in any prior-year team with a non-null finalAvg, returns that value.
  * Otherwise returns 35 (new-shooter default).
@@ -461,52 +457,68 @@ export function isShooterRookie(
   return !shotInYear(prior1YearTeams, prior1AvgMap) && !shotInYear(prior2YearTeams, prior2AvgMap);
 }
 
+/**
+ * Compute the Most Improved percentage score.
+ * Formula: 100 × (finalAvg − startingAvg) / (50 − startingAvg)
+ * A shooter starting at (or above) the 50 cap has no possible improvement, so
+ * the score is 0 — this also shields historical imports from a zero or
+ * sign-flipped denominator (spec 004 DD-4).
+ */
 export function computeMostImprovedScore(startingAvg: number, finalAvg: number): number {
+  if (startingAvg >= 50) return 0;
   return (100 * (finalAvg - startingAvg)) / (50 - startingAvg);
 }
 
 /**
- * Compute season awards from final shooter averages.
- * Excludes dummy shooters. Requires weeksShot >= 6.
+ * Compute season awards from per-shooter season lines plus final standings.
+ * Shooter awards (Highest Average, Rookie of the Year, Most Improved) follow
+ * the business rules in .specs/features/scoring-engine.md §"Season Awards":
+ * dummies excluded, weeksShot >= 6, finalAvg at full precision. Team
+ * placements derive from the rank-1/rank-2 standings rows
+ * (points = totalRankPoints + totalBonusPoints) and are filled in every
+ * branch; each field is null when its source row/shooter does not exist.
  */
-export function computeSeasonAwards(seasonData: SeasonData): ComputedAwards {
+export function computeSeasonAwards(
+  shooters: AwardShooterInput[],
+  finalStandings: SeasonStandings[],
+): SeasonAwards {
   const WEEK_COUNT = 15;
   const MIN_WEEKS = 6;
 
+  const first = finalStandings.find((row) => row.rank === 1) ?? null;
+  const second = finalStandings.find((row) => row.rank === 2) ?? null;
+  const placements = {
+    firstPlaceTeam: first ? first.teamName : null,
+    firstPlacePoints: first ? first.totalRankPoints + first.totalBonusPoints : null,
+    secondPlaceTeam: second ? second.teamName : null,
+    secondPlacePoints: second ? second.totalRankPoints + second.totalBonusPoints : null,
+  };
+
   const eligible: {
     name: string;
-    teamName: string;
     finalAvg: number;
     startingAvg: number;
     rookie: boolean;
-    weeksShot: number;
   }[] = [];
 
-  for (const team of seasonData.teams) {
-    for (const shooter of team.shooters) {
-      if (shooter.isDummy) continue;
+  for (const shooter of shooters) {
+    if (shooter.isDummy) continue;
 
-      const weeksShot = shooter.scores.filter((s) => s !== null).length;
-      if (weeksShot < MIN_WEEKS) continue;
+    const weeksShot = shooter.scores.filter((s) => s !== null).length;
+    if (weeksShot < MIN_WEEKS) continue;
 
-      const finalAvg = computeShooterAverage(shooter.startingAvg, shooter.scores, WEEK_COUNT - 1);
-      eligible.push({
-        name: shooter.name,
-        teamName: team.name,
-        finalAvg,
-        startingAvg: shooter.startingAvg,
-        rookie: shooter.rookie,
-        weeksShot,
-      });
-    }
+    const finalAvg = computeShooterAverage(shooter.startingAvg, shooter.scores, WEEK_COUNT - 1);
+    eligible.push({
+      name: shooter.name,
+      finalAvg,
+      startingAvg: shooter.startingAvg,
+      rookie: shooter.rookie,
+    });
   }
 
   if (eligible.length === 0) {
     return {
-      firstPlaceTeam: null,
-      firstPlacePoints: null,
-      secondPlaceTeam: null,
-      secondPlacePoints: null,
+      ...placements,
       highestAvgShooter: null,
       highestAvg: null,
       rookieOfYear: null,
@@ -532,10 +544,7 @@ export function computeSeasonAwards(seasonData: SeasonData): ComputedAwards {
   const improvementPct = `${improvementScore.toFixed(2)}%`;
 
   return {
-    firstPlaceTeam: null,
-    firstPlacePoints: null,
-    secondPlaceTeam: null,
-    secondPlacePoints: null,
+    ...placements,
     highestAvgShooter: topShooter.name,
     highestAvg: topShooter.finalAvg,
     rookieOfYear: topRookie ? topRookie.name : null,

--- a/src/services/season-awards-service.test.ts
+++ b/src/services/season-awards-service.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @file season-awards-service.test.ts
+ * Unit tests for SeasonAwardsService (spec 004 DD-3).
+ *
+ * ScoreRepository is stubbed with in-memory data; a REAL ScoreService runs on
+ * top of it so previewAwards exercises the genuine buildScorecardData
+ * derivation (prior-year rookie/W0 rules included). Never imports
+ * app-services.
+ *
+ * Pinned invariant: the awards path reads PUBLISHED data only — the stub
+ * asserts getEntries is never called (entries are draft audit docs and may
+ * not exist for complete seasons).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { SeasonAwardsService } from './season-awards-service';
+import { ScoreService } from './score-service';
+import { success, failure } from '@/repositories/score-repository';
+import type { ScoreRepository } from '@/repositories/score-repository';
+import type { Team, WeekResult } from '@/types/score';
+import type { Season, SeasonStandings } from '@/types/season';
+import type { Shooter } from '@/types/shooter';
+
+// ---------------------------------------------------------------------------
+// Fixtures — one team, two shooters, six published weeks
+// ---------------------------------------------------------------------------
+
+const YEAR = 2025;
+
+function makeShooter(name: string, startingAvg: number, finalAvg: number | null = null): Shooter {
+  return {
+    id: '',
+    name,
+    rookie: false,
+    startingAvg,
+    finalAvg,
+    weeksShot: null,
+    scores: new Array<number | null>(15).fill(null),
+  };
+}
+
+function makeTeam(name: string, shooters: Shooter[]): Team {
+  return {
+    id: name.toLowerCase().replace(/\s+/g, '-'),
+    name,
+    captain: '',
+    shooters,
+    totals: { targets: [], rankPoints: [], bonusPoints: [] },
+  };
+}
+
+/** Six published weeks: Vet shoots 45 every week, Rook shoots 40. */
+function makeWeeks(teamName: string): WeekResult[] {
+  return Array.from({ length: 6 }, (_, i) => ({
+    weekNumber: i + 1,
+    publishedAt: '',
+    teamResults: [
+      {
+        teamId: 'team-a',
+        teamName,
+        targets: 85,
+        rankPoints: 30,
+        bonusPoints: 0,
+        shooterScores: [
+          { name: 'Vet', score1: null, score2: null, total: 45 },
+          { name: 'Rook', score1: null, score2: null, total: 40 },
+        ],
+      },
+    ],
+  }));
+}
+
+const STANDINGS: SeasonStandings[] = [
+  { rank: 1, teamId: 'team-a', teamName: 'Team A', totalRankPoints: 400, totalBonusPoints: 33, totalTargets: 5000 },
+  { rank: 2, teamId: 'team-b', teamName: 'Team B', totalRankPoints: 390, totalBonusPoints: 25, totalTargets: 4900 },
+];
+
+function makeSeason(overrides: Partial<Season> = {}): Season {
+  return {
+    id: String(YEAR),
+    year: YEAR,
+    status: 'active',
+    currentWeek: 15,
+    standings: STANDINGS,
+    awards: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Stub repository. `Vet` has a prior-year finalAvg of 40 (non-rookie,
+ * startingAvg 40); `Rook` has no prior history (rookie, default 35).
+ */
+function makeRepo(opts: {
+  season?: Season | null;
+  seasonFailure?: boolean;
+  teamsFail?: boolean;
+  weeksFail?: boolean;
+  updateSeasonFail?: boolean;
+} = {}): ScoreRepository & { updateSeason: ReturnType<typeof vi.fn>; getEntries: ReturnType<typeof vi.fn> } {
+  const teamA = makeTeam('Team A', [makeShooter('Vet', 40), makeShooter('Rook', 35)]);
+  const priorTeam = makeTeam('Old Team', [makeShooter('Vet', 38, 40)]);
+  const stub = {
+    getSeason: async () =>
+      opts.seasonFailure
+        ? failure('boom', 'FIRESTORE_READ_ERROR')
+        : success(opts.season === undefined ? makeSeason() : opts.season),
+    getTeams: async (y: number) => {
+      if (opts.teamsFail && y === YEAR) return failure('teams boom', 'FIRESTORE_READ_ERROR');
+      if (y === YEAR) return success([teamA]);
+      if (y === YEAR - 1) return success([priorTeam]);
+      return success([]);
+    },
+    getAllWeekResults: async (y: number) => {
+      if (opts.weeksFail && y === YEAR) return failure('weeks boom', 'FIRESTORE_READ_ERROR');
+      if (y === YEAR) return success(makeWeeks('Team A'));
+      return success([]);
+    },
+    updateSeason: vi.fn(async () =>
+      opts.updateSeasonFail
+        ? failure('write boom', 'FIRESTORE_WRITE_ERROR')
+        : success({}),
+    ),
+    getEntries: vi.fn(async () => success([])),
+  };
+  return stub as unknown as ScoreRepository & {
+    updateSeason: ReturnType<typeof vi.fn>;
+    getEntries: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeServices(opts: Parameters<typeof makeRepo>[0] = {}) {
+  const repo = makeRepo(opts);
+  const scoreService = new ScoreService(repo);
+  const service = new SeasonAwardsService(repo, scoreService);
+  return { repo, scoreService, service };
+}
+
+// ---------------------------------------------------------------------------
+// previewAwards
+// ---------------------------------------------------------------------------
+
+describe('SeasonAwardsService.previewAwards', () => {
+  it('happy path: full flat awards from published weeks + stored standings', async () => {
+    const { service } = makeServices();
+    const result = await service.previewAwards(YEAR);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // Placements from the stored standings rows (points = rank + bonus).
+    expect(result.data.firstPlaceTeam).toBe('Team A');
+    expect(result.data.firstPlacePoints).toBe(433);
+    expect(result.data.secondPlaceTeam).toBe('Team B');
+    expect(result.data.secondPlacePoints).toBe(415);
+
+    // Vet: prior finalAvg 40 → startingAvg 40, non-rookie; 6×45 → finalAvg 45.
+    expect(result.data.highestAvgShooter).toBe('Vet');
+    expect(result.data.highestAvg).toBe(45);
+
+    // Rook: no prior history → rookie, startingAvg 35; 6×40 → finalAvg 40.
+    expect(result.data.rookieOfYear).toBe('Rook');
+    expect(result.data.rookieAvg).toBe(40);
+
+    // Most improved: Vet 100·(45−40)/(50−40)=50% beats Rook 100·5/15≈33.33%.
+    expect(result.data.mostImproved).toBe('Vet');
+    expect(result.data.improvement).toBe('50.00%');
+  });
+
+  it('consistency property: winners agree with the scorecard rows the public sees', async () => {
+    const { service, scoreService } = makeServices();
+    const [awards, scorecards] = await Promise.all([
+      service.previewAwards(YEAR),
+      scoreService.buildScorecardData(YEAR),
+    ]);
+    expect(awards.success && scorecards.success).toBe(true);
+    if (!awards.success || !scorecards.success) return;
+
+    const rows = scorecards.data.teams.flatMap((b) => b.shooters).filter((r) => !r.isDummy);
+    const topRow = rows.reduce((best, r) =>
+      Number(r.finalAvg) > Number(best.finalAvg) ? r : best,
+    );
+    expect(awards.data.highestAvgShooter).toBe(topRow.name);
+  });
+
+  it('NO_DATA when the season document is missing', async () => {
+    const { service } = makeServices({ season: null });
+    const result = await service.previewAwards(YEAR);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('NO_DATA');
+  });
+
+  it('NO_DATA when the season has zero published weeks (currentWeek 0)', async () => {
+    const { service } = makeServices({ season: makeSeason({ currentWeek: 0 }) });
+    const result = await service.previewAwards(YEAR);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('NO_DATA');
+  });
+
+  it('propagates a getSeason failure unchanged', async () => {
+    const { service } = makeServices({ seasonFailure: true });
+    const result = await service.previewAwards(YEAR);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('FIRESTORE_READ_ERROR');
+  });
+
+  it('propagates a buildScorecardData failure (teams + weeks both failing)', async () => {
+    const { service } = makeServices({ teamsFail: true, weeksFail: true });
+    const result = await service.previewAwards(YEAR);
+    expect(result.success).toBe(false);
+  });
+
+  it('never reads draft entries — published data only', async () => {
+    const { service, repo } = makeServices();
+    await service.previewAwards(YEAR);
+    expect(repo.getEntries).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finalizeSeason
+// ---------------------------------------------------------------------------
+
+describe('SeasonAwardsService.finalizeSeason', () => {
+  it("writes { awards, status: 'complete' } via updateSeason and clears the cache", async () => {
+    const { service, repo, scoreService } = makeServices();
+    const clearSpy = vi.spyOn(scoreService, 'clearCache');
+
+    const result = await service.finalizeSeason(YEAR);
+    expect(result.success).toBe(true);
+
+    expect(repo.updateSeason).toHaveBeenCalledTimes(1);
+    const [year, updates] = repo.updateSeason.mock.calls[0] as [number, Partial<Season>];
+    expect(year).toBe(YEAR);
+    expect(updates.status).toBe('complete');
+    expect(updates.awards?.highestAvgShooter).toBe('Vet');
+    expect(updates.awards?.firstPlaceTeam).toBe('Team A');
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('propagates a preview failure without writing', async () => {
+    const { service, repo } = makeServices({ season: null });
+    const result = await service.finalizeSeason(YEAR);
+    expect(result.success).toBe(false);
+    expect(repo.updateSeason).not.toHaveBeenCalled();
+  });
+
+  it('propagates an updateSeason failure and does NOT clear the cache after a failed write', async () => {
+    const { service, scoreService } = makeServices({ updateSeasonFail: true });
+    const clearSpy = vi.spyOn(scoreService, 'clearCache');
+    const result = await service.finalizeSeason(YEAR);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('FIRESTORE_WRITE_ERROR');
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: a second finalize recomputes and rewrites without error', async () => {
+    const { service, repo } = makeServices();
+    const first = await service.finalizeSeason(YEAR);
+    const second = await service.finalizeSeason(YEAR);
+    expect(first.success && second.success).toBe(true);
+    expect(repo.updateSeason).toHaveBeenCalledTimes(2);
+    if (!first.success || !second.success) return;
+    expect(second.data).toEqual(first.data);
+  });
+});

--- a/src/services/season-awards-service.ts
+++ b/src/services/season-awards-service.ts
@@ -1,0 +1,76 @@
+/**
+ * SeasonAwardsService — season-end awards orchestration (spec 004 DD-3)
+ *
+ * Preview and finalize season awards. Reads go through the shared
+ * ScoreService (cached, Result-typed) and consume PUBLISHED data only —
+ * teams + published week docs via buildScorecardData, never the draft
+ * `entries` audit docs — so trophies always agree with the public scorecards
+ * page. Placements come from the stored season standings; the single write
+ * goes through ScoreRepository.updateSeason.
+ *
+ * Import rule: types, scoring-engine, scorecard-builder, score-service,
+ * repositories — never components/modules. Constructed only in the
+ * composition root (app-services.ts); tests construct directly with stub
+ * repositories and never import app-services.
+ */
+
+import { failure, success, type Result } from '@/repositories/score-repository';
+import { computeSeasonAwards } from '@/services/scoring-engine';
+import { toAwardShooterInputs } from '@/services/scorecard-builder';
+import type { ScoreRepository } from '@/repositories/score-repository';
+import type { ScoreService } from '@/services/score-service';
+import type { SeasonAwards } from '@/types/season';
+
+export class SeasonAwardsService {
+  private readonly repository: ScoreRepository;
+  private readonly scoreService: ScoreService;
+
+  constructor(repository: ScoreRepository, scoreService: ScoreService) {
+    if (!repository) throw new Error('SeasonAwardsService: repository is required');
+    if (!scoreService) throw new Error('SeasonAwardsService: scoreService is required');
+    this.repository = repository;
+    this.scoreService = scoreService;
+  }
+
+  /**
+   * Compute the awards for a season from published data, without writing.
+   * Fails with NO_DATA when the season document is missing or has no
+   * published weeks.
+   */
+  async previewAwards(year: number): Promise<Result<SeasonAwards>> {
+    const seasonResult = await this.scoreService.getSeason(year);
+    if (!seasonResult.success) return seasonResult;
+
+    const season = seasonResult.data;
+    if (!season || season.currentWeek < 1) {
+      return failure(`No published data for season ${year}`, 'NO_DATA');
+    }
+
+    const viewResult = await this.scoreService.buildScorecardData(year);
+    if (!viewResult.success) return viewResult;
+
+    const inputs = toAwardShooterInputs(viewResult.data.teams);
+    return success(computeSeasonAwards(inputs, season.standings ?? []));
+  }
+
+  /**
+   * previewAwards, then write { awards, status: 'complete' } to the season
+   * document and clear the shared cache. Idempotent by design: every run
+   * recomputes from current published data and overwrites — re-running after
+   * a week correction is the documented recovery path (spec 004 DD-3).
+   */
+  async finalizeSeason(year: number): Promise<Result<SeasonAwards>> {
+    const preview = await this.previewAwards(year);
+    if (!preview.success) return preview;
+
+    const write = await this.repository.updateSeason(year, {
+      awards: preview.data,
+      status: 'complete',
+    });
+    if (!write.success) return write;
+
+    // Blunt by design: guarantees season:{year} AND seasons:all refresh.
+    this.scoreService.clearCache();
+    return preview;
+  }
+}

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -104,9 +104,9 @@ select:focus {
   color: var(--c-text-muted);
 }
 
-/* ── Season Awards (spec 004) — same visual language as accolades ────────── */
+/* ── Season Awards (spec 004) — design-system table, mirrors .standing-table ─ */
 .awards-section {
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 
 .awards-section__heading {
@@ -116,44 +116,56 @@ select:focus {
   margin: 0 0 var(--space-3);
 }
 
-.awards-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.awards-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
+.awards-table {
+  width: 100%;
+  border-collapse: collapse;
   font-size: var(--text-sm);
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--c-table-border);
 }
 
-.awards-badge {
-  display: inline-block;
-  min-width: 132px;
-  text-align: center;
-  padding: 2px var(--space-2);
-  border-radius: var(--radius-sm);
+.awards-table th {
+  background: var(--c-table-header-bg);
+  color: var(--c-text-inverse);
   font-size: var(--text-xs);
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
-  white-space: nowrap;
-  background: var(--c-accent);
-  color: var(--c-text-inverse);
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
 }
 
-.awards-item__name {
-  font-weight: 600;
+.awards-table td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--c-table-border);
   color: var(--c-text);
 }
 
-.awards-item__detail {
+.awards-table tr:hover td { background: var(--c-table-hover); }
+.awards-table tr:last-child td { border-bottom: none; }
+
+/* Award column hugs its content; Winner takes the remaining width. */
+.awards-table th:first-child,
+.awards-table td:first-child {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.awards-table__icon {
+  font-size: var(--text-base);
+  margin-right: var(--space-2);
+}
+
+.awards-table__winner {
+  font-weight: 600;
+}
+
+.awards-table__result {
   color: var(--c-text-muted);
+  white-space: nowrap;
 }
 
 .hs-subtitle {

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -104,6 +104,58 @@ select:focus {
   color: var(--c-text-muted);
 }
 
+/* ── Season Awards (spec 004) — same visual language as accolades ────────── */
+.awards-section {
+  margin-bottom: var(--space-4);
+}
+
+.awards-section__heading {
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--c-heading);
+  margin: 0 0 var(--space-3);
+}
+
+.awards-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.awards-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.awards-badge {
+  display: inline-block;
+  min-width: 132px;
+  text-align: center;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  white-space: nowrap;
+  background: var(--c-accent);
+  color: var(--c-text-inverse);
+}
+
+.awards-item__name {
+  font-weight: 600;
+  color: var(--c-text);
+}
+
+.awards-item__detail {
+  color: var(--c-text-muted);
+}
+
 .hs-subtitle {
   font-size: var(--text-sm);
   color: var(--c-text-muted);

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -35,6 +35,7 @@ export interface SeasonAwards {
  */
 export interface AwardShooterInput {
   name: string;
+  /** Not consumed by the engine today; retained for future per-award team attribution. */
   teamName: string;
   isDummy: boolean;
   rookie: boolean;

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -3,20 +3,19 @@
  */
 
 /**
- * Season-level trophy / award winners.
- * Populated at season end; embedded in the seasons/{year} document.
+ * Season-level trophy / award winners, embedded in the seasons/{year} document.
+ * Written at season end by the admin finalize flow; also the engine's return
+ * shape (computeSeasonAwards) — one type end to end.
+ *
+ * FLAT shape by prod precedent: all seven historical seasons (2019–2025) store
+ * exactly these ten fields, verified against prod 2026-07-12
+ * (.specs/features/004-season-awards/spec.md §"Verified Production Evidence").
+ * `improvement` is a pre-formatted percent string (e.g. "55.24%") by the same
+ * precedent — changing it to a number would require migrating seven prod docs.
+ * All fields nullable: placements are null when standings lack a rank-1/rank-2
+ * row; shooter awards are null when no shooter meets eligibility.
  */
 export interface SeasonAwards {
-  highestAvg: { shooterName: string; teamName: string; avg: number };
-  rookieOfYear: { shooterName: string; teamName: string; avg: number } | null;
-  mostImproved: { shooterName: string; teamName: string; improvement: string } | null;
-}
-
-/**
- * Computed season awards returned by computeSeasonAwards().
- * Not the same shape as SeasonAwards (Firestore-stored).
- */
-export interface ComputedAwards {
   firstPlaceTeam: string | null;
   firstPlacePoints: number | null;
   secondPlaceTeam: string | null;
@@ -27,6 +26,22 @@ export interface ComputedAwards {
   rookieAvg: number | null;
   mostImproved: string | null;
   improvement: string | null;
+}
+
+/**
+ * Minimal per-shooter facts computeSeasonAwards consumes. Adapted from the
+ * published scorecard derivation by toAwardShooterInputs (scorecard-builder)
+ * so trophies always agree with the public scorecards page.
+ */
+export interface AwardShooterInput {
+  name: string;
+  teamName: string;
+  isDummy: boolean;
+  rookie: boolean;
+  /** Going-in (W0) average — numeric only; display-only '-' rows are excluded upstream. */
+  startingAvg: number;
+  /** 15 weekly scores (W1–W15); null = did not shoot. */
+  scores: (number | null)[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Finishes the season-awards pipeline that F-26 found half-built and WS5-02 decided (Tyler,
2026-07-12) to **finish, not delete** — the current season ends soon and trophies must be
calculated. The engine now computes complete awards including team placements, an admin
Season End tab previews and finalizes them, and the home page displays awards for any
completed season. Implements approved spec `.specs/features/004-season-awards/`.

## Changes
- **Flat `SeasonAwards` shape by prod precedent** (`src/types/season.ts`): all seven
  historical prod seasons (2019–2025, verified 2026-07-12) store the same flat ten-field
  document, so the type was reconciled to that shape and the divergent `ComputedAwards`
  type deleted — one type end to end, and **no prod backfill needed** (historical docs
  already conform). `improvement` stays a pre-formatted percent string per the same
  precedent.
- **Engine** (`src/services/scoring-engine.ts`): `computeSeasonAwards(shooters,
  finalStandings)` now fills team placements from the rank-1/rank-2 standings rows
  (points = totalRankPoints + totalBonusPoints) in every branch; `computeMostImprovedScore`
  guards `startingAvg >= 50` → 0 (DD-4, kills the divide-by-zero/sign-flip edge). Pure —
  no I/O.
- **Published-data-only computation** (`src/services/season-awards-service.ts` +
  `toAwardShooterInputs` in `scorecard-builder.ts`): awards are computed from the same
  published-week derivation the public scorecards page renders — never the draft `entries`
  audit docs. Consistency property: the trophy winners always agree with what the public
  sees, pinned by a test asserting `getEntries` is never called and a test comparing the
  Highest Average winner against the top public scorecard row.
- **Composition root** (`src/services/app-services.ts`): `SeasonAwardsService` constructed
  once, sharing the repository and cached `ScoreService`; components receive it by
  injection only.
- **Admin Season End tab** (`src/components/admin-tabs/season-end-tab.ts`): two-phase
  preview → confirm → finalize. Finalize writes `{ awards, status: 'complete' }` via one
  `updateSeason` and clears the shared cache; idempotent by design — re-running after a
  week correction is the documented recovery path. Warns when fewer than 15 weeks are
  published. All dynamic values via `textContent`.
- **Historical display** (`src/components/home-standings.ts`): Season view renders an
  awards section from the already-loaded season doc — zero extra Firestore reads (AC-6);
  week views never show it; every field independently null-guarded and escaped.
- **Seed fixtures** (`scripts/fixtures/seed-data.js`): emit the canonical flat shape with
  the same guard; active seasons omit the `awards` field entirely, matching prod.
- **F-26 ledger close-out**: WS5-02 marked DONE in the deep-review backlog; #220 row added
  to the report remediation ledger (the `validateFirebaseConfig` half of F-26 stays in
  WS-5 scope); `firestore-schema.md` and `scoring-engine.md` updated to the shipped shape.

## Testing
- Typecheck, 260 unit tests (incl. new `season-awards-service.test.ts`,
  `scorecard-builder.test.ts`, expanded `scoring-engine.test.ts`), 57 rules tests,
  15 functions tests, production build — all pass.
- Full emulator E2E: 2025 awards display (incl. historical data), week views hide awards,
  2024 no-data case, admin preview → finalize on two seasons, cache invalidation without
  reload, idempotent re-finalize, and the published-data-only path proven on a season with
  zero `entries` docs.
- Post-merge spot-check planned per tasks.md: prod 2025 Season view must match the stored
  doc (433 / 415 / 44.43 / 43.29 / "55.24%"); 2026 shows no awards until finalized.

## Constitutional Compliance
- §II.3/§II.4: dependency direction preserved; `SeasonAwardsService` built only in the
  composition root; components get services by injection (hook rule
  `no-private-service-in-component` clean).
- §III.2: all Firestore-sourced strings rendered via `escapeHtml()`/`textContent`; no
  `firestore.rules` change needed — `seasons/{year}` writes were already admin-only,
  pinned by the existing rules suite (57 tests pass unmodified).
- §III.5: types in `src/types/season.ts`; conventional commits throughout.
- §IV.2: no `onSnapshot`, no client-side filtering (bounded per-season reads via the
  cached ScoreService), no components importing the firebase SDK; `score-service.ts`
  untouched at 749 lines.
- §VI.1: finalize is a single document write; home-page awards add zero reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
