### PR TITLE
docs(specs): archive shipped spec 004-season-awards

### DIFF
--- a/.specs/features/archive/004-season-awards/spec.md
+++ b/.specs/features/archive/004-season-awards/spec.md
@@ -2,7 +2,7 @@
 
 **Feature ID**: 004-season-awards
 **Created**: 2026-07-12
-**Status**: Implemented — PR #220
+**Status**: Shipped (PR [#220](https://github.com/salmoncow/citl/pull/220), merged 2026-07-13)
 **Source**: Maintainer decision (Tyler, 2026-07-12) recorded in
 [backlog WS5-02](../../reviews/2026-07-deep-review/backlog.md) — promotion of finding
 [F-26 (P2)](../../reviews/2026-07-deep-review/report.md) to a full feature.

--- a/.specs/features/archive/004-season-awards/tasks.md
+++ b/.specs/features/archive/004-season-awards/tasks.md
@@ -2,7 +2,7 @@
 
 **Feature**: 004-season-awards
 **Spec**: [spec.md](./spec.md)
-**Status**: Implemented — PR #220
+**Status**: Shipped (PR [#220](https://github.com/salmoncow/citl/pull/220), merged 2026-07-13)
 
 Each numbered group is one prospective commit; commit only when every box is checked and the
 group's validation gate passes. AC refs map to spec.md §"Acceptance Criteria"; DD refs to

--- a/.specs/reviews/2026-07-deep-review/backlog.md
+++ b/.specs/reviews/2026-07-deep-review/backlog.md
@@ -284,7 +284,7 @@ Remove `lookupYardage` from src/utils/yardage.ts (+ its test cases; the app rend
 
 **Acceptance**: typecheck + tests pass; grep for the three names returns nothing outside git history.
 
-### WS5-02 · P2 · M · Season-awards pipeline (F-26) — **DONE ([PR #220](https://github.com/salmoncow/citl/pull/220), 2026-07-12) via [`features/004-season-awards/`](../../features/004-season-awards/spec.md)**
+### WS5-02 · P2 · M · Season-awards pipeline (F-26) — **DONE ([PR #220](https://github.com/salmoncow/citl/pull/220), 2026-07-12) via [`features/archive/004-season-awards/`](../../features/archive/004-season-awards/spec.md)**
 **Decision: FINISH, as its own feature spec — NOT in the WS-5 sweep.** The pipeline went
 unnoticed because no season end has occurred since the migration; the current season ends soon
 and trophies must be calculated. Feature requirements (for `@speckit` →


### PR DESCRIPTION
Post-merge lifecycle step for [#220](https://github.com/salmoncow/citl/pull/220): move `.specs/features/004-season-awards/` to `features/archive/`, set status to Shipped (merged 2026-07-13), and repoint the backlog WS5-02 link to the archive path. Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)