### PR TITLE
chore: add Claude Code dev-server launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
## What

Commits `.claude/launch.json`, a generic dev-server launch config used by Claude Code's preview tooling. It maps directly to the documented workflow (`npm run dev` → `localhost:3000`).

## Why

The file was showing up as untracked on `main`. It contains no secrets or machine-specific paths — it just mirrors `npm run dev`. Tracking it keeps the preview tooling reproducible for any contributor.

This is consistent with the repo's `.claude/` convention: shared tooling (`settings.json`, `agents/`, `skills/`) is committed, while only personal/local overrides (`settings.local.json`, `user-*`, `.history`) stay gitignored.

## Alternatives considered

- **Gitignore it** — rejected; it's shared tooling, not a personal override, and would just be regenerated ad-hoc otherwise.
- **Delete it** — pointless; the preview tools recreate it on use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)