### PR TITLE
docs(specs): archive shipped spec 005-standings-unification

### DIFF
--- a/.specs/features/archive/005-standings-unification/spec.md
+++ b/.specs/features/archive/005-standings-unification/spec.md
@@ -2,10 +2,10 @@
 
 **Feature ID**: 005-standings-unification
 **Created**: 2026-07-13
-**Status**: Implemented — [PR #224](https://github.com/salmoncow/citl/pull/224) (2026-07-13); archive after merge
-**Source**: Backlog item [FU-01](../../reviews/2026-07-deep-review/backlog.md) (promotion of the
-spec 003 [DD-4](../archive/003-service-decomposition/spec.md) deferral); original incident
-context [F-05](../../reviews/2026-07-deep-review/report.md).
+**Status**: Shipped ([PR #224](https://github.com/salmoncow/citl/pull/224), merged 2026-07-13)
+**Source**: Backlog item [FU-01](../../../reviews/2026-07-deep-review/backlog.md) (promotion of the
+spec 003 [DD-4](../003-service-decomposition/spec.md) deferral); original incident
+context [F-05](../../../reviews/2026-07-deep-review/report.md).
 
 ---
 
@@ -33,7 +33,7 @@ the current season wherever its stored docs already agree).
 ### The live divergence path (verified 2026-07-13 — this is not theoretical)
 
 Bonus points depend on going-in averages, which depend on **all earlier weeks' scores**
-(see [.specs/domain/scoring-rules.md](../../domain/scoring-rules.md)). When an admin edits
+(see [.specs/domain/scoring-rules.md](../../../domain/scoring-rules.md)). When an admin edits
 week 2's entries and republishes week 2 while the season stands at week 5:
 
 - `_publishWeekInner` (post-F-05 fix) correctly recomputes `season.standings` from entries
@@ -123,13 +123,13 @@ Two further divergence paths exist today and are closed by the same design:
   publish against daily ceilings of 20,000 writes / 50,000 reads. No new Cloud Functions →
   the `firebase-deploy-runbook` post-deploy steps are **N/A**.
 - **§IV.2 (forbidden patterns)**: the ruleset in
-  [`scripts/forbidden-patterns.json`](../../../scripts/forbidden-patterns.json) is active
+  [`scripts/forbidden-patterns.json`](../../../../scripts/forbidden-patterns.json) is active
   via the PostToolUse hook and CI lint gate — notably the 750-line cap (AC-5) and the
   bounded-`getDocs` rule (the publish path's new week-doc read reuses the existing bounded
   `getAllWeekResults`; no new query shapes).
 - **§VIII.1 (version bumps)**: no constitution change is needed — no new standard is
   introduced. The deleteTeam business rule lands in
-  [.specs/domain/scoring-rules.md](../../domain/scoring-rules.md) (living domain reference,
+  [.specs/domain/scoring-rules.md](../../../domain/scoring-rules.md) (living domain reference,
   its designated home).
 
 ## Architecture Approach
@@ -345,7 +345,7 @@ AC-2's "one derivation" criterion as FU-01 explicitly allows.
 
 **Decision**: the stored shapes of `seasons/{year}`, `seasons/{year}/weeks/{n}`, and
 `season.standings` are **unchanged** (see
-[firestore-schema.md](../../technical/firestore-schema.md)); only prose in that doc
+[firestore-schema.md](../../../technical/firestore-schema.md)); only prose in that doc
 changes (the "Denormalized standings" pattern description and a `publishedAt`
 preserved-on-rewrite note). No backfill script:
 

--- a/.specs/features/archive/005-standings-unification/tasks.md
+++ b/.specs/features/archive/005-standings-unification/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: 005-standings-unification
 
 **Spec**: [spec.md](./spec.md)
-**Status**: Implemented — [PR #224](https://github.com/salmoncow/citl/pull/224) (2026-07-13)
+**Status**: Shipped ([PR #224](https://github.com/salmoncow/citl/pull/224), merged 2026-07-13)
 **PR**: single PR per DD-7 — `feat(standings): unify standings derivations; publish rewrites week docs`
 (branch `claude/compassionate-turing-5432ec`)
 
@@ -177,12 +177,14 @@ deleted. **AC**: AC-2 (module half), AC-5 (new-file budget).
 - [x] **6.5 (S)** Set spec.md + this file's Status to "Implemented — PR #NNN"; after
       merge, move `005-standings-unification/` to `.specs/features/archive/` per the
       `.specs/README.md` lifecycle. Link-check all edited docs' relative links.
+      *(Archived post-merge in the follow-up docs PR.)*
 
 ---
 
 ## Post-merge / post-deploy
 
-- [ ] Deploy via the normal pipeline (no new Cloud Function → `firebase-deploy-runbook`
-      IAM steps N/A, spec §Constitutional Constraints).
+- [x] Deploy via the normal pipeline (no new Cloud Function → `firebase-deploy-runbook`
+      IAM steps N/A, spec §Constitutional Constraints). *(Merged to main 2026-07-13;
+      deploy-production ran on the merge commit.)*
 - [ ] Prod spot-check after the next real publish: home Week-N views vs Season view agree
       for the current season; archived seasons byte-identical (spot-check one).

--- a/src/services/standings.ts
+++ b/src/services/standings.ts
@@ -12,8 +12,7 @@
  * holds by construction, not by policing. `deleteTeam` patches week docs and
  * re-derives with the same function; `home-standings.ts` imports it for the
  * historical-week view. There is deliberately no second derivation anywhere
- * in src/ — see .specs/features/005-standings-unification/ (DD-1–DD-6; moves
- * to features/archive/ at close-out).
+ * in src/ — see .specs/features/archive/005-standings-unification/ (DD-1–DD-6).
  *
  * Import rule: only @/types/* and @/services/scoring-engine.
  */


### PR DESCRIPTION
## Summary
- Execute the post-merge archive step of the spec lifecycle for feature 005 (shipped in #224): everything under `.specs/features/` must be in-flight only.

## Changes
- Move `.specs/features/005-standings-unification/` → `.specs/features/archive/`
- Set spec + tasks status to Shipped (PR #224, merged 2026-07-13); check the post-merge deploy item
- Rewrite the spec's relative links for the archive depth (link-checker verified: no new dead links)
- Point the `src/services/standings.ts` header at the archive path (comment-only)

## Testing
- [x] Relative-link check over `.specs/`: zero dead links introduced (3 pre-existing hits are frozen/archived audit-trail text)
- [x] `npm run typecheck` clean (comment-only source change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)